### PR TITLE
fix: adjust header styling for better layout and alignment

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -35,7 +35,7 @@ export function Header() {
 
   return (
     <>
-      <header id="header" className="flex h-14 md:h-20 w-full shrink-0 flex-wrap items-center px-4 md:px-6">
+      <header id="header" className="flex max-w-7xl mx-auto h-14 md:h-20 shrink-0 flex-wrap items-center px-4 md:px-6">
         <div className="shrink font-bold pr-4 hidden md:block">TCG Pocket Collection Tracker</div>
         <NavigationMenu className="max-w-full justify-start">
           <NavigationMenuList>


### PR DESCRIPTION
I updated the header styles to improve the layout on larger monitors.
![image](https://github.com/user-attachments/assets/b3b0b6bf-ba46-4640-b048-20abcff6f06f)

![image](https://github.com/user-attachments/assets/061ee2c6-840d-4a65-a8e4-9a1813fe362f)

