### PR TITLE
Add CollectionCard component and integrate with Collection page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.5",
         "@radix-ui/react-navigation-menu": "^1.2.4",
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-toast": "^1.2.5",
         "@tailwindcss/vite": "^4.0.3",
         "appwrite": "^17.0.0",
         "class-variance-authority": "^0.7.1",
@@ -19,6 +20,7 @@
         "lucide-react": "^0.474.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.5",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.3",
@@ -1172,6 +1174,39 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.5.tgz",
+      "integrity": "sha512-ZzUsAaOx8NdXZZKcFNDhbSlbsCUy8qQWmzTdgrlrhhZAOx2ofLtKrBDW9fkqhFvXgmtv560Uj16pkLkqML7SHA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3636,6 +3671,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-remove-scroll": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.474.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.5",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.3",

--- a/frontend/src/components/CollectionCard.tsx
+++ b/frontend/src/components/CollectionCard.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { FaMinus } from 'react-icons/fa';
+import type { Pokemon } from '@/types/pokemon';
+
+export function CollectionCard(pokemon: Pokemon) {
+    const [counter, setCounter] = useState(pokemon.counter || 0);
+
+    const incrementCounter = () => {
+        setCounter(counter + 1);
+    };
+
+    const decrementCounter = () => {
+        if (counter > 0) setCounter(counter - 1);
+    };
+
+    return (
+        <article className='relative group overflow-hidden w-full h-full rounded-lg'>
+            <button className='cursor-pointer w-full h-full'>
+                <img onClick={incrementCounter} src={pokemon.image} alt="" className={`${counter === 0 ? 'grayscale' : ''} w-full h-full transition ease-in-out duration-100`} />
+            </button>
+            <button onClick={decrementCounter} className="absolute cursor-pointer top-0 left-0 inline-flex items-center justify-center p-0.5 overflow-hidden text-sm font-medium text-gray-900 rounded-full group bg-gradient-to-br from-purple-600 to-blue-500 hover:from-purple-600 hover:to-blue-500 hover:text-white dark:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800">
+                    <span className="px-3 py-3 transition-all ease-in duration-75 bg-white dark:bg-gray-900 rounded-full hover:bg-transparent hover:dark:bg-transparent">
+                        <FaMinus />
+                    </span>
+                </button> 
+            <div className="absolute bottom-0 w-full h-1/6 bg-black/70 flex items-center justify-center transition-transform transform translate-y-full group-hover:translate-y-0">
+                <h1 className="text-white text-lg">{counter}</h1>
+            </div>
+        </article>
+    );
+}

--- a/frontend/src/pages/Collection.tsx
+++ b/frontend/src/pages/Collection.tsx
@@ -1,4 +1,5 @@
 import { Cards } from '@/components/Cards.tsx'
+import { CollectionCard } from '@/components/CollectionCard'
 import type { Models } from 'appwrite'
 import type { FC } from 'react'
 
@@ -6,11 +7,32 @@ interface Props {
   user: Models.User<Models.Preferences> | null
 }
 
+interface Pokemon {
+  id: number
+  image: string
+  counter: number
+}
+
 export const Collection: FC<Props> = ({ user }) => {
+
+  const pokemonExample: Pokemon = {
+    id: 1,
+    image: "https://assets.pokemon-zone.com/game-assets/CardPreviews/cPK_10_004000_00_DIALGAex_RR.webp?width=25&quality=100",
+    counter: 0
+  }
+
   if (user) {
     // TODO: Refactor that cards still show without a user, but prompts for a login if you are not logged in yet.
     return <Cards user={user} />
   }
 
-  return null
+  return (
+    <ul className='max-w-7xl mx-auto grid grid-cols-5 gap-5'>
+      {Array.from({ length: 20 }).map((_, index) => (
+        <li key={index}>
+          <CollectionCard id={pokemonExample.id} image={pokemonExample.image} counter={pokemonExample.counter} />
+        </li>
+      ))}
+    </ul>
+  )
 }

--- a/frontend/src/types/pokemon.ts
+++ b/frontend/src/types/pokemon.ts
@@ -1,0 +1,5 @@
+export interface Pokemon {
+    id: number,
+    image: string,
+    counter: number
+}


### PR DESCRIPTION
This PR introduces the CollectionCard component and integrates it with the Collection page. The CollectionCard component displays a Pokémon card with increment and decrement counter functionality. The Collection page renders multiple CollectionCard components based on a sample Pokémon data.

CollectionCard Component:
- Added CollectionCard component that displays a Pokémon image and a counter.
- The counter can be incremented by clicking on the image and decremented by clicking on a button.
- The image is displayed in grayscale when the counter is zero.

Collection Page:
- Integrated CollectionCard component into the Collection page.
- Rendered multiple CollectionCard components using a sample Pokémon data.
- Ensured that the cards are displayed in a grid layout.


Pokemon Type:
- Defined the Pokemon interface in the pokemon.ts file.