### PR TITLE
Improve card equivalence for deck-building mode

### DIFF
--- a/frontend/public/locales/en-US/common/sets.json
+++ b/frontend/public/locales/en-US/common/sets.json
@@ -1,14 +1,14 @@
 {
   "geneticapex": "Genetic Apex",
   "mythicalisland": "Mythical Island",
-  "space-timesmackdown": "Space Timesmackdown",
+  "space-timesmackdown": "Space-Time Smackdown",
   "triumphantlight": "Triumphant Light",
   "shiningrevelry": "Shining Revelry",
   "promo-a": "Promo-A",
 
   "geneticapex(a1)": "Genetic Apex (A1)",
   "mythicalisland(a1a)": "Mythical Island (A1a)",
-  "space-timesmackdown(a2)": "Space Timesmackdown (A2)",
+  "space-timesmackdown(a2)": "Space-Time Smackdown (A2)",
   "triumphantlight(a2a)": "Triumphant Light (A2a)",
   "shiningrevelry(a2b)": "Shining Revelry (A2b)",
   "promo-a(p-a)": "Promo-A (P-A)",


### PR DESCRIPTION
Addressing two issues seen on the Community forum under site feedback.

(1) Very small change: Space Timesmackdown -> Space-Time Smackdown
https://community.tcgpocketcollectiontracker.com/t/the-names-of-the-pack-expansions-at-the-overview-tab-are-showing-incorrectly/1499/2

(2) Refactor on deckbuilding card equivalence logic: two cards are equivalent iff they have the same name and attack name(s) rather than same name and expansion. I could be wrong, I didn't extensively check this, but all non-pokemon cards (cards without attacks) of the same name do not differ beyond art and no single pokemon has two different cards with different attacks under the same name.
https://community.tcgpocketcollectiontracker.com/t/deck-building-mode-and-promo-cards/2297