### PR TITLE
UI tweaks (5, 6)

### DIFF
--- a/frontend/public/locales/en-US/complete-progress.json
+++ b/frontend/public/locales/en-US/complete-progress.json
@@ -1,3 +1,3 @@
 {
-  "youHave": "You have {{nCardsOwned}} out of {{nTotalCards}} cards"
+  "youHave": "{{nCardsOwned}} / {{nTotalCards}} cards"
 }

--- a/frontend/src/components/RadialChart.tsx
+++ b/frontend/src/components/RadialChart.tsx
@@ -32,7 +32,7 @@ export const RadialChart: React.FC<RadialChartProps> = ({
         cy={size / 2}
         r={radius}
         fill="none"
-        stroke="#e5e7eb" // tailwind slate-200
+        stroke="#262626" // tailwind slate-200
         strokeWidth={strokeWidth}
       />
       <circle

--- a/frontend/src/components/ui/progress-custom.tsx
+++ b/frontend/src/components/ui/progress-custom.tsx
@@ -10,7 +10,7 @@ interface ProgressProps extends React.ComponentPropsWithoutRef<typeof ProgressPr
 
 const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, ProgressProps>(
   ({ className, value, barColor = '#2563eb', ...props }, ref) => (
-    <ProgressPrimitive.Root ref={ref} className={cn('relative h-2 w-full overflow-hidden rounded-full bg-white', className)} {...props}>
+    <ProgressPrimitive.Root ref={ref} className={cn('relative h-2 w-full overflow-hidden rounded-full bg-neutral-800', className)} {...props}>
       <ProgressPrimitive.Indicator
         className="h-full flex-1 transition-all"
         style={{

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -111,7 +111,7 @@ function Overview() {
             <RadialChart
               value={totalUniqueCards === 0 ? 0 : CardsDB.getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter, deckbuildingMode }) / totalUniqueCards}
               label={`${CardsDB.getNrOfCardsOwned({ ownedCards, rarityFilter, numberFilter, deckbuildingMode })} / ${totalUniqueCards}`}
-              color="#38bdf8"
+              color="#2463eb"
               size={120}
               strokeWidth={12}
             />


### PR DESCRIPTION
Commit #1 
before: 
<img width="300" alt="Screenshot 2025-05-09 at 12 44 52 PM" src="https://github.com/user-attachments/assets/54af822b-92b7-4778-9164-f70cff2e827b" />

after:
<img width="295" alt="Screenshot 2025-05-09 at 12 45 04 PM" src="https://github.com/user-attachments/assets/7f0aa820-2d54-4628-86b6-024ea0be9cb4" />

---

Commit #2
before:
<img width="308" alt="Screenshot 2025-05-09 at 1 38 24 PM" src="https://github.com/user-attachments/assets/1ef8360d-9a02-43dd-8dcb-6df7bdeec2ba" />


after:
<img width="310" alt="Screenshot 2025-05-09 at 1 38 30 PM" src="https://github.com/user-attachments/assets/8d65b0eb-88b3-4b73-97b7-74004fb1b197" />

---

Commit #3

before (see commit #1)

after:
<img width="309" alt="Screenshot 2025-05-09 at 1 39 38 PM" src="https://github.com/user-attachments/assets/7118e504-a858-4d21-b190-3f693e3e5360" />

