### PR TITLE
Fix names with ex & shining revelry alignment

### DIFF
--- a/frontend/assets/cards/A3.json
+++ b/frontend/assets/cards/A3.json
@@ -4355,7 +4355,7 @@
     "retreat": "2",
     "rarity": "◊",
     "fullart": "No",
-    "ex": "yes",
+    "ex": "no",
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5391,7 +5391,7 @@
     "retreat": "N/A",
     "rarity": "◊◊",
     "fullart": "No",
-    "ex": "yes",
+    "ex": "no",
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [

--- a/frontend/src/pages/overview/components/GradientCard.tsx
+++ b/frontend/src/pages/overview/components/GradientCard.tsx
@@ -17,7 +17,7 @@ export function GradientCard({ title, packNames, percentage, className, backgrou
       className={`${className} tex flex flex-col items-center justify-center rounded-4xl p-4 sm:p-8 transition-all duration-200`}
       style={{ backgroundColor }}
     >
-      <header className="font-semibold text-2xl sm:text-6xl text-slate-900">{t(title, { ns: 'common/packs' })}</header>
+      <header className="font-semibold text-center text-2xl sm:text-6xl text-slate-900">{t(title, { ns: 'common/packs' })}</header>
       <p className="mt-2 text-center text-md sm:text-xl text-slate-900">
         {t('text', {
           packNames: packNames,


### PR DESCRIPTION
Addresses https://github.com/marcelpanse/tcg-pocket-collection-tracker/issues/372
![image](https://github.com/user-attachments/assets/ca360da0-e61c-4976-ad92-28e04f457824)
![image](https://github.com/user-attachments/assets/32a67cc9-945f-4560-9e7a-ac02a35cba40)

Also fixes alignment for shining revelry words in overview:
Before:
![image](https://github.com/user-attachments/assets/7f9e48a7-3934-4d18-96b0-f17c093a6368)
After: 
![image](https://github.com/user-attachments/assets/d87900d2-ae73-4056-9f23-2fcdaa8b29e8)
