### PR TITLE
feat: add Italian translation

### DIFF
--- a/frontend/public/locales/it-IT/common/packs.json
+++ b/frontend/public/locales/it-IT/common/packs.json
@@ -1,0 +1,11 @@
+{
+  "pikachupack": "Busta Pikachu",
+  "charizardpack": "Busta Charizard",
+  "mewtwopack": "Busta Mewtwo",
+  "dialgapack": "Busta Dialga",
+  "palkiapack": "Busta Palkia",
+  "mewpack": "Busta Mew",
+  "arceuspack": "Busta Arceus",
+  "shiningrevelrypack": "Busta Tripudio Splendente",
+  "everypack": "Ogni busta"
+}

--- a/frontend/public/locales/it-IT/common/sets.json
+++ b/frontend/public/locales/it-IT/common/sets.json
@@ -1,0 +1,17 @@
+{
+  "geneticapex": "Geni Supremi",
+  "mythicalisland": "L'Isola Misteriosa",
+  "space-timesmackdown": "Scontro Spaziotemporale",
+  "triumphantlight": "Luce Trionfale",
+  "shiningrevelry": "Tripudio Splendente",
+  "promo-a": "Promo-A",
+
+  "geneticapex(a1)": "Geni Supremi (A1)",
+  "mythicalisland(a1a)": "L'Isola Misteriosa (A1a)",
+  "space-timesmackdown(a2)": "Scontro Spaziotemporale (A2)",
+  "triumphantlight(a2a)": "Luce Trionfale (A2a)",
+  "shiningrevelry(a2b)": "Tripudio Splendente (A2b)",
+  "promo-a(p-a)": "Promo-A (P-A)",
+
+  "all": "Tutte"
+}

--- a/frontend/public/locales/it-IT/common/types.json
+++ b/frontend/public/locales/it-IT/common/types.json
@@ -1,0 +1,12 @@
+{
+  "grass": "Erba",
+  "water": "Acqua",
+  "psychic": "Psiche",
+  "darkness": "Oscurità",
+  "dragon": "Drago",
+  "fire": "Fuoco",
+  "lightning": "Lampo",
+  "fighting": "Combattimento",
+  "metal": "Metallo",
+  "colorless": "Incolore"
+}

--- a/frontend/public/locales/it-IT/complete-progress.json
+++ b/frontend/public/locales/it-IT/complete-progress.json
@@ -1,0 +1,3 @@
+{
+  "youHave": "Hai {{nCardsOwned}} carte su {{nTotalCards}}"
+}

--- a/frontend/public/locales/it-IT/deckbuilding-filter.json
+++ b/frontend/public/locales/it-IT/deckbuilding-filter.json
@@ -1,0 +1,4 @@
+{
+  "deckbuildingModeLabel": "Modalità costruzione mazzo",
+  "deckbuildingModeTooltip": "Questo conterà tutte le versioni di una carta come se fosse la stessa, ovvero per te è lo stesso se la carta è in versione base (diamante) o full art (stella/corona)."
+}

--- a/frontend/public/locales/it-IT/edit-profile.json
+++ b/frontend/public/locales/it-IT/edit-profile.json
@@ -1,0 +1,16 @@
+{
+  "editProfile": "Modifica profilo",
+  "updateProfile": {
+    "title": "Aggiorna il tuo profilo",
+    "description": "Assicurati di aggiornare il tuo profilo con gli stessi dati della tua app di Pokémon Pocket. Useremo queste informazioni per organizzare gli scambi e la tua pagina pubblica della collezione."
+  },
+  "email": "Email",
+  "registeredEmail": "La tua email registrata.",
+  "username": "Nome utente",
+  "usernameDescription": "Usa lo stesso nome utente che hai su Pokémon Pocket qui.",
+  "friendID": "ID amico",
+  "friendIDDescription": "Usa lo stessso ID amico che hai su Pokémon Pocket qui (senza trattini)",
+  "isPublicDescription": "If you want to share your collection, you can do so here.",
+  "isPublicButton": "Apri pagina pubblica",
+  "save": "Salva"
+}

--- a/frontend/public/locales/it-IT/expansion-overview.json
+++ b/frontend/public/locales/it-IT/expansion-overview.json
@@ -1,0 +1,4 @@
+{
+  "probabilityNewCard": "Probabilità di ottenere una nuova carta per busta",
+  "totalCards": "Carte totali"
+}

--- a/frontend/public/locales/it-IT/gradient-card.json
+++ b/frontend/public/locales/it-IT/gradient-card.json
@@ -1,0 +1,3 @@
+{
+  "text": "è la busta da cui è più probabile ottenere una nuova carta scegliendo tra {{packNames}}. Hai una probabilità del {{chancePercentage}}% di ottenere una nuova carta."
+}

--- a/frontend/public/locales/it-IT/hamburguer-menu.json
+++ b/frontend/public/locales/it-IT/hamburguer-menu.json
@@ -1,0 +1,10 @@
+{
+  "overview": "Panoramica",
+  "collection": "Collezione",
+  "trade": "Scambio",
+  "community": "Community",
+  "toggle": "Menu pieghevole",
+  "editProfile": "Modifica profilo",
+  "logOut": "Logout",
+  "login": "Login"
+}

--- a/frontend/public/locales/it-IT/header.json
+++ b/frontend/public/locales/it-IT/header.json
@@ -1,0 +1,29 @@
+{
+  "overview": "Panoramica",
+  "collection": "Collezione",
+  "trade": "Scambio",
+  "selectLanguage": "Seleziona lingua",
+  "languages": {
+    "es-ES": "Spagnolo",
+    "en-US": "Inglese",
+    "pt-BR": "Portoghese",
+    "fr-FR": "Francese",
+    "it-IT": "Italiano"
+  },
+  "community": "Community",
+  "login": "Login",
+  "signUp": "Login / Registrazione",
+  "myAccount": "Il mio account",
+  "editProfile": "Modifica profilo",
+  "logOut": "Logout",
+  "install": "🌟 Ti piace TCG Pocket Tracker? Aggiungilo alla tua schermata home per un accesso veloce!",
+  "accept": "🚀 Sì, installalo ora!",
+  "cancel": "😊 No, grazie",
+  "export": "Esporta",
+  "import": "Importa",
+  "aboutUs": "Su di noi",
+  "aboutUsDialog": {
+    "title": "Su di noi",
+    "content": "TCG Pocket Tracker è un progetto gratuito e open source il cui scopo è aiutarti a tenere traccia della tua collezione di Pokémon Pocket. Fornisce un'interfaccia semplice e intuitiva per gestire la propria collezione. Il progetto è open source e accoglie contributi dalla community. Se hai qualsiasi domanda o feedback, entra in contatto con noi sul <a href=\"https://community.tcgpocketcollectiontracker.com\" style=\"text-decoration: underline;\">nostro forum della community</a> o su <a href=\"https://github.com/marcelpanse/tcg-pocket-collection-tracker\" style=\"text-decoration: underline;\">GitHub</a>."
+  }
+}

--- a/frontend/public/locales/it-IT/login.json
+++ b/frontend/public/locales/it-IT/login.json
@@ -1,0 +1,7 @@
+{
+  "invalidCode": "Codice invalido",
+  "validEmail": "Inserisci un indirizzo email valido",
+  "fill6Digit": "Grazie. Inserisci il codice a 6 cifre che trovi nella email che ti abbiamo inviato.",
+  "fillEmail": "Inserisci il tuo indirizzo email per ricevere un link magico per il login. Se non hai ancora un account, ne creeremo uno in automatico per te. Non usiamo il tuo indirizzo mail per altri motivi.",
+  "button": "Login / Registrazione"
+}

--- a/frontend/public/locales/it-IT/number-filter.json
+++ b/frontend/public/locales/it-IT/number-filter.json
@@ -1,0 +1,5 @@
+{
+  "numberCards": "Numbero di carte desiderate",
+  "maxNum": "Massimo numero di carte",
+  "minNum": "Minimo numero di carte"
+}

--- a/frontend/public/locales/it-IT/owned-filter.json
+++ b/frontend/public/locales/it-IT/owned-filter.json
@@ -1,0 +1,5 @@
+{
+  "all": "Tutte",
+  "missing": "Mancanti",
+  "owned": "Possedute"
+}

--- a/frontend/public/locales/it-IT/pages/card-detail.json
+++ b/frontend/public/locales/it-IT/pages/card-detail.json
@@ -1,0 +1,35 @@
+{
+  "text": {
+    "tradeTokens": "Gettoni scambio",
+    "hp": "PS",
+    "cardType": "Tipo di carta",
+    "evolutionType": "Tipo di evoluzione",
+    "ex": "EX",
+    "craftingCost": "Costo punti busta",
+    "artist": "Artista",
+    "setDetails": "Dettagli espansione",
+    "expansion": "Espansione",
+    "pack": "Busta",
+    "weakness": "Debolezza",
+    "retreat": "Costo di ritirata",
+    "ability": "Abilità",
+    "abilityEffect": "Effetto abilità",
+    "details": "Dettagli"
+  },
+  "cardType": {
+    "pokémon": "Pokémon",
+    "trainer": "Allenatore"
+  },
+  "evolutionType": {
+    "basic": "Base",
+    "stage1": "Fase 1",
+    "stage2": "Fase 2",
+    "item": "Strumento",
+    "tool": "Oggetto Pokémon",
+    "supporter": "Aiuto"
+  },
+  "ex": {
+    "yes": "Sì",
+    "no": "No"
+  }
+}

--- a/frontend/public/locales/it-IT/pages/collection.json
+++ b/frontend/public/locales/it-IT/pages/collection.json
@@ -1,0 +1,4 @@
+{
+  "publicCollectionTitle": "Stai osservando una collezione pubblica",
+  "publicCollectionDescription": "Al momento stai osservando una collezione pubblica. Clicca su un qualsiasi elemento di navigazione per tornare alla tua collezione."
+}

--- a/frontend/public/locales/it-IT/pages/overview.json
+++ b/frontend/public/locales/it-IT/pages/overview.json
@@ -1,0 +1,21 @@
+{
+  "stats": {
+    "title": "Grazie per essere parte della nostra community",
+    "description": "Al momento, la nostra community di {{usersCount}} utenti ha complessivamente tenuto traccia di {{collectionCount}} carte in totale!"
+  },
+  "dontHaveCards": {
+    "title": "Non hai ancora nessuna carta salvata!",
+    "description": "Vai alla pagina della collezione per aggiungere la tua prima carta o premi il pulsante di login per creare un account."
+  },
+  "usersOurCommunity": {
+    "youAre": "Fantastico, sei parte del",
+    "join": "Unisciti al",
+    "text": "utenti nella nostra community! 🎉"
+  },
+  "all": "tutte le buste",
+  "youHave": "Hai",
+  "uniqueCards": " carte su {{totalUniqueCards}} carte uniche",
+  "numberOfCopies-single": "con almeno 1 copia",
+  "numberOfCopies-plural": "con almeno {{numberFilter}} copie",
+  "cardsTotal": "carte in totale"
+}

--- a/frontend/public/locales/it-IT/rarity-filter.json
+++ b/frontend/public/locales/it-IT/rarity-filter.json
@@ -1,0 +1,3 @@
+{
+  "filters": "Rarità"
+}


### PR DESCRIPTION
Add Italian translation for all translatable text.

Tested locally.

A few issues:
- some text is not translated (e.g. "Scan", "Sign up to view your tradeable cards", "X selected, X uniques owned, X total owned" in the Collection page, etc.) -> they feel a bit off, it would be great to transalate them as well (if I can find some time I can try to understand how to do it)
- there is a small bug that prevents the text to be displayed correctly (it displays the key name and not the translated value):
![image](https://github.com/user-attachments/assets/9c870a05-6b5f-4811-a9f9-079d407d5da1)
![image](https://github.com/user-attachments/assets/98a67f71-b7ca-467d-a119-332cb9ccffec)
As you can see, it says "mewtwo, charizard, pikachu" instead of the correct names (in English should be "Mewtwo pack, Charizard pack, Pikachu pack"). At a quick look, the issue is that the `GradientCard` component receives - for instance - "mewtwo" as key but it should instead receive "mewtwopack". I couldn't find as easy fix - it's probably worth a separate issue.