### PR TITLE
Fixed Dropdown Colors for Trade Page

### DIFF
--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -49,7 +49,7 @@ function Trade() {
               {currentTab === 'looking_for' ? 'Maximum' : 'Minimum'} number of cards:
               <select value={minCards} onChange={(e) => setMinCards(Number.parseInt(e.target.value))} className="p-1">
                 {[0, 1, 2, 3, 4, 5].map((number) => (
-                  <option key={number} value={number}>
+                  <option key={number} value={number} className="text-black">
                     {number}
                   </option>
                 ))}


### PR DESCRIPTION
Made the option text force to black (because the backgrounds are white or light gray.

![image](https://github.com/user-attachments/assets/44fbaf56-11a7-40a0-bafc-353da4b2454f)


#232 