### PR TITLE
Add type definition for rarities

### DIFF
--- a/frontend/src/components/RarityFilter.tsx
+++ b/frontend/src/components/RarityFilter.tsx
@@ -2,12 +2,13 @@ import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import useWindowDimensions from '@/lib/hooks/useWindowDimensionsHook.ts'
+import type { PickableRarity } from '@/types'
 import { type FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
-  rarityFilter: string[]
-  setRarityFilter: (rarityFilter: string[]) => void
+  rarityFilter: PickableRarity[]
+  setRarityFilter: (rarityFilter: PickableRarity[]) => void
 }
 const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter }) => {
   const { width } = useWindowDimensions()
@@ -21,7 +22,7 @@ const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter }) => {
         type="multiple"
         size="sm"
         value={rarityFilter}
-        onValueChange={(value) => setRarityFilter(value)}
+        onValueChange={(value: PickableRarity[]) => setRarityFilter(value)}
         className={`justify-end shadow-none border-2 border-slate-600 rounded-md ${isMobile ? 'flex-col' : 'flex-row'}`}
       >
         <ToggleGroupItem value="◊" aria-label="◊" className="text-gray-400 hover:text-gray-500">

--- a/frontend/src/components/RarityFilter.tsx
+++ b/frontend/src/components/RarityFilter.tsx
@@ -2,13 +2,13 @@ import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import useWindowDimensions from '@/lib/hooks/useWindowDimensionsHook.ts'
-import type { PickableRarity } from '@/types'
+import type { Rarity } from '@/types'
 import { type FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
-  rarityFilter: PickableRarity[]
-  setRarityFilter: (rarityFilter: PickableRarity[]) => void
+  rarityFilter: Rarity[]
+  setRarityFilter: (rarityFilter: Rarity[]) => void
 }
 const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter }) => {
   const { width } = useWindowDimensions()
@@ -22,7 +22,7 @@ const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter }) => {
         type="multiple"
         size="sm"
         value={rarityFilter}
-        onValueChange={(value: PickableRarity[]) => setRarityFilter(value)}
+        onValueChange={(value: Rarity[]) => setRarityFilter(value)}
         className={`justify-end shadow-none border-2 border-slate-600 rounded-md ${isMobile ? 'flex-col' : 'flex-row'}`}
       >
         <ToggleGroupItem value="◊" aria-label="◊" className="text-gray-400 hover:text-gray-500">

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -1,11 +1,11 @@
-import type { Card, CollectionRow, Expansion, Pack, PickableRarity, Rarity, SellableForTokensRarity, TradeableRarity } from '@/types'
+import type { Card, CollectionRow, Expansion, ExpansionId, Pack, PickableRarity, Rarity } from '@/types'
 import A1 from '../../assets/cards/A1.json'
 import A1a from '../../assets/cards/A1a.json'
 import A2 from '../../assets/cards/A2.json'
 import A2a from '../../assets/cards/A2a.json'
 import PA from '../../assets/cards/P-A.json'
 
-const update = (cards: Card[], expansionName: Expansion['id']) => {
+const update = (cards: Card[], expansionName: ExpansionId) => {
   for (const card of cards) {
     // we set the card_id to the linkedCardID if it exists, so we really threat it as a single card eventhough it appears in multiple expansions.
     // @ts-ignore there is an ID in the JSON, but I don't want it in the Type because you should always use the card_id, having both is confusing.
@@ -74,21 +74,30 @@ export const expansions: Expansion[] = [
   },
 ]
 
-export const tradeableRaritiesDictionary: Record<TradeableRarity, number> = {
+export const tradeableRaritiesDictionary: Record<Rarity, number | null> = {
   '◊': 0,
   '◊◊': 0,
   '◊◊◊': 120,
   '◊◊◊◊': 500,
   '☆': 500,
+  '☆☆': null,
+  '☆☆☆': null,
+  'Crown Rare': null,
+  Unknown: null,
+  '': null,
 }
 
-export const sellableForTokensDictionary: Record<SellableForTokensRarity, number> = {
+export const sellableForTokensDictionary: Record<Rarity, number | null> = {
+  '◊': null,
+  '◊◊': null,
   '◊◊◊': 25,
   '◊◊◊◊': 125,
   '☆': 100,
   '☆☆': 300,
   '☆☆☆': 300,
   'Crown Rare': 1500,
+  Unknown: null,
+  '': null,
 }
 
 interface NrOfCardsOwnedProps {
@@ -106,11 +115,17 @@ export const getNrOfCardsOwned = ({ ownedCards, rarityFilter, numberFilter, expa
       if (!rarityFilter.length || !cardRarity) return true
       return rarityFilter.includes(cardRarity)
     },
-    expansion: (card: CollectionRow) => (expansion ? expansion.cards.find((c) => card.card_id === c.card_id) : true),
-    pack: (card: CollectionRow) => (expansion && packName ? expansion.cards.find((c) => c.pack === packName && card.card_id === c.card_id) : true),
+    expansion: (cr: CollectionRow) => (expansion ? expansion.cards.find((c) => cr.card_id === c.card_id) : true),
+    pack: (cr: CollectionRow) => (expansion && packName ? expansion.cards.find((c) => c.pack === packName && cr.card_id === c.card_id) : true),
   }
 
-  return ownedCards.filter(filters.number).filter(filters.rarity).filter(filters.expansion).filter(filters.pack).length
+  // biome-ignore format: improve readability for filters
+  return ownedCards
+    .filter(filters.number)
+    .filter(filters.rarity)
+    .filter(filters.expansion)
+    .filter(filters.pack)
+    .length
 }
 
 interface TotalNrOfCardsProps {

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -1,4 +1,4 @@
-import type { Card, CollectionRow, Expansion, ExpansionId, Pack, PickableRarity, Rarity } from '@/types'
+import type { Card, CollectionRow, Expansion, ExpansionId, Pack, Rarity } from '@/types'
 import A1 from '../../assets/cards/A1.json'
 import A1a from '../../assets/cards/A1a.json'
 import A2 from '../../assets/cards/A2.json'
@@ -152,7 +152,7 @@ export const getTotalNrOfCards = ({ rarityFilter, expansion, packName }: TotalNr
   return filteredCards.length
 }
 
-const probabilityPerRarity1_3: Record<PickableRarity, number> = {
+const probabilityPerRarity1_3: Record<Rarity, number> = {
   '◊': 100,
   '◊◊': 0,
   '◊◊◊': 0,
@@ -161,8 +161,10 @@ const probabilityPerRarity1_3: Record<PickableRarity, number> = {
   '☆☆': 0,
   '☆☆☆': 0,
   'Crown Rare': 0,
+  Unknown: 0,
+  '': 0,
 }
-const probabilityPerRarity4: Record<PickableRarity, number> = {
+const probabilityPerRarity4: Record<Rarity, number> = {
   '◊': 0,
   '◊◊': 90,
   '◊◊◊': 5,
@@ -171,8 +173,10 @@ const probabilityPerRarity4: Record<PickableRarity, number> = {
   '☆☆': 0.5,
   '☆☆☆': 0.222,
   'Crown Rare': 0.04,
+  Unknown: 0,
+  '': 0,
 }
-const probabilityPerRarity5: Record<PickableRarity, number> = {
+const probabilityPerRarity5: Record<Rarity, number> = {
   '◊': 0,
   '◊◊': 60,
   '◊◊◊': 20,
@@ -181,13 +185,15 @@ const probabilityPerRarity5: Record<PickableRarity, number> = {
   '☆☆': 2,
   '☆☆☆': 0.888,
   'Crown Rare': 0.16,
+  Unknown: 0,
+  '': 0,
 }
 
 interface PullRateProps {
   ownedCards: CollectionRow[]
   expansion: Expansion
   pack: Pack
-  rarityFilter?: PickableRarity[]
+  rarityFilter?: Rarity[]
   numberFilter?: number
 }
 export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numberFilter = 1 }: PullRateProps) => {

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -8,7 +8,7 @@ import SearchInput from '@/components/SearchInput.tsx'
 import { allCards } from '@/lib/CardsDB'
 import { CollectionContext } from '@/lib/context/CollectionContext.ts'
 import { UserContext } from '@/lib/context/UserContext.ts'
-import type { Card, PickableRarity } from '@/types'
+import type { Card, Rarity } from '@/types'
 import { useEffect, useMemo, useState } from 'react'
 import { useContext } from 'react'
 
@@ -17,7 +17,7 @@ function Collection() {
   const { ownedCards, setOwnedCards } = useContext(CollectionContext)
   const [searchValue, setSearchValue] = useState('')
   const [expansionFilter, setExpansionFilter] = useState<string>('all')
-  const [rarityFilter, setRarityFilter] = useState<PickableRarity[]>([])
+  const [rarityFilter, setRarityFilter] = useState<Rarity[]>([])
   const [ownedFilter, setOwnedFilter] = useState<'all' | 'owned' | 'missing'>('all')
   const [resetScrollTrigger, setResetScrollTrigger] = useState(false)
 

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -8,6 +8,7 @@ import SearchInput from '@/components/SearchInput.tsx'
 import { allCards } from '@/lib/CardsDB'
 import { CollectionContext } from '@/lib/context/CollectionContext.ts'
 import { UserContext } from '@/lib/context/UserContext.ts'
+import type { Card, PickableRarity } from '@/types'
 import { useEffect, useMemo, useState } from 'react'
 import { useContext } from 'react'
 
@@ -16,9 +17,14 @@ function Collection() {
   const { ownedCards, setOwnedCards } = useContext(CollectionContext)
   const [searchValue, setSearchValue] = useState('')
   const [expansionFilter, setExpansionFilter] = useState<string>('all')
-  const [rarityFilter, setRarityFilter] = useState<string[]>([])
+  const [rarityFilter, setRarityFilter] = useState<PickableRarity[]>([])
   const [ownedFilter, setOwnedFilter] = useState<'all' | 'owned' | 'missing'>('all')
   const [resetScrollTrigger, setResetScrollTrigger] = useState(false)
+
+  const filterRarities = (c: Card) => {
+    if (rarityFilter.length === 0) return true
+    return c.rarity !== 'Unknown' && c.rarity !== '' && rarityFilter.includes(c.rarity)
+  }
 
   const getFilteredCards = useMemo(() => {
     let filteredCards = allCards
@@ -33,9 +39,7 @@ function Collection() {
         filteredCards = filteredCards.filter((card) => !ownedCards.find((oc) => oc.card_id === card.card_id && oc.amount_owned > 0))
       }
     }
-    if (rarityFilter.length > 0) {
-      filteredCards = filteredCards.filter((card) => rarityFilter.includes(card.rarity))
-    }
+    filteredCards = filteredCards.filter(filterRarities)
     if (searchValue) {
       filteredCards = filteredCards.filter((card) => {
         return card.name.toLowerCase().includes(searchValue.toLowerCase()) || card.card_id.toLowerCase().includes(searchValue.toLowerCase())

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -5,6 +5,7 @@ import { AlertTitle } from '@/components/ui/alert.tsx'
 import * as CardsDB from '@/lib/CardsDB.ts'
 import { CollectionContext } from '@/lib/context/CollectionContext'
 import { GradientCard } from '@/pages/overview/components/GradientCard.tsx'
+import type { PickableRarity } from '@/types'
 import { Siren } from 'lucide-react'
 import { use, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -22,7 +23,7 @@ function Overview() {
 
   const [highestProbabilityPack, setHighestProbabilityPack] = useState<Pack | undefined>()
   const ownedCardsCount = useMemo(() => ownedCards.reduce((total, card) => total + card.amount_owned, 0), [ownedCards])
-  const [rarityFilter, setRarityFilter] = useState<string[]>(() => {
+  const [rarityFilter, setRarityFilter] = useState<PickableRarity[]>(() => {
     const savedRarityFilter = localStorage.getItem('rarityFilter')
     return savedRarityFilter ? JSON.parse(savedRarityFilter) : []
   })

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -5,7 +5,7 @@ import { AlertTitle } from '@/components/ui/alert.tsx'
 import * as CardsDB from '@/lib/CardsDB.ts'
 import { CollectionContext } from '@/lib/context/CollectionContext'
 import { GradientCard } from '@/pages/overview/components/GradientCard.tsx'
-import type { PickableRarity } from '@/types'
+import type { Rarity } from '@/types'
 import { Siren } from 'lucide-react'
 import { use, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -23,7 +23,7 @@ function Overview() {
 
   const [highestProbabilityPack, setHighestProbabilityPack] = useState<Pack | undefined>()
   const ownedCardsCount = useMemo(() => ownedCards.reduce((total, card) => total + card.amount_owned, 0), [ownedCards])
-  const [rarityFilter, setRarityFilter] = useState<PickableRarity[]>(() => {
+  const [rarityFilter, setRarityFilter] = useState<Rarity[]>(() => {
     const savedRarityFilter = localStorage.getItem('rarityFilter')
     return savedRarityFilter ? JSON.parse(savedRarityFilter) : []
   })

--- a/frontend/src/pages/overview/components/CompleteProgress.tsx
+++ b/frontend/src/pages/overview/components/CompleteProgress.tsx
@@ -1,7 +1,7 @@
 import { Progress } from '@/components/ui/progress.tsx'
 import { getNrOfCardsOwned, getTotalNrOfCards } from '@/lib/CardsDB.ts'
 import { CollectionContext } from '@/lib/context/CollectionContext'
-import type { Expansion } from '@/types'
+import type { Expansion, Rarity } from '@/types'
 import { use, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -9,7 +9,7 @@ interface CompleteProgressProps {
   title: string
   expansion: Expansion
   packName?: string
-  rarityFilter?: string[]
+  rarityFilter?: Rarity[]
   numberFilter?: number
 }
 

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -3,7 +3,7 @@ import * as CardsDB from '@/lib/CardsDB.ts'
 import { CollectionContext } from '@/lib/context/CollectionContext'
 import { CompleteProgress } from '@/pages/overview/components/CompleteProgress.tsx'
 import { GradientCard } from '@/pages/overview/components/GradientCard.tsx'
-import type { Expansion } from '@/types'
+import type { Expansion, PickableRarity } from '@/types'
 import { use, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMediaQuery } from 'react-responsive'
@@ -11,7 +11,7 @@ import { Carousel } from './Carousel'
 
 interface ExpansionOverviewProps {
   expansion: Expansion
-  rarityFilter: string[]
+  rarityFilter: PickableRarity[]
   numberFilter: number
 }
 export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: ExpansionOverviewProps) {

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -3,7 +3,7 @@ import * as CardsDB from '@/lib/CardsDB.ts'
 import { CollectionContext } from '@/lib/context/CollectionContext'
 import { CompleteProgress } from '@/pages/overview/components/CompleteProgress.tsx'
 import { GradientCard } from '@/pages/overview/components/GradientCard.tsx'
-import type { Expansion, PickableRarity } from '@/types'
+import type { Expansion, Rarity } from '@/types'
 import { use, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMediaQuery } from 'react-responsive'
@@ -11,7 +11,7 @@ import { Carousel } from './Carousel'
 
 interface ExpansionOverviewProps {
   expansion: Expansion
-  rarityFilter: PickableRarity[]
+  rarityFilter: Rarity[]
   numberFilter: number
 }
 export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: ExpansionOverviewProps) {

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -10,6 +10,7 @@ import { UserContext } from '@/lib/context/UserContext'
 import { NoCardsNeeded } from '@/pages/trade/components/NoCardsNeeded.tsx'
 import { NoSellableCards } from '@/pages/trade/components/NoSellableCards.tsx'
 import { NoTradeableCards } from '@/pages/trade/components/NoTradeableCards.tsx'
+import type { Card, PickableRarity } from '@/types'
 import { type MouseEvent, use, useMemo, useState } from 'react'
 import { UserNotLoggedIn } from './components/UserNotLoggedIn'
 
@@ -18,13 +19,18 @@ function Trade() {
   const { ownedCards } = use(CollectionContext)
   const { toast } = useToast()
 
-  const [rarityFilter, setRarityFilter] = useState<string[]>([])
+  const [rarityFilter, setRarityFilter] = useState<PickableRarity[]>([])
   const [forTradeMinCards, setForTradeMinCards] = useState<number>(0)
   const [lookingForMinCards, setLookingForMinCards] = useState<number>(2)
   const [buyingTokensMinCards, setBuyingTokensMinCards] = useState<number>(3)
   const [currentTab, setCurrentTab] = useState('looking_for')
 
   const tradeableExpansions = useMemo(() => expansions.filter((e) => e.tradeable).map((e) => e.id), [])
+
+  const filterRarities = (c: Card) => {
+    if (rarityFilter.length === 0) return true
+    return c.rarity !== 'Unknown' && c.rarity !== '' && rarityFilter.includes(c.rarity)
+  }
 
   // LOOKING FOR CARDS
   const lookingForCards = useMemo(
@@ -35,11 +41,11 @@ function Trade() {
             ownedCards.findIndex((oc) => oc.card_id === ac.card_id) === -1 ||
             ownedCards[ownedCards.findIndex((oc) => oc.card_id === ac.card_id)].amount_owned <= forTradeMinCards,
         )
-        .filter((c) => Object.keys(tradeableRaritiesDictionary).includes(c.rarity) && tradeableExpansions.includes(c.expansion)),
+        .filter((c) => tradeableRaritiesDictionary[c.rarity] !== null && tradeableExpansions.includes(c.expansion)),
     [ownedCards, forTradeMinCards],
   )
   const lookingForCardsFiltered = useMemo(() => {
-    return lookingForCards.filter((c) => rarityFilter.length === 0 || rarityFilter.includes(c.rarity))
+    return lookingForCards.filter(filterRarities)
   }, [lookingForCards, rarityFilter])
 
   // FOR TRADE CARDS
@@ -51,11 +57,11 @@ function Trade() {
         ...ac,
         amount_owned: myCards.find((oc) => oc.card_id === ac.card_id)?.amount_owned,
       }))
-      .filter((c) => Object.keys(tradeableRaritiesDictionary).includes(c.rarity) && tradeableExpansions.includes(c.expansion))
+      .filter((c) => tradeableRaritiesDictionary[c.rarity] !== null && tradeableExpansions.includes(c.expansion))
   }, [ownedCards, lookingForMinCards])
 
   const forTradeCardsFiltered = useMemo(() => {
-    return forTradeCards.filter((c) => rarityFilter.length === 0 || rarityFilter.includes(c.rarity))
+    return forTradeCards.filter(filterRarities)
   }, [forTradeCards, rarityFilter])
 
   // BUYING TOKENS
@@ -68,13 +74,10 @@ function Trade() {
         ...ac,
         amount_owned: myCards.find((oc) => oc.card_id === ac.card_id)?.amount_owned,
       }))
-      .filter((c) => Object.keys(sellableForTokensDictionary).includes(c.rarity))
+      .filter((c) => sellableForTokensDictionary[c.rarity] !== null)
   }, [ownedCards, buyingTokensMinCards])
 
-  const buyingTokensCardsFiltered = useMemo(
-    () => buyingTokensCards.filter((c) => rarityFilter.length === 0 || rarityFilter.includes(c.rarity)),
-    [buyingTokensCards, rarityFilter],
-  )
+  const buyingTokensCardsFiltered = useMemo(() => buyingTokensCards.filter(filterRarities), [buyingTokensCards, rarityFilter])
 
   const getCardValues = () => {
     let cardValues = ''

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -10,7 +10,7 @@ import { UserContext } from '@/lib/context/UserContext'
 import { NoCardsNeeded } from '@/pages/trade/components/NoCardsNeeded.tsx'
 import { NoSellableCards } from '@/pages/trade/components/NoSellableCards.tsx'
 import { NoTradeableCards } from '@/pages/trade/components/NoTradeableCards.tsx'
-import type { Card, PickableRarity } from '@/types'
+import type { Card, Rarity } from '@/types'
 import { type MouseEvent, use, useMemo, useState } from 'react'
 import { UserNotLoggedIn } from './components/UserNotLoggedIn'
 
@@ -19,7 +19,7 @@ function Trade() {
   const { ownedCards } = use(CollectionContext)
   const { toast } = useToast()
 
-  const [rarityFilter, setRarityFilter] = useState<PickableRarity[]>([])
+  const [rarityFilter, setRarityFilter] = useState<Rarity[]>([])
   const [forTradeMinCards, setForTradeMinCards] = useState<number>(0)
   const [lookingForMinCards, setLookingForMinCards] = useState<number>(2)
   const [buyingTokensMinCards, setBuyingTokensMinCards] = useState<number>(3)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,11 +1,10 @@
 const expansionIds = ['A1', 'A1a', 'A2', 'A2a', 'P-A'] as const
+export type ExpansionId = (typeof expansionIds)[number]
 
 const rarities = ['◊', '◊◊', '◊◊◊', '◊◊◊◊', '☆', '☆☆', '☆☆☆', 'Crown Rare', 'Unknown', ''] as const
 
 export type Rarity = (typeof rarities)[number]
 export type PickableRarity = Exclude<Rarity, '' | 'Unknown'>
-export type TradeableRarity = Exclude<Rarity, '☆☆' | '☆☆☆' | 'Crown Rare' | '' | 'Unknown'>
-export type SellableForTokensRarity = Exclude<PickableRarity, '◊' | '◊◊' | '' | 'Unknown'>
 
 export interface AccountRow {
   $id: string
@@ -22,7 +21,7 @@ export interface CollectionRow {
 
 export interface Expansion {
   name: string
-  id: (typeof expansionIds)[number]
+  id: ExpansionId
   cards: Card[]
   packs: Pack[]
   tradeable?: boolean
@@ -37,7 +36,7 @@ export interface Pack {
 export interface Card {
   card_id: string
   linkedCardID?: string
-  expansion: string
+  expansion: ExpansionId
   name: string
   hp: string
   card_type: string
@@ -62,7 +61,7 @@ export interface Card {
   pack: string
   alternate_versions: {
     version: string
-    rarity: string
+    rarity: Rarity
   }[]
   artist: string
   probability: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,12 @@
+const expansionIds = ['A1', 'A1a', 'A2', 'A2a', 'P-A'] as const
+
+const rarities = ['◊', '◊◊', '◊◊◊', '◊◊◊◊', '☆', '☆☆', '☆☆☆', 'Crown Rare', 'Unknown', ''] as const
+
+export type Rarity = (typeof rarities)[number]
+export type PickableRarity = Exclude<Rarity, '' | 'Unknown'>
+export type TradeableRarity = Exclude<Rarity, '☆☆' | '☆☆☆' | 'Crown Rare' | '' | 'Unknown'>
+export type SellableForTokensRarity = Exclude<PickableRarity, '◊' | '◊◊' | '' | 'Unknown'>
+
 export interface AccountRow {
   $id: string
   username: string
@@ -8,11 +17,12 @@ export interface CollectionRow {
   email: string
   card_id: string
   amount_owned: number
+  rarity?: Rarity
 }
 
 export interface Expansion {
   name: string
-  id: string
+  id: (typeof expansionIds)[number]
   cards: Card[]
   packs: Pack[]
   tradeable?: boolean
@@ -45,7 +55,7 @@ export interface Card {
   }
   weakness: string
   retreat: string
-  rarity: string
+  rarity: Rarity
   fullart: string
   ex: string
   set_details: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,7 +4,6 @@ export type ExpansionId = (typeof expansionIds)[number]
 const rarities = ['◊', '◊◊', '◊◊◊', '◊◊◊◊', '☆', '☆☆', '☆☆☆', 'Crown Rare', 'Unknown', ''] as const
 
 export type Rarity = (typeof rarities)[number]
-export type PickableRarity = Exclude<Rarity, '' | 'Unknown'>
 
 export interface AccountRow {
   $id: string


### PR DESCRIPTION
Thanks for making such a cool project!

I was having a browse and thought there might be a good opportunity to use TypeScript to improve the type safety when handling rarities within the app.

A couple of thoughts:
1. I tried to avoid adding entries for every rarity to each object by having separate types like `PickableRarity`, etc, but actually in the end I thought it was probably good practice to have a single type and handle each possible value explicitly.
2. I was wondering why there are two different rarities for promo cards ("" and "Unknown"), do you think this is something that could be simplified? I'm not sure if this is something the scraper would handle, I didn't look at that part too closely.

I'm very open to any suggestions you might have, and if you don't like it at all then that's fair enough 😄 