### PR TITLE
feat(filters): enhance UI by adding set images to expansion tabs and table headers

### DIFF
--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -139,9 +139,16 @@ export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
               className="absolute top-0 left-0 w-full"
             >
               {row.type === 'header' ? (
-                <h2 className="mx-auto mt-10 text-center w-full max-w-[900px] scroll-m-20 border-b-2 border-slate-600 pb-2 font-semibold text-md sm:text-lg md:text-2xl tracking-tight transition-colors first:mt-0">
-                  {t((row.data as { type: string; row: Row<CardType> }).row.getValue('set_details') as string)}
-                </h2>
+                <div className="flex items-center justify-center gap-2 m-10 mx-auto max-w-[900px] scroll-m-20 border-b-2 border-slate-600 pb-2  tracking-tight transition-colors first:mt-0">
+                  <img
+                    src={`/images/sets/${(row.data as { type: string; row: Row<CardType> }).row.original.expansion}.webp`}
+                    alt={(row.data as { type: string; row: Row<CardType> }).row.getValue('set_details') as string}
+                    className="h-6 sm:h-8"
+                  />
+                  <h2 className="text-center font-semibold text-md sm:text-lg md:text-2xl ">
+                    {t((row.data as { type: string; row: Row<CardType> }).row.getValue('set_details') as string)}
+                  </h2>
+                </div>
               ) : (
                 <div className="flex justify-center gap-x-3">
                   {(row.data as { type: string; row: Row<CardType> }[]).map(({ row: subRow }) => (

--- a/frontend/src/components/FancyCard.tsx
+++ b/frontend/src/components/FancyCard.tsx
@@ -83,6 +83,7 @@ function FancyCard({ selected, setIsSelected, card, size = 'default' }: Props) {
       {baseName && (
         <img
           draggable={false}
+          loading="lazy"
           onMouseDown={() => setIsSelected?.(!selected)}
           ref={cardRef}
           className="card-test"

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -24,7 +24,10 @@ const ExpansionsFilter: FC<Props> = ({ expansionFilter, setExpansionFilter, setP
         <TabsTrigger value="all">{t('all')}</TabsTrigger>
         {expansions.map((expansion) => (
           <TabsTrigger key={`tab_trigger_${expansion.id}`} value={expansion.id}>
-            {t(expansion.name)}
+            <div className="flex flex-col items-center gap-1">
+              <img src={`/images/sets/${expansion.id}.webp`} alt={`${expansion.id}`} className="h-5" />
+              <span>{t(expansion.name)}</span>
+            </div>
           </TabsTrigger>
         ))}
       </TabsList>

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -25,7 +25,6 @@ const ExpansionsFilter: FC<Props> = ({ expansionFilter, setExpansionFilter, setP
         {expansions.map((expansion) => (
           <TabsTrigger key={`tab_trigger_${expansion.id}`} value={expansion.id}>
             <div className="flex flex-col items-center gap-1">
-              <img src={`/images/sets/${expansion.id}.webp`} alt={`${expansion.id}`} className="h-5" />
               <span>{t(expansion.name)}</span>
             </div>
           </TabsTrigger>


### PR DESCRIPTION


Improve the visual representation of expansions by displaying set images alongside their names in the expansion tabs and table headers. This change enhances user experience by making it easier to identify sets at a glance.