### PR TITLE
Add pack filter and translatable pack names

### DIFF
--- a/frontend/public/locales/en-US/common/packs.json
+++ b/frontend/public/locales/en-US/common/packs.json
@@ -7,5 +7,7 @@
   "mewpack": "Mew pack",
   "arceuspack": "Arceus pack",
   "shiningrevelrypack": "Shining Revelry pack",
-  "everypack": "Every pack"
+  "everypack": "Every pack",
+
+  "all": "All packs"
 }

--- a/frontend/public/locales/en-US/gradient-card.json
+++ b/frontend/public/locales/en-US/gradient-card.json
@@ -1,3 +1,3 @@
 {
-  "text": "is the most probable pack to get a new card from among {{packNames}} packs. You have a {{chancePercentage}}% chance of getting a new card."
+  "text": "is the most probable pack to get a new card from among {{packNames}}. You have a {{chancePercentage}}% chance of getting a new card."
 }

--- a/frontend/public/locales/en-US/pages/overview.json
+++ b/frontend/public/locales/en-US/pages/overview.json
@@ -12,7 +12,7 @@
     "join": "Join the",
     "text": "users in our community! 🎉"
   },
-  "all": "all",
+  "all": "all the packs",
   "youHave": "You have",
   "uniqueCards": "out of {{totalUniqueCards}} unique cards",
   "numberOfCopies-single": "with at least 1 copy",

--- a/frontend/public/locales/es-ES/common/packs.json
+++ b/frontend/public/locales/es-ES/common/packs.json
@@ -6,5 +6,7 @@
   "palkiapack": "Sobre de Palkia",
   "mewpack": "Sobre de Mew",
   "arceuspack": "Sobre de Arceus",
-  "everypack": "Todos los sobres"
+  "everypack": "Todos los sobres",
+
+  "all": "Todos los sobres"
 }

--- a/frontend/public/locales/es-ES/pages/overview.json
+++ b/frontend/public/locales/es-ES/pages/overview.json
@@ -8,7 +8,7 @@
     "join": "Únete a los",
     "text": "usuarios en nuestra comunidad! 🎉"
   },
-  "all": "todos",
+  "all": "todos los sobres",
   "youHave": "Tienes",
   "uniqueCards": "de {{totalUniqueCards}} cartas únicas",
   "numberOfCopies-single": "con al menos 1 copia",

--- a/frontend/public/locales/pt-BR/gradient-card.json
+++ b/frontend/public/locales/pt-BR/gradient-card.json
@@ -1,3 +1,3 @@
 {
-  "text": "é o pacote com maior probabilidade de obter uma nova carta dentre {{packNames}} os pacotes. Você tem {{chancePercentage}}% de chance de obter uma nova carta."
+  "text": "é o pacote com maior probabilidade de obter uma nova carta dentre {{packNames}}. Você tem {{chancePercentage}}% de chance de obter uma nova carta."
 }

--- a/frontend/public/locales/pt-BR/pages/overview.json
+++ b/frontend/public/locales/pt-BR/pages/overview.json
@@ -8,7 +8,7 @@
     "join": "Junte-se aos",
     "text": "usuários da nossa comunidade! 🎉"
   },
-  "all": "todos",
+  "all": "todos os pacotes",
   "youHave": "Você tem",
   "uniqueCards": "de {{totalUniqueCards}} cartas únicas",
   "numberOfCopies-single": "com pelo menos 1 cópia",

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -3,6 +3,7 @@ import { updateMultipleCards } from '@/components/Card.tsx'
 import ExpansionsFilter from '@/components/filters/ExpansionsFilter.tsx'
 import NumberFilter from '@/components/filters/NumberFilter.tsx'
 import OwnedFilter from '@/components/filters/OwnedFilter.tsx'
+import PackFilter from '@/components/filters/PackFilter.tsx'
 import RarityFilter from '@/components/filters/RarityFilter.tsx'
 import SearchInput from '@/components/filters/SearchInput.tsx'
 import { Button } from '@/components/ui/button.tsx'
@@ -29,6 +30,7 @@ interface Props {
 
   filtersDialog?: {
     expansions?: boolean
+    pack?: boolean
     search?: boolean
     owned?: boolean
     rarity?: boolean
@@ -45,6 +47,7 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, visibleFilt
   const [langState, setLangState] = useState(i18n.language)
   const [searchValue, setSearchValue] = useState('')
   const [expansionFilter, setExpansionFilter] = useState<string>('all')
+  const [packFilter, setPackFilter] = useState<string>('all')
   const [rarityFilter, setRarityFilter] = useState<Rarity[]>([])
   const [ownedFilter, setOwnedFilter] = useState<'all' | 'owned' | 'missing'>('all')
   const [numberFilter, setNumberFilter] = useState(0)
@@ -63,6 +66,9 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, visibleFilt
 
     if (expansionFilter !== 'all') {
       filteredCards = filteredCards.filter((card) => card.expansion === expansionFilter)
+    }
+    if (packFilter !== 'all') {
+      filteredCards = filteredCards.filter((card) => card.pack === packFilter || card.pack === 'everypack')
     }
     if (ownedFilter !== 'all') {
       if (ownedFilter === 'owned') {
@@ -91,7 +97,7 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, visibleFilt
     filteredCards = filteredCards.filter((f) => (f.amount_owned || 0) >= numberFilter)
 
     return filteredCards
-  }, [cards, expansionFilter, rarityFilter, searchValue, ownedFilter, numberFilter, langState])
+  }, [cards, expansionFilter, packFilter, rarityFilter, searchValue, ownedFilter, numberFilter, langState])
 
   useEffect(() => {
     onFiltersChanged(getFilteredCards)
@@ -115,7 +121,9 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, visibleFilt
       {children}
 
       <div className="flex items-center gap-2 flex-col md:flex-row gap-y-1 px-4 mb-2">
-        {visibleFilters?.expansions && <ExpansionsFilter expansionFilter={expansionFilter} setExpansionFilter={setExpansionFilter} />}
+        {visibleFilters?.expansions && (
+          <ExpansionsFilter expansionFilter={expansionFilter} setExpansionFilter={setExpansionFilter} setPackFilter={setPackFilter} />
+        )}
       </div>
       <div className="items-center gap-2 flex-row gap-y-1 px-4 flex">
         {visibleFilters?.search && <SearchInput setSearchValue={setSearchValue} />}
@@ -133,7 +141,10 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, visibleFilt
               </DialogHeader>
               <div className="flex flex-col gap-3">
                 {filtersDialog.search && <SearchInput setSearchValue={setSearchValue} fullWidth />}
-                {filtersDialog.expansions && <ExpansionsFilter expansionFilter={expansionFilter} setExpansionFilter={setExpansionFilter} />}
+                {filtersDialog.expansions && (
+                  <ExpansionsFilter expansionFilter={expansionFilter} setExpansionFilter={setExpansionFilter} setPackFilter={setPackFilter} />
+                )}
+                {filtersDialog.pack && <PackFilter packFilter={packFilter} setPackFilter={setPackFilter} expansion={expansionFilter} />}
                 {filtersDialog.rarity && <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />}
                 {filtersDialog.owned && <OwnedFilter ownedFilter={ownedFilter} setOwnedFilter={setOwnedFilter} fullWidth />}
                 {filtersDialog.amount && (

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -6,12 +6,20 @@ import { useTranslation } from 'react-i18next'
 interface Props {
   expansionFilter: string
   setExpansionFilter: (expansionFilter: string) => void
+  setPackFilter: (expansionFilter: string) => void
 }
-const ExpansionsFilter: FC<Props> = ({ expansionFilter, setExpansionFilter }) => {
+const ExpansionsFilter: FC<Props> = ({ expansionFilter, setExpansionFilter, setPackFilter }) => {
   const { t } = useTranslation('common/sets')
 
   return (
-    <Tabs value={expansionFilter} onValueChange={(value) => setExpansionFilter(value)} className="w-full">
+    <Tabs
+      value={expansionFilter}
+      onValueChange={(value) => {
+        setExpansionFilter(value)
+        setPackFilter('all')
+      }}
+      className="w-full"
+    >
       <TabsList className="w-full flex-wrap h-auto border-2 border-slate-600 rounded-md">
         <TabsTrigger value="all">{t('all')}</TabsTrigger>
         {expansions.map((expansion) => (

--- a/frontend/src/components/filters/PackFilter.tsx
+++ b/frontend/src/components/filters/PackFilter.tsx
@@ -1,0 +1,36 @@
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs.tsx'
+import { expansions } from '@/lib/CardsDB.ts'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  packFilter: string
+  setPackFilter: (packFilter: string) => void
+  expansion: string
+}
+const PackFilter: FC<Props> = ({ packFilter, setPackFilter, expansion }) => {
+  const { t } = useTranslation('common/packs')
+
+  return (
+    <Tabs value={packFilter} onValueChange={(value) => setPackFilter(value)} className="w-full">
+      <TabsList className="w-full flex-wrap h-auto border-2 border-slate-600 rounded-md">
+        <TabsTrigger value="all">{t('all')}</TabsTrigger>
+        {expansions
+          .filter((exp) => exp.id === expansion)
+          .map((exp) => {
+            if (exp.packs.length > 1) {
+              return exp.packs
+                .filter((pack) => pack.name !== 'everypack')
+                .map((pack) => (
+                  <TabsTrigger key={`tab_trigger_${pack.name}`} value={pack.name}>
+                    {t(pack.name)}
+                  </TabsTrigger>
+                ))
+            }
+          })}
+      </TabsList>
+    </Tabs>
+  )
+}
+
+export default PackFilter

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -61,7 +61,7 @@ function Collection() {
         cards={cardCollection}
         onFiltersChanged={(cards) => setFilteredCards(cards)}
         visibleFilters={{ expansions: !isMobile, search: true, owned: !isMobile, rarity: !isMobile }}
-        filtersDialog={{ expansions: true, search: true, owned: true, rarity: true, amount: true }}
+        filtersDialog={{ expansions: true, pack: true, search: true, owned: true, rarity: true, amount: true }}
         batchUpdate={Boolean(!friendCards)}
       >
         <div>

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -65,7 +65,7 @@ function Overview() {
       const pullRates = expansion.packs
         .filter((p) => p.name !== 'everypack')
         .map((pack) => ({
-          packName: pack.name.replace('pack', ''),
+          packName: pack.name,
           percentage: CardsDB.pullRate({ ownedCards, expansion, pack, rarityFilter, numberFilter, deckbuildingMode }),
           fill: pack.color,
         }))

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -28,7 +28,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckb
       packs = packs.filter((pack) => pack.name !== 'everypack')
     }
     const chartData = packs.map((pack) => ({
-      packName: pack.name.replace('pack', ''),
+      packName: pack.name,
       percentage: CardsDB.pullRate({ ownedCards, expansion, pack, rarityFilter, numberFilter, deckbuildingMode }),
       fill: pack.color,
     }))
@@ -51,7 +51,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckb
               <>
                 <GradientCard
                   title={highestProbabilityPack.packName}
-                  packNames={chartData.map((cd) => cd.packName).join(', ')}
+                  packNames={chartData.map((cd) => t(cd.packName, { ns: 'common/packs' })).join(', ')}
                   percentage={highestProbabilityPack.percentage}
                   className="col-span-8 snap-start flex-shrink-0 w-full"
                   backgroundColor={highestProbabilityPack.fill}
@@ -90,7 +90,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckb
             <>
               <GradientCard
                 title={highestProbabilityPack.packName}
-                packNames={chartData.map((cd) => cd.packName).join(', ')}
+                packNames={chartData.map((cd) => t(cd.packName, { ns: 'common/packs' })).join(', ')}
                 percentage={highestProbabilityPack.percentage}
                 className="col-span-8 lg:col-span-4"
                 backgroundColor={highestProbabilityPack.fill}


### PR DESCRIPTION
Change 1: Add Pack filter to address https://github.com/marcelpanse/tcg-pocket-collection-tracker/issues/353.
![image](https://github.com/user-attachments/assets/2d8e4326-d735-4cec-854d-5f7fac9bac18)
The list of packs changes with the choice of expansion, and resets to "All packs" when a new expansion is chosen. Utilizes translations set in common/packs. When a pack other than "All packs" is chosen, it shows cards in that pack + everypack cards for that expansion. For expansions with only one pack, it just has the "All packs" option. First time working in frontend, so I copied the existing expansions code mostly. I would be willing to look into making it a dropdown if that's preferred.

Change 2: Uses pack translation names on the overview tab. 
![image](https://github.com/user-attachments/assets/499d9f25-bcf1-48b6-a08f-4c7ba179f55d)
Mild edits to some translations to make more grammatical sense. Still no "and" between pack names but oh well 🤷. I used Google translate for any non-English language changes.