### PR TITLE
275 checkbox to combine fullart and regular cards

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "react-hook-form": "^7.54.2",
     "react-responsive": "^10.0.1",
     "react-router": "^7.2.0",
+    "react-tooltip": "^5.28.0",
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.15",

--- a/frontend/public/locales/en-US/deckbuilding-filter.json
+++ b/frontend/public/locales/en-US/deckbuilding-filter.json
@@ -1,0 +1,4 @@
+{
+  "deckbuildingModeLabel": "Deck-building Mode",
+  "deckbuildingModeTooltip": "This will count all versions of a card as the same, which means you don't care if the card is a basic (diamond) or full-art (star/crown) version."
+}

--- a/frontend/public/locales/es-ES/deckbuilding-filter.json
+++ b/frontend/public/locales/es-ES/deckbuilding-filter.json
@@ -1,0 +1,4 @@
+{
+  "deckbuildingModeLabel": "Modo de construcción de mazo",
+  "deckbuildingModeTooltip": "Esto contará todas las versiones de una carta como la misma, lo que significa que no te importa si la carta es una versión básica (diamante) o de arte completo (estrella/corona)."
+}

--- a/frontend/public/locales/fr-FR/deckbuilding-filter.json
+++ b/frontend/public/locales/fr-FR/deckbuilding-filter.json
@@ -1,0 +1,4 @@
+{
+  "deckbuildingModeLabel": "Mode construction de deck",
+  "deckbuildingModeTooltip": "Cela comptera toutes les versions d'une carte comme étant la même, ce qui signifie que peu importe si la carte est une version basique (diamant) ou une version full-art (étoile/couronne)."
+}

--- a/frontend/public/locales/pt-BR/deckbuilding-filter.json
+++ b/frontend/public/locales/pt-BR/deckbuilding-filter.json
@@ -1,0 +1,4 @@
+{
+  "deckbuildingModeLabel": "Modo de construção de baralho",
+  "deckbuildingModeTooltip": "Isso contará todas as versões de uma carta como sendo a mesma, o que significa que você não se importa se a carta é uma versão básica (diamante) ou full-art (estrela/coroa)."
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -172,8 +172,6 @@ export const incrementMultipleCards = async (
   setOwnedCards: React.Dispatch<React.SetStateAction<CollectionRow[]>>,
   user: User | null,
 ) => {
-  console.log('incrementing multiple cards', cardIds, incrementAmount)
-
   if (!user || !user.user.email) {
     throw new Error('User not logged in')
   }

--- a/frontend/src/components/DeckbuildingFilter.tsx
+++ b/frontend/src/components/DeckbuildingFilter.tsx
@@ -1,0 +1,26 @@
+import useWindowDimensions from '@/lib/hooks/useWindowDimensionsHook'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Tooltip } from 'react-tooltip'
+
+interface Props {
+  deckbuildingMode: boolean
+  setDeckbuildingMode: (deckbuildingMode: boolean) => void
+}
+const DeckbuildingFilter: FC<Props> = ({ deckbuildingMode, setDeckbuildingMode }) => {
+  const { t } = useTranslation('deckbuilding-filter')
+  const { width } = useWindowDimensions()
+  const isMobile = width < 768
+
+  return (
+    <div className="flex items-center space-x-2">
+      <input type="checkbox" id="checkbox" checked={deckbuildingMode} onChange={() => setDeckbuildingMode(!deckbuildingMode)} className="w-5 h-5" />
+      <label htmlFor="checkbox" className="text-lg" data-tooltip-id="deckbuildingMode" data-tooltip-content={t('deckbuildingModeTooltip')}>
+        {t('deckbuildingModeLabel')}
+      </label>
+      {!isMobile && <Tooltip id="deckbuildingMode" style={{ maxWidth: '300px', whiteSpace: 'normal' }} />}
+    </div>
+  )
+}
+
+export default DeckbuildingFilter

--- a/frontend/src/components/InstallPrompt.tsx
+++ b/frontend/src/components/InstallPrompt.tsx
@@ -44,11 +44,9 @@ const InstallPrompt = () => {
   }, [])
 
   const handleInstallClick = async () => {
-    console.log('install clicked', deferredPrompt)
     if (deferredPrompt) {
-      console.log('prompting')
       await deferredPrompt.prompt()
-      console.log('awaiting user choice')
+
       const choiceResult = await deferredPrompt.userChoice
 
       if (choiceResult.outcome === 'accepted') {

--- a/frontend/src/components/RarityFilter.tsx
+++ b/frontend/src/components/RarityFilter.tsx
@@ -3,17 +3,25 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import useWindowDimensions from '@/lib/hooks/useWindowDimensionsHook.ts'
 import type { Rarity } from '@/types'
-import { type FC, useMemo } from 'react'
+import { type FC, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
   rarityFilter: Rarity[]
   setRarityFilter: (rarityFilter: Rarity[]) => void
+  deckbuildingMode?: boolean
 }
-const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter }) => {
+const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter, deckbuildingMode }) => {
   const { width } = useWindowDimensions()
   const { t } = useTranslation('rarity-filter')
   const isMobile = width < 768
+
+  useEffect(() => {
+    if (deckbuildingMode) {
+      const basicRarities: Rarity[] = ['◊', '◊◊', '◊◊◊', '◊◊◊◊']
+      setRarityFilter(rarityFilter.filter((rf) => basicRarities.includes(rf)))
+    }
+  }, [deckbuildingMode])
 
   const Toggles = useMemo(
     () => (
@@ -37,21 +45,25 @@ const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter }) => {
         <ToggleGroupItem value="◊◊◊◊" aria-label="◊◊◊◊" className="text-gray-400 hover:text-gray-500">
           ♢♢♢♢
         </ToggleGroupItem>
-        <ToggleGroupItem value="☆" aria-label="☆" className="text-yellow-500 hover:text-yellow-600 .dark:data-[state=on]:text-yellow-500">
-          ☆
-        </ToggleGroupItem>
-        <ToggleGroupItem value="☆☆" aria-label="☆☆" className="text-yellow-500 hover:text-yellow-600 data-[state=on]:text-yellow-500">
-          ☆☆
-        </ToggleGroupItem>
-        <ToggleGroupItem value="☆☆☆" aria-label="☆☆☆" className="text-yellow-500 hover:text-yellow-600 data-[state=on]:text-yellow-500">
-          ☆☆☆
-        </ToggleGroupItem>
-        <ToggleGroupItem value="Crown Rare" aria-label="♛">
-          👑
-        </ToggleGroupItem>
+        {!deckbuildingMode && (
+          <>
+            <ToggleGroupItem value="☆" aria-label="☆" className="text-yellow-500 hover:text-yellow-600 .dark:data-[state=on]:text-yellow-500">
+              ☆
+            </ToggleGroupItem>
+            <ToggleGroupItem value="☆☆" aria-label="☆☆" className="text-yellow-500 hover:text-yellow-600 data-[state=on]:text-yellow-500">
+              ☆☆
+            </ToggleGroupItem>
+            <ToggleGroupItem value="☆☆☆" aria-label="☆☆☆" className="text-yellow-500 hover:text-yellow-600 data-[state=on]:text-yellow-500">
+              ☆☆☆
+            </ToggleGroupItem>
+            <ToggleGroupItem value="Crown Rare" aria-label="♛">
+              👑
+            </ToggleGroupItem>
+          </>
+        )}
       </ToggleGroup>
     ),
-    [rarityFilter, isMobile],
+    [rarityFilter, isMobile, deckbuildingMode],
   )
 
   if (!isMobile) {

--- a/frontend/src/components/RarityFilter.tsx
+++ b/frontend/src/components/RarityFilter.tsx
@@ -13,8 +13,8 @@ interface Props {
 }
 const RarityFilter: FC<Props> = ({ rarityFilter, setRarityFilter, deckbuildingMode }) => {
   const { width } = useWindowDimensions()
-  const { t } = useTranslation('rarity-filter')
   const isMobile = width < 768
+  const { t } = useTranslation('rarity-filter')
 
   useEffect(() => {
     if (deckbuildingMode) {

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -263,8 +263,6 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
 
   let missingCards = cardsInPackWithAmounts.filter((c) => c.amount_owned <= numberFilter - 1)
 
-  // console.log(missingCards.filter((mc) => mc.name === 'Exeggutor ex'))
-
   if (rarityFilter.length > 0) {
     //filter out cards that are not in the rarity filter
     missingCards = missingCards.filter((c) => {

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -109,6 +109,8 @@ export const sellableForTokensDictionary: Record<Rarity, number | null> = {
   '': null,
 }
 
+const basicCards: Rarity[] = ['◊', '◊◊', '◊◊◊', '◊◊◊◊']
+
 interface NrOfCardsOwnedProps {
   ownedCards: CollectionRow[]
   rarityFilter: Rarity[]
@@ -126,12 +128,12 @@ export const getNrOfCardsOwned = ({ ownedCards, rarityFilter, numberFilter, expa
     allCardsWithAmounts = allCardsWithAmounts
       .map((ac) => {
         const amount_owned = allCardsWithAmounts
-          .filter((ov) => ov.name === ac.name && ov.expansion === ac.expansion) // can't use card ID, because we are specifically looking for cards with the same name but different arts
+          .filter((c) => c.name === ac.name && c.expansion === ac.expansion) // can't use card ID, because we are specifically looking for cards with the same name but different arts
           .reduce((acc, rc) => acc + (rc.amount_owned || 0), 0)
 
         return { ...ac, amount_owned }
       })
-      .filter((x) => x.fullart === 'No')
+      .filter((c) => basicCards.includes(c.rarity))
   }
 
   const filters = {
@@ -244,7 +246,7 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
   })
 
   if (deckbuildingMode) {
-    const basicCards: Rarity[] = ['◊', '◊◊', '◊◊◊', '◊◊◊◊']
+    // This function adds all the full-art cards amounts to the basic versions, then removes the full-art ones from the list
     cardsInPackWithAmounts = cardsInPack
       .map((cip) => {
         const amount = cardsInPackWithAmounts
@@ -280,6 +282,9 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
     if (rarityList[0] === 'Unknown' || rarityList[0] === '') continue
 
     if (deckbuildingMode) {
+      // while in deckbuilding mode, we only have diamond cards in the list,
+      // but want to include the chance of getting one of the missing cards as a more rare version,
+      // so we add the rarities here
       const matchingCards = cardsInPack.filter((cip) => cip.name === card.name && cip.expansion === card.expansion)
 
       for (const mc of matchingCards) {

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -276,11 +276,10 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
   let totalProbability5 = 0
   for (const card of missingCards) {
     const rarityList = [card.rarity]
+    // Skip cards that cannot be picked
     if (rarityList[0] === 'Unknown' || rarityList[0] === '') continue
 
     if (deckbuildingMode) {
-      // Skip cards that cannot be picked
-
       const matchingCards = cardsInPack.filter((cip) => cip.name === card.name && cip.expansion === card.expansion)
 
       for (const mc of matchingCards) {
@@ -290,14 +289,12 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
       }
     }
 
-    console.log('rarityList:', rarityList)
-
     let chanceToGetThisCard1_3 = 0
     let chanceToGetThisCard4 = 0
     let chanceToGetThisCard5 = 0
 
     for (const rarity of rarityList) {
-      const nrOfcardsOfThisRarity = cardsInPackWithAmounts.filter((c) => c.rarity === rarity).length
+      const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity).length
 
       // the chance to get this card is the probability of getting this card in the pack divided by the number of cards of this rarity
       chanceToGetThisCard1_3 += probabilityPerRarity1_3[rarity] / 100 / nrOfcardsOfThisRarity
@@ -305,20 +302,11 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
       chanceToGetThisCard5 += probabilityPerRarity5[rarity] / 100 / nrOfcardsOfThisRarity
     }
 
-    if (card.name === 'Exeggutor ex') {
-      console.log('totalProbability1_3', chanceToGetThisCard1_3)
-      console.log('totalProbability4', chanceToGetThisCard4)
-      console.log('totalProbability5', chanceToGetThisCard5)
-    }
-
     // add up the chances to get this card
     totalProbability1_3 += chanceToGetThisCard1_3
     totalProbability4 += chanceToGetThisCard4
     totalProbability5 += chanceToGetThisCard5
   }
-  // console.log('totalProbability1_3', totalProbability1_3)
-  // console.log('totalProbability4', totalProbability4)
-  // console.log('totalProbability5', totalProbability5)
 
   // take the total probabilities per card draw (for the 1-3 you need to take the cube root of the probability) and multiply
   const chanceToGetNewCard = 1 - (1 - totalProbability1_3) ** 3 * (1 - totalProbability4) * (1 - totalProbability5)

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -35,8 +35,9 @@ function Overview() {
     const savedNumberFilter = localStorage.getItem('numberFilter')
     return savedNumberFilter ? Number.parseInt(savedNumberFilter) : 1
   })
+  const [deckbuildingMode, setDeckbuildingMode] = useState(false)
 
-  const totalUniqueCards = CardsDB.getTotalNrOfCards({ rarityFilter })
+  const totalUniqueCards = CardsDB.getTotalNrOfCards({ rarityFilter, deckbuildingMode })
 
   useEffect(() => {
     fetch('https://vcwloujmsjuacqpwthee.supabase.co/storage/v1/object/public/stats/stats.json')
@@ -60,7 +61,7 @@ function Overview() {
         .filter((p) => p.name !== 'everypack')
         .map((pack) => ({
           packName: pack.name.replace('pack', ''),
-          percentage: CardsDB.pullRate({ ownedCards, expansion, pack, rarityFilter, numberFilter }),
+          percentage: CardsDB.pullRate({ ownedCards, expansion, pack, rarityFilter, numberFilter, deckbuildingMode }),
           fill: pack.color,
         }))
       const highestProbabilityPackCandidate = pullRates.sort((a, b) => b.percentage - a.percentage)[0]
@@ -70,7 +71,7 @@ function Overview() {
     }
 
     setHighestProbabilityPack(newHighestProbabilityPack)
-  }, [ownedCards, rarityFilter, numberFilter])
+  }, [ownedCards, rarityFilter, numberFilter, deckbuildingMode])
 
   return (
     <main className="fade-in-up">
@@ -94,13 +95,19 @@ function Overview() {
         <div className="mb-8 flex items-center gap-2">
           <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
           <NumberFilter numberFilter={numberFilter} setNumberFilter={setNumberFilter} options={[1, 2, 3, 4, 5]} />
+          <div className="flex items-center space-x-2">
+            <input type="checkbox" id="checkbox" checked={deckbuildingMode} onChange={() => setDeckbuildingMode(!deckbuildingMode)} className="w-5 h-5" />
+            <label htmlFor="checkbox" className="text-lg">
+              Deck-building Mode
+            </label>
+          </div>
         </div>
 
         <section className="grid grid-cols-8 gap-6">
           <div className="col-span-8 flex h-full w-full flex-col items-center justify-center rounded-4xl border-2 border-slate-600 border-solid p-4 sm:p-8 md:col-span-2">
             <h2 className="mb-2 text-center text-lg sm:text-2xl">{t('youHave')}</h2>
             <h1 className="mb-3 text-balance text-center font-semibold text-3xl sm:text-7xl">
-              {CardsDB.getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter })}
+              {CardsDB.getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter, deckbuildingMode })}
             </h1>
             <h2 className="text-balance text-center text-lg sm:text-2xl">{t('uniqueCards', { totalUniqueCards: totalUniqueCards })}</h2>
             <h2 className="text-balance text-center text-md sm:text-lg">
@@ -123,7 +130,13 @@ function Overview() {
       </article>
       <article className="mx-auto min-h-screen max-w-7xl sm:p-6 p-0 pt-6 grid grid-cols-8 gap-6">
         {CardsDB.expansions.map((expansion) => (
-          <ExpansionOverview key={expansion.id} expansion={expansion} rarityFilter={rarityFilter} numberFilter={numberFilter} />
+          <ExpansionOverview
+            key={expansion.id}
+            expansion={expansion}
+            rarityFilter={rarityFilter}
+            numberFilter={numberFilter}
+            deckbuildingMode={deckbuildingMode}
+          />
         ))}
       </article>
     </main>

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -1,3 +1,4 @@
+import DeckbuildingFilter from '@/components/DeckbuildingFilter'
 import NumberFilter from '@/components/NumberFilter'
 import RarityFilter from '@/components/RarityFilter.tsx'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -35,7 +36,10 @@ function Overview() {
     const savedNumberFilter = localStorage.getItem('numberFilter')
     return savedNumberFilter ? Number.parseInt(savedNumberFilter) : 1
   })
-  const [deckbuildingMode, setDeckbuildingMode] = useState(false)
+  const [deckbuildingMode, setDeckbuildingMode] = useState(() => {
+    const savedDeckbuildingFilter = localStorage.getItem('deckbuildingFilter')
+    return savedDeckbuildingFilter === 'true'
+  })
 
   const totalUniqueCards = CardsDB.getTotalNrOfCards({ rarityFilter, deckbuildingMode })
 
@@ -51,7 +55,8 @@ function Overview() {
   useEffect(() => {
     localStorage.setItem('rarityFilter', JSON.stringify(rarityFilter))
     localStorage.setItem('numberFilter', numberFilter.toString())
-  }, [rarityFilter, numberFilter])
+    localStorage.setItem('deckbuildingFilter', JSON.stringify(deckbuildingMode))
+  }, [rarityFilter, numberFilter, deckbuildingMode])
 
   useEffect(() => {
     let newHighestProbabilityPack: Pack | undefined
@@ -95,12 +100,7 @@ function Overview() {
         <div className="mb-8 flex items-center gap-2">
           <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} deckbuildingMode={deckbuildingMode} />
           <NumberFilter numberFilter={numberFilter} setNumberFilter={setNumberFilter} options={[1, 2, 3, 4, 5]} />
-          <div className="flex items-center space-x-2">
-            <input type="checkbox" id="checkbox" checked={deckbuildingMode} onChange={() => setDeckbuildingMode(!deckbuildingMode)} className="w-5 h-5" />
-            <label htmlFor="checkbox" className="text-lg">
-              Deck-building Mode
-            </label>
-          </div>
+          <DeckbuildingFilter deckbuildingMode={deckbuildingMode} setDeckbuildingMode={setDeckbuildingMode} />
         </div>
 
         <section className="grid grid-cols-8 gap-6">

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -93,7 +93,7 @@ function Overview() {
         )}
 
         <div className="mb-8 flex items-center gap-2">
-          <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
+          <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} deckbuildingMode={deckbuildingMode} />
           <NumberFilter numberFilter={numberFilter} setNumberFilter={setNumberFilter} options={[1, 2, 3, 4, 5]} />
           <div className="flex items-center space-x-2">
             <input type="checkbox" id="checkbox" checked={deckbuildingMode} onChange={() => setDeckbuildingMode(!deckbuildingMode)} className="w-5 h-5" />

--- a/frontend/src/pages/overview/components/CompleteProgress.tsx
+++ b/frontend/src/pages/overview/components/CompleteProgress.tsx
@@ -11,9 +11,10 @@ interface CompleteProgressProps {
   packName?: string
   rarityFilter?: Rarity[]
   numberFilter?: number
+  deckbuildingMode?: boolean
 }
 
-export function CompleteProgress({ title, expansion, packName, rarityFilter = [], numberFilter = 1 }: CompleteProgressProps) {
+export function CompleteProgress({ title, expansion, packName, rarityFilter = [], numberFilter = 1, deckbuildingMode }: CompleteProgressProps) {
   const { ownedCards } = use(CollectionContext)
   const { t } = useTranslation('complete-progress')
 
@@ -21,7 +22,10 @@ export function CompleteProgress({ title, expansion, packName, rarityFilter = []
     return getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter, expansion, packName })
   }, [ownedCards, expansion, packName, rarityFilter, numberFilter])
 
-  const totalNrOfCards = useMemo(() => getTotalNrOfCards({ rarityFilter, expansion, packName }), [rarityFilter, expansion, packName])
+  const totalNrOfCards = useMemo(
+    () => getTotalNrOfCards({ rarityFilter, expansion, packName, deckbuildingMode }),
+    [rarityFilter, expansion, packName, deckbuildingMode],
+  )
   const progressValue = useMemo(() => (nrOfCardsOwned / totalNrOfCards) * 100, [nrOfCardsOwned, totalNrOfCards])
 
   return (

--- a/frontend/src/pages/overview/components/CompleteProgress.tsx
+++ b/frontend/src/pages/overview/components/CompleteProgress.tsx
@@ -19,8 +19,8 @@ export function CompleteProgress({ title, expansion, packName, rarityFilter = []
   const { t } = useTranslation('complete-progress')
 
   const nrOfCardsOwned = useMemo(() => {
-    return getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter, expansion, packName })
-  }, [ownedCards, expansion, packName, rarityFilter, numberFilter])
+    return getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter, expansion, packName, deckbuildingMode })
+  }, [ownedCards, expansion, packName, rarityFilter, numberFilter, deckbuildingMode])
 
   const totalNrOfCards = useMemo(
     () => getTotalNrOfCards({ rarityFilter, expansion, packName, deckbuildingMode }),

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -13,8 +13,9 @@ interface ExpansionOverviewProps {
   expansion: Expansion
   rarityFilter: Rarity[]
   numberFilter: number
+  deckbuildingMode: boolean
 }
-export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: ExpansionOverviewProps) {
+export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckbuildingMode }: ExpansionOverviewProps) {
   const { ownedCards } = use(CollectionContext)
   const { t } = useTranslation(['expansion-overview', 'common/sets', 'common/packs'])
 
@@ -29,7 +30,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: Exp
     console.log('packs', packs)
     const chartData = packs.map((pack) => ({
       packName: pack.name.replace('pack', ''),
-      percentage: CardsDB.pullRate({ ownedCards, expansion, pack, rarityFilter, numberFilter }),
+      percentage: CardsDB.pullRate({ ownedCards, expansion, pack, rarityFilter, numberFilter, deckbuildingMode }),
       fill: pack.color,
     }))
 
@@ -39,7 +40,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: Exp
       highestProbabilityPack,
       chartData,
     }
-  }, [ownedCards, expansion, rarityFilter, numberFilter])
+  }, [ownedCards, expansion, rarityFilter, numberFilter, deckbuildingMode])
 
   return (
     <>
@@ -62,7 +63,13 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: Exp
               </>
             )}
             <div className="col-span-8 snap-start flex-shrink-0 w-full border-2 border-slate-600 border-solid rounded-4xl p-4 sm:p-8">
-              <CompleteProgress title={t('totalCards')} expansion={expansion} rarityFilter={rarityFilter} numberFilter={numberFilter} />
+              <CompleteProgress
+                title={t('totalCards')}
+                expansion={expansion}
+                rarityFilter={rarityFilter}
+                numberFilter={numberFilter}
+                deckbuildingMode={deckbuildingMode}
+              />
               {expansion.packs.length > 1 &&
                 expansion.packs.map((pack) => (
                   <CompleteProgress
@@ -72,6 +79,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: Exp
                     expansion={expansion}
                     packName={pack.name}
                     numberFilter={numberFilter}
+                    deckbuildingMode={deckbuildingMode}
                   />
                 ))}
             </div>
@@ -94,7 +102,13 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: Exp
             </>
           )}
           <div className="col-span-4 lg:col-span-2">
-            <CompleteProgress title={t('totalCards')} expansion={expansion} rarityFilter={rarityFilter} numberFilter={numberFilter} />
+            <CompleteProgress
+              title={t('totalCards')}
+              expansion={expansion}
+              rarityFilter={rarityFilter}
+              numberFilter={numberFilter}
+              deckbuildingMode={deckbuildingMode}
+            />
             {expansion.packs.length > 1 &&
               expansion.packs.map((pack) => (
                 <CompleteProgress
@@ -104,6 +118,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter }: Exp
                   title={t(pack.name, { ns: 'common/packs' })}
                   expansion={expansion}
                   packName={pack.name}
+                  deckbuildingMode={deckbuildingMode}
                 />
               ))}
           </div>

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -27,7 +27,6 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckb
     if (packs.length > 1) {
       packs = packs.filter((pack) => pack.name !== 'everypack')
     }
-    console.log('packs', packs)
     const chartData = packs.map((pack) => ({
       packName: pack.name.replace('pack', ''),
       percentage: CardsDB.pullRate({ ownedCards, expansion, pack, rarityFilter, numberFilter, deckbuildingMode }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       react-router:
         specifier: ^7.2.0
         version: 7.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-tooltip:
+        specifier: ^5.28.0
+        version: 5.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       recharts:
         specifier: ^2.15.1
         version: 2.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1339,6 +1342,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -2058,6 +2064,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-tooltip@5.28.0:
+    resolution: {integrity: sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==}
+    peerDependencies:
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -3409,6 +3421,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classnames@2.5.1: {}
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -4076,6 +4090,13 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.12
+
+  react-tooltip@5.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@floating-ui/dom': 1.6.13
+      classnames: 2.5.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
Closes #275

Adds a checkbox that allows the user to treat full-art cards like basic cards when counting how many are already owned and the chance of getting a "new" card.

This new filter is called "Deck-building Mode". A tooltip explaining the mode has been added in desktop mode. In mobile it seemed too large and in-the way.

Card counts change when this mode is turned on.

When this filter is turned on, the star and crown rarities are removed from the rarity filter, as they no longer make sense.

Images highlight changes that are made between modes:
<img width="1206" alt="Screenshot 2025-04-03 at 17 44 35" src="https://github.com/user-attachments/assets/19335691-ed5e-4ebf-afe2-29e31fa0dc1c" />
<img width="877" alt="Screenshot 2025-04-03 at 17 36 35" src="https://github.com/user-attachments/assets/bcd9d254-a626-4b1e-9bc4-7d712934fba4" />


