### PR TITLE
Add a filter to the overview page for number of cards

### DIFF
--- a/frontend/public/locales/en/number-filter.json
+++ b/frontend/public/locales/en/number-filter.json
@@ -1,0 +1,5 @@
+{
+  "numberCards": "Number of Cards",
+  "maxNum": "Maximum number of cards",
+  "minNum": "Minimum number of cards"
+}

--- a/frontend/public/locales/en/pages/overview.json
+++ b/frontend/public/locales/en/pages/overview.json
@@ -11,5 +11,7 @@
   "all": "all",
   "youHave": "You have",
   "uniqueCards": "out of {{totalUniqueCards}} unique cards",
+  "numberOfCopies-single": "with at least 1 copy",
+  "numberOfCopies-plural": "with at least {{numberFilter}} copies",
   "cardsTotal": "cards in total"
 }

--- a/frontend/public/locales/es/number-filter.json
+++ b/frontend/public/locales/es/number-filter.json
@@ -1,0 +1,5 @@
+{
+  "numberCards": "Número de cartas",
+  "maxNum": "Número máximo de cartas",
+  "minNum": "Número mínimo de cartas"
+}

--- a/frontend/public/locales/es/pages/overview.json
+++ b/frontend/public/locales/es/pages/overview.json
@@ -11,5 +11,7 @@
   "all": "todos",
   "youHave": "Tienes",
   "uniqueCards": "de {{totalUniqueCards}} cartas únicas",
+  "numberOfCopies-single": "con al menos 1 copia",
+  "numberOfCopies-plural": "con al menos {{numberFilter}} copias",
   "cardsTotal": "cartas en total"
 }

--- a/frontend/public/locales/pt-BR/number-filter.json
+++ b/frontend/public/locales/pt-BR/number-filter.json
@@ -1,0 +1,5 @@
+{
+  "numberCards": "Número de cartas",
+  "maxNum": "Número máximo de cartas",
+  "minNum": "Número mínimo de cartas"
+}

--- a/frontend/public/locales/pt-BR/pages/overview.json
+++ b/frontend/public/locales/pt-BR/pages/overview.json
@@ -11,5 +11,7 @@
   "all": "todos",
   "youHave": "Você tem",
   "uniqueCards": "de {{totalUniqueCards}} cartas únicas",
+  "numberOfCopies-single": "com pelo menos 1 cópia",
+  "numberOfCopies-plural": "com pelo menos {{numberFilter}} cópias",
   "cardsTotal": "cartas no total"
 }

--- a/frontend/src/components/NumberFilter.tsx
+++ b/frontend/src/components/NumberFilter.tsx
@@ -1,0 +1,29 @@
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  numberFilter: number
+  setNumberFilter: (numberFilter: number) => void
+  options: number[]
+  labelKey?: string
+}
+const NumberFilter: FC<Props> = ({ numberFilter, setNumberFilter, options, labelKey = 'numberCards' }) => {
+  const { t } = useTranslation('number-filter')
+
+  return (
+    <div className="px-3 py-1 border-2 border-slate-600 rounded-md">
+      <label className="flex items-center gap-x-2 text-white/50 text-sm">
+        <h2>{t(labelKey)}</h2>
+        <select value={numberFilter} onChange={(e) => setNumberFilter(Number.parseInt(e.target.value))} className="p-1">
+          {options.map((number) => (
+            <option key={number} value={number} className="text-black">
+              {number}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}
+
+export default NumberFilter

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -15,7 +15,6 @@ i18n
       loadPath: '/locales/{{lng}}/{{ns}}.json',
     },
     supportedLngs: ['en', 'es', 'pt-BR'],
-    pluralSeparator: '_',
   })
 
 export default i18n

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -15,6 +15,7 @@ i18n
       loadPath: '/locales/{{lng}}/{{ns}}.json',
     },
     supportedLngs: ['en', 'es', 'pt-BR'],
+    pluralSeparator: '_',
   })
 
 export default i18n

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -94,10 +94,11 @@ export const sellableForTokensDictionary: { [id: string]: number } = {
 interface NrOfCardsOwnedProps {
   ownedCards: CollectionRow[]
   rarityFilter: string[]
+  numberFilter: number
   expansion?: Expansion
   packName?: string
 }
-export const getNrOfCardsOwned = ({ ownedCards, rarityFilter, expansion, packName }: NrOfCardsOwnedProps) => {
+export const getNrOfCardsOwned = ({ ownedCards, rarityFilter, numberFilter, expansion, packName }: NrOfCardsOwnedProps) => {
   let filteredOwnedCards = ownedCards
     .filter((oc) => oc.amount_owned > 0)
     .map((cr) => ({ ...cr, rarity: allCards.find((c) => c.card_id === cr.card_id)?.rarity || '' }))
@@ -106,6 +107,8 @@ export const getNrOfCardsOwned = ({ ownedCards, rarityFilter, expansion, packNam
     //filter out cards that are not in the rarity filter
     filteredOwnedCards = filteredOwnedCards.filter((oc) => rarityFilter.includes(oc.rarity))
   }
+
+  filteredOwnedCards = filteredOwnedCards.filter((oc) => oc.amount_owned > numberFilter - 1)
 
   if (!expansion) {
     return filteredOwnedCards.length
@@ -178,8 +181,9 @@ interface PullRateProps {
   expansion: Expansion
   pack: Pack
   rarityFilter?: string[]
+  numberFilter?: number
 }
-export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [] }: PullRateProps) => {
+export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numberFilter = 1 }: PullRateProps) => {
   if (ownedCards.length === 0) {
     return 1
   }
@@ -189,7 +193,7 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [] }: Pul
 
   const cardsInPack = expansion.cards.filter((c) => c.pack === pack.name || c.pack === 'Every pack')
   // console.log('cards in pack', cardsInPack.length) //79
-  let missingCards = cardsInPack.filter((c) => !ownedCards.find((oc) => oc.card_id === c.card_id && oc.amount_owned > 0))
+  let missingCards = cardsInPack.filter((c) => !ownedCards.find((oc) => oc.card_id === c.card_id && oc.amount_owned > numberFilter - 1))
   // console.log('missing cards', missingCards)
 
   if (rarityFilter.length > 0) {

--- a/frontend/src/locales/en/number-filter.json
+++ b/frontend/src/locales/en/number-filter.json
@@ -1,0 +1,5 @@
+{
+  "numberCards": "Number of Cards",
+  "maxNum": "Maximum number of cards",
+  "minNum": "Minimum number of cards"
+}

--- a/frontend/src/locales/en/pages/overview.json
+++ b/frontend/src/locales/en/pages/overview.json
@@ -11,5 +11,7 @@
   "all": "all",
   "youHave": "You have",
   "uniqueCards": "out of {{totalUniqueCards}} unique cards",
+  "numberOfCopies-single": "with at least 1 copy",
+  "numberOfCopies-plural": "with at least {{numberFilter}} copies",
   "cardsTotal": "cards in total"
 }

--- a/frontend/src/locales/es/number-filter.json
+++ b/frontend/src/locales/es/number-filter.json
@@ -1,0 +1,5 @@
+{
+  "numberCards": "Número de cartas",
+  "maxNum": "Número máximo de cartas",
+  "minNum": "Número mínimo de cartas"
+}

--- a/frontend/src/locales/es/pages/overview.json
+++ b/frontend/src/locales/es/pages/overview.json
@@ -11,5 +11,7 @@
   "all": "todos",
   "youHave": "Tienes",
   "uniqueCards": "de {{totalUniqueCards}} cartas únicas",
+  "numberOfCopies-single": "con al menos 1 copia",
+  "numberOfCopies-plural": "con al menos {{numberFilter}} copias",
   "cardsTotal": "cartas en total"
 }

--- a/frontend/src/locales/pt-br/number-filter.json
+++ b/frontend/src/locales/pt-br/number-filter.json
@@ -1,0 +1,5 @@
+{
+  "numberCards": "Número de cartas",
+  "maxNum": "Número máximo de cartas",
+  "minNum": "Número mínimo de cartas"
+}

--- a/frontend/src/locales/pt-br/pages/overview.json
+++ b/frontend/src/locales/pt-br/pages/overview.json
@@ -11,5 +11,7 @@
   "all": "todos",
   "youHave": "Você tem",
   "uniqueCards": "de {{totalUniqueCards}} cartas únicas",
+  "numberOfCopies-single": "com pelo menos 1 cópia",
+  "numberOfCopies-plural": "com pelo menos {{numberFilter}} cópias",
   "cardsTotal": "cartas no total"
 }

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -1,3 +1,4 @@
+import NumberFilter from '@/components/NumberFilter'
 import RarityFilter from '@/components/RarityFilter.tsx'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { AlertTitle } from '@/components/ui/alert.tsx'
@@ -25,13 +26,17 @@ function Overview() {
     const savedRarityFilter = localStorage.getItem('rarityFilter')
     return savedRarityFilter ? JSON.parse(savedRarityFilter) : []
   })
-  const [numberFilter, setNumberFilter] = useState(1)
+  const [numberFilter, setNumberFilter] = useState(() => {
+    const savedNumberFilter = localStorage.getItem('numberFilter')
+    return savedNumberFilter ? Number.parseInt(savedNumberFilter) : 1
+  })
 
   const totalUniqueCards = CardsDB.getTotalNrOfCards({ rarityFilter })
 
   useEffect(() => {
     localStorage.setItem('rarityFilter', JSON.stringify(rarityFilter))
-  }, [rarityFilter])
+    localStorage.setItem('numberFilter', numberFilter.toString())
+  }, [rarityFilter, numberFilter])
 
   useEffect(() => {
     let newHighestProbabilityPack: Pack | undefined
@@ -66,18 +71,7 @@ function Overview() {
 
         <div className="mb-8 flex items-center gap-2">
           <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
-          <div className="px-3 py-1 border-2 border-slate-600 rounded-md">
-            <label className="flex items-center gap-x-2 text-white/50 text-sm">
-              Number of cards:
-              <select value={numberFilter} onChange={(e) => setNumberFilter(Number.parseInt(e.target.value))} className="p-1">
-                {[1, 2].map((number) => (
-                  <option key={number} value={number} className="text-black">
-                    {number}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
+          <NumberFilter numberFilter={numberFilter} setNumberFilter={setNumberFilter} options={[1, 2]} />
         </div>
 
         <section className="grid grid-cols-8 gap-6">

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -25,6 +25,7 @@ function Overview() {
     const savedRarityFilter = localStorage.getItem('rarityFilter')
     return savedRarityFilter ? JSON.parse(savedRarityFilter) : []
   })
+  const [numberFilter, setNumberFilter] = useState(1)
 
   const totalUniqueCards = CardsDB.getTotalNrOfCards({ rarityFilter })
 
@@ -40,7 +41,7 @@ function Overview() {
         .filter((p) => p.name !== 'Every pack')
         .map((pack) => ({
           packName: pack.name.replace(' pack', ''),
-          percentage: CardsDB.pullRate({ ownedCards: ownedCards, expansion, pack, rarityFilter }),
+          percentage: CardsDB.pullRate({ ownedCards: ownedCards, expansion, pack, rarityFilter, numberFilter }),
           fill: pack.color,
         }))
       const highestProbabilityPackCandidate = pullRates.sort((a, b) => b.percentage - a.percentage)[0]
@@ -49,9 +50,8 @@ function Overview() {
       }
     }
 
-    console.log('newHighestProbabilityPack', newHighestProbabilityPack)
     setHighestProbabilityPack(newHighestProbabilityPack)
-  }, [ownedCards, rarityFilter])
+  }, [ownedCards, rarityFilter, numberFilter])
 
   return (
     <main className="fade-in-up">
@@ -66,13 +66,30 @@ function Overview() {
 
         <div className="mb-8 flex items-center gap-2">
           <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
+          <div className="px-3 py-1 border-2 border-slate-600 rounded-md">
+            <label className="flex items-center gap-x-2 text-white/50 text-sm">
+              Number of cards:
+              <select value={numberFilter} onChange={(e) => setNumberFilter(Number.parseInt(e.target.value))} className="p-1">
+                {[1, 2].map((number) => (
+                  <option key={number} value={number} className="text-black">
+                    {number}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
         </div>
 
         <section className="grid grid-cols-8 gap-6">
           <div className="col-span-8 flex h-full w-full flex-col items-center justify-center rounded-4xl border-2 border-slate-600 border-solid p-4 sm:p-8 md:col-span-2">
             <h2 className="mb-2 text-center text-lg sm:text-2xl">{t('youHave')}</h2>
-            <h1 className="mb-3 text-balance text-center font-semibold text-3xl sm:text-7xl">{CardsDB.getNrOfCardsOwned({ ownedCards, rarityFilter })}</h1>
+            <h1 className="mb-3 text-balance text-center font-semibold text-3xl sm:text-7xl">
+              {CardsDB.getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter })}
+            </h1>
             <h2 className="text-balance text-center text-lg sm:text-2xl">{t('uniqueCards', { totalUniqueCards: totalUniqueCards })}</h2>
+            <h2 className="text-balance text-center text-md sm:text-lg">
+              {numberFilter === 1 ? t('numberOfCopies-single') : t('numberOfCopies-plural', { numberFilter: numberFilter })}
+            </h2>
           </div>
           <GradientCard
             title={highestProbabilityPack?.packName || ''}
@@ -90,7 +107,7 @@ function Overview() {
       </article>
       <article className="mx-auto min-h-screen max-w-7xl sm:p-6 p-0 pt-6 grid grid-cols-8 gap-6">
         {CardsDB.expansions.map((expansion) => (
-          <ExpansionOverview key={expansion.id} expansion={expansion} rarityFilter={rarityFilter} />
+          <ExpansionOverview key={expansion.id} expansion={expansion} rarityFilter={rarityFilter} numberFilter={numberFilter} />
         ))}
       </article>
     </main>

--- a/frontend/src/pages/overview/components/CompleteProgress.tsx
+++ b/frontend/src/pages/overview/components/CompleteProgress.tsx
@@ -10,14 +10,18 @@ interface CompleteProgressProps {
   expansion: Expansion
   packName?: string
   rarityFilter?: string[]
+  numberFilter?: number
 }
 
-export function CompleteProgress({ title, expansion, packName, rarityFilter = [] }: CompleteProgressProps) {
+export function CompleteProgress({ title, expansion, packName, rarityFilter = [], numberFilter = 1 }: CompleteProgressProps) {
   const { ownedCards } = use(CollectionContext)
   const { t } = useTranslation('complete-progress')
 
-  const nrOfCardsOwned = useMemo(() => getNrOfCardsOwned({ ownedCards, rarityFilter, expansion, packName }), [ownedCards, expansion, packName, rarityFilter])
-  const totalNrOfCards = useMemo(() => getTotalNrOfCards({ rarityFilter, expansion, packName }), [rarityFilter, expansion, packName])
+  const nrOfCardsOwned = useMemo(
+    () => getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter, expansion, packName }),
+    [ownedCards, expansion, packName, rarityFilter, numberFilter],
+  )
+  const totalNrOfCards = useMemo(() => getTotalNrOfCards({ rarityFilter, expansion, packName }), [rarityFilter, expansion, packName, numberFilter])
   const progressValue = useMemo(() => (nrOfCardsOwned / totalNrOfCards) * 100, [nrOfCardsOwned, totalNrOfCards])
 
   return (

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -12,8 +12,9 @@ import { Carousel } from './Carousel'
 interface ExpansionOverviewProps {
   expansion: Expansion
   rarityFilter: string[]
+  numberFilter: number
 }
-export function ExpansionOverview({ expansion, rarityFilter }: ExpansionOverviewProps) {
+export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: ExpansionOverviewProps) {
   const { ownedCards } = use(CollectionContext)
   const { t } = useTranslation('expansion-overview')
 
@@ -26,7 +27,7 @@ export function ExpansionOverview({ expansion, rarityFilter }: ExpansionOverview
     }
     const chartData = packs.map((pack) => ({
       packName: pack.name.replace(' pack', '').replace('Every', 'Promo-A'),
-      percentage: CardsDB.pullRate({ ownedCards: ownedCards, expansion: expansion, pack: pack, rarityFilter }),
+      percentage: CardsDB.pullRate({ ownedCards: ownedCards, expansion: expansion, pack: pack, rarityFilter, numberFilter }),
       fill: pack.color,
     }))
 
@@ -36,7 +37,7 @@ export function ExpansionOverview({ expansion, rarityFilter }: ExpansionOverview
       highestProbabilityPack,
       chartData,
     }
-  }, [ownedCards, expansion, rarityFilter])
+  }, [ownedCards, expansion, rarityFilter, numberFilter])
 
   return (
     <>
@@ -59,10 +60,17 @@ export function ExpansionOverview({ expansion, rarityFilter }: ExpansionOverview
               </>
             )}
             <div className="col-span-8 snap-start flex-shrink-0 w-full border-2 border-slate-600 border-solid rounded-4xl p-4 sm:p-8">
-              <CompleteProgress title={t('totalCards')} expansion={expansion} rarityFilter={rarityFilter} />
+              <CompleteProgress title={t('totalCards')} expansion={expansion} rarityFilter={rarityFilter} numberFilter={numberFilter} />
               {expansion.packs.length > 1 &&
                 expansion.packs.map((pack) => (
-                  <CompleteProgress key={pack.name} rarityFilter={rarityFilter} title={pack.name} expansion={expansion} packName={pack.name} />
+                  <CompleteProgress
+                    key={pack.name}
+                    rarityFilter={rarityFilter}
+                    title={pack.name}
+                    expansion={expansion}
+                    packName={pack.name}
+                    numberFilter={numberFilter}
+                  />
                 ))}
             </div>
           </Carousel>
@@ -84,10 +92,17 @@ export function ExpansionOverview({ expansion, rarityFilter }: ExpansionOverview
             </>
           )}
           <div className="col-span-4 lg:col-span-2">
-            <CompleteProgress title={t('totalCards')} expansion={expansion} rarityFilter={rarityFilter} />
+            <CompleteProgress title={t('totalCards')} expansion={expansion} rarityFilter={rarityFilter} numberFilter={numberFilter} />
             {expansion.packs.length > 1 &&
               expansion.packs.map((pack) => (
-                <CompleteProgress key={pack.name} rarityFilter={rarityFilter} title={pack.name} expansion={expansion} packName={pack.name} />
+                <CompleteProgress
+                  key={pack.name}
+                  rarityFilter={rarityFilter}
+                  numberFilter={numberFilter}
+                  title={pack.name}
+                  expansion={expansion}
+                  packName={pack.name}
+                />
               ))}
           </div>
         </>

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -1,3 +1,4 @@
+import NumberFilter from '@/components/NumberFilter'
 import RarityFilter from '@/components/RarityFilter.tsx'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { UserContext } from '@/lib/context/UserContext'
@@ -43,19 +44,12 @@ function Trade() {
             <TabsTrigger value="buying_tokens">Buying Tokens</TabsTrigger>
           </TabsList>
           <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
-
-          <div className="px-3 py-1 border-2 border-slate-600 rounded-md">
-            <label className="flex items-center gap-x-2 text-white/50 text-sm">
-              {currentTab === 'looking_for' ? 'Maximum' : 'Minimum'} number of cards:
-              <select value={minCards} onChange={(e) => setMinCards(Number.parseInt(e.target.value))} className="p-1">
-                {[0, 1, 2, 3, 4, 5].map((number) => (
-                  <option key={number} value={number} className="text-black">
-                    {number}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
+          <NumberFilter
+            numberFilter={minCards}
+            setNumberFilter={setMinCards}
+            options={[0, 1, 2, 3, 4, 5]}
+            labelKey={currentTab === 'looking_for' ? 'maxNum' : 'minNum'}
+          />
         </div>
         <div className="max-w-auto mx-4 md:mx-8">
           <TabsContent value="looking_for">


### PR DESCRIPTION
I added a filter to the overview page, which will let the user select if they want to check if they have at least 1 copy of a card, or at least 2 copies.

I also adjusted the various components used on the overview page so that they update with this filter, and show the appropriate percentages and values for each case.

As part of this, I moved the "NumberFilter" component into its own file, and added this to both the overview page and the trade page, where it was previously.

I also added some translations to go with these changes (es and pt translations provided by AI - certainly worth double-checking).

Fullscreen examples with differences between 1 and 2 highlighted:
<img width="1235" alt="Screenshot 2025-03-05 at 17 03 10" src="https://github.com/user-attachments/assets/682b6cb2-81c6-4784-8eeb-8cb8daab411d" />
<img width="1290" alt="Screenshot 2025-03-05 at 17 03 24" src="https://github.com/user-attachments/assets/9c82a652-e26d-4a76-84e2-168e1faaa3c3" />

Mobile example:
<img width="535" alt="Screenshot 2025-03-05 at 17 09 37" src="https://github.com/user-attachments/assets/a9a49706-26d3-4237-a39c-e8b48ca58936" />

