### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through a stack trace

### DIFF
--- a/supabase/functions/stats-tracker/index.ts
+++ b/supabase/functions/stats-tracker/index.ts
@@ -51,7 +51,7 @@ Deno.serve(async (_req) => {
       connection.release()
     }
   } catch (err) {
-    console.error(err)
-    return new Response(String(err), { status: 500 })
+    console.error('An error occurred:', err)
+    return new Response('An internal server error occurred', { status: 500 })
   }
 })


### PR DESCRIPTION
Potential fix for [https://github.com/marcelpanse/tcg-pocket-collection-tracker/security/code-scanning/6](https://github.com/marcelpanse/tcg-pocket-collection-tracker/security/code-scanning/6)

To fix the issue, we should avoid exposing the raw `err` object to the user. Instead, we can log the detailed error information on the server for debugging purposes and return a generic error message to the user. This ensures that sensitive information, such as stack traces, is not leaked while still allowing developers to diagnose issues.

The fix involves:
1. Logging the error details (e.g., stack trace) to the server console using `console.error`.
2. Returning a generic error message (e.g., "An internal server error occurred") to the user in the HTTP response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
