### PR TITLE
add rare pack probability and fix shiny odds

### DIFF
--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -218,8 +218,8 @@ const probabilityPerRarity4: Record<Rarity, number> = {
   '☆': 2.572,
   '☆☆': 0.5,
   '☆☆☆': 0.222,
-  '✵': 0.714,
-  '✵✵': 0.33,
+  '✵': 0,
+  '✵✵': 0,
   'Crown Rare': 0.04,
   Unknown: 0,
   '': 0,
@@ -232,9 +232,51 @@ const probabilityPerRarity5: Record<Rarity, number> = {
   '☆': 10.288,
   '☆☆': 2,
   '☆☆☆': 0.888,
+  '✵': 0,
+  '✵✵': 0,
+  'Crown Rare': 0.16,
+  Unknown: 0,
+  '': 0,
+}
+const probabilityPerRarity4Shiny: Record<Rarity, number> = {
+  '◊': 0,
+  '◊◊': 89,
+  '◊◊◊': 4.9525,
+  '◊◊◊◊': 1.666,
+  '☆': 2.572,
+  '☆☆': 0.5,
+  '☆☆☆': 0.222,
+  '✵': 0.71425,
+  '✵✵': 0.33325,
+  'Crown Rare': 0.04,
+  Unknown: 0,
+  '': 0,
+}
+const probabilityPerRarity5Shiny: Record<Rarity, number> = {
+  '◊': 0,
+  '◊◊': 56,
+  '◊◊◊': 19.81,
+  '◊◊◊◊': 6.664,
+  '☆': 10.288,
+  '☆☆': 2,
+  '☆☆☆': 0.888,
   '✵': 2.857,
   '✵✵': 1.333,
   'Crown Rare': 0.16,
+  Unknown: 0,
+  '': 0,
+}
+const abilityByRarityToBeInRarePack: Record<Rarity, number> = {
+  '◊': 0,
+  '◊◊': 0,
+  '◊◊◊': 0,
+  '◊◊◊◊': 0,
+  '☆': 1,
+  '☆☆': 1,
+  '☆☆☆': 1,
+  '✵': 1,
+  '✵✵': 1,
+  'Crown Rare': 1,
   Unknown: 0,
   '': 0,
 }
@@ -253,6 +295,7 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
   }
 
   const cardsInPack = expansion.cards.filter((c) => c.pack === pack.name || c.pack === 'everypack')
+  const cardsInRarePack = cardsInPack.filter((c) => abilityByRarityToBeInRarePack[c.rarity] === 1)
 
   let cardsInPackWithAmounts = cardsInPack.map((cip) => {
     const amount = ownedCards.find((oc) => cip.card_id === oc.card_id)?.amount_owned || 0
@@ -288,6 +331,7 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
   let totalProbability1_3 = 0
   let totalProbability4 = 0
   let totalProbability5 = 0
+  let rareProbability1_5 = 0
   for (const card of missingCards) {
     const rarityList = [card.rarity]
     // Skip cards that cannot be picked
@@ -309,26 +353,36 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
     let chanceToGetThisCard1_3 = 0
     let chanceToGetThisCard4 = 0
     let chanceToGetThisCard5 = 0
+    let chanceToGetThisCardRare1_5 = 0
 
     for (const rarity of rarityList) {
       const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity).length
 
       // the chance to get this card is the probability of getting this card in the pack divided by the number of cards of this rarity
       chanceToGetThisCard1_3 += probabilityPerRarity1_3[rarity] / 100 / nrOfcardsOfThisRarity
-      chanceToGetThisCard4 += probabilityPerRarity4[rarity] / 100 / nrOfcardsOfThisRarity
-      chanceToGetThisCard5 += probabilityPerRarity5[rarity] / 100 / nrOfcardsOfThisRarity
+      if (expansion.id === 'A2b') {
+        chanceToGetThisCard4 += probabilityPerRarity4Shiny[rarity] / 100 / nrOfcardsOfThisRarity
+        chanceToGetThisCard5 += probabilityPerRarity5Shiny[rarity] / 100 / nrOfcardsOfThisRarity
+      } else {
+        chanceToGetThisCard4 += probabilityPerRarity4[rarity] / 100 / nrOfcardsOfThisRarity
+        chanceToGetThisCard5 += probabilityPerRarity5[rarity] / 100 / nrOfcardsOfThisRarity
+      }
+      chanceToGetThisCardRare1_5 += abilityByRarityToBeInRarePack[rarity] / cardsInRarePack.length
     }
 
     // add up the chances to get this card
     totalProbability1_3 += chanceToGetThisCard1_3
     totalProbability4 += chanceToGetThisCard4
     totalProbability5 += chanceToGetThisCard5
+    rareProbability1_5 += chanceToGetThisCardRare1_5
   }
 
-  // take the total probabilities per card draw (for the 1-3 you need to take the cube root of the probability) and multiply
-  const chanceToGetNewCard = 1 - (1 - totalProbability1_3) ** 3 * (1 - totalProbability4) * (1 - totalProbability5)
+  // take the total probabilities per card draw (for the 1-3 you need to cube the probability) and multiply
+  const chanceToGetNewCard = 0.9995 * (1 - (1 - totalProbability1_3) ** 3 * (1 - totalProbability4) * (1 - totalProbability5))
+  const chanceToGetNewCardInRarePack = 0.0005 * (1 - (1 - rareProbability1_5) ** 5)
 
-  return chanceToGetNewCard
+  // disjoint union of probabilities
+  return chanceToGetNewCard + chanceToGetNewCardInRarePack
 }
 
 export const pullRateForSpecificCard = (expansion: Expansion, packName: string, card: Card) => {


### PR DESCRIPTION
Currently the probabilities don't appear to take rare packs into account. They also have slightly inaccurate percentages for the Shining Revelry pack.

For rare pack, all star-ranked, shiny, or crown cards in the pack are available at equal rates (1/n for each card where n is the total number of cards in the pack of any of these rarities). This rate applies for all 5 cards, so (1 - (1 - m/n) ** 5)) where m is unowned cards of these rarities. Rare packs appear .05% of the time.

For shiny odds, I added new probability distribution for the shiny pack cards 4 and 5 and filtered on expansion id to choose either the regular or shiny distribution for these cards.

The percentages for the fourth card for shiny are slightly more precise than as noted in the game. This is based on the idea that from the fourth card to the fifth card, all percentages except for 2 diamonds are quadrupled. Using this logic, since the probabilities for the fifth card in the shiny pack do add up to 100, we can assume that the probabilities were simply divided by 4 to achieve the probabilities for the fourth card. These numbers allow the fourth card probabilities to add up to 100.

Thanks!