### PR TITLE
feat(ExpansionOverview): add set icon to expansion title

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -35,7 +35,7 @@ export function Header() {
 
   return (
     <>
-      <header id="header" className="flex h-14 md:h-20 w-full shrink-0 flex-wrap items-center px-4 md:px-6">
+      <header id="header" className="flex max-w-7xl mx-auto h-14 md:h-20 shrink-0 flex-wrap items-center px-4 md:px-6">
         <div className="shrink font-bold pr-4 hidden md:block">TCG Pocket Collection Tracker</div>
         <NavigationMenu className="max-w-full justify-start">
           <NavigationMenuList>

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -43,7 +43,10 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckb
 
   return (
     <>
-      <h2 className="col-span-8 text-2xl pl-8">{t(expansion.name, { ns: 'common/sets' })}</h2>
+      <h2 className="col-span-8 text-2xl pl-8 flex items-center">
+        {t(expansion.name, { ns: 'common/sets' })}
+        <img src={`https://s3.limitlesstcg.com/pocket/sets/${expansion.id}.webp`} alt={`${expansion.id}`} className="ml-2 inline" />
+      </h2>
       {isMobile ? (
         <div className="col-span-full">
           <Carousel padding="2rem">


### PR DESCRIPTION
Include the set icon next to the expansion title in the ExpansionOverview component to enhance visual identification and user experience
![image](https://github.com/user-attachments/assets/ec35b952-f016-4f68-bcef-28a4e4b2ad66)
![image](https://github.com/user-attachments/assets/7f48afad-2fa8-4ef7-b11e-5892f6ab74e2)

