### PR TITLE
docs(locales): update and add Spanish translations for various components

### DIFF
--- a/frontend/public/locales/en-US/gradient-card.json
+++ b/frontend/public/locales/en-US/gradient-card.json
@@ -1,3 +1,4 @@
 {
+  "open": "You should open a",
   "text": "there's a <strong>{{chancePercentage}}%</strong> chance of a new card!"
 }

--- a/frontend/public/locales/en-US/header.json
+++ b/frontend/public/locales/en-US/header.json
@@ -10,7 +10,7 @@
     "fr-FR": "French",
     "it-IT": "Italian"
   },
-  "community": "Community",
+  "community": "Community ↗",
   "login": "Login",
   "signUp": "Login / Sign up",
   "myAccount": "My account",

--- a/frontend/public/locales/es-ES/common/packs.json
+++ b/frontend/public/locales/es-ES/common/packs.json
@@ -6,6 +6,9 @@
   "palkiapack": "Palkia",
   "mewpack": "Mew",
   "arceuspack": "Arceus",
+  "shiningrevelrypack": "Festival Brillante",
+  "lunalapack": "Lunala",
+  "solgaleopack": "Solgaleo",
   "everypack": "Todos los sobres",
 
   "all": "Todos los sobres"

--- a/frontend/public/locales/es-ES/common/sets.json
+++ b/frontend/public/locales/es-ES/common/sets.json
@@ -9,6 +9,8 @@
   "mythicalisland(a1a)": "La Isla Singular (A1a)",
   "space-timesmackdown(a2)": "Pugna Espaciotemporal (A2)",
   "triumphantlight(a2a)": "Luz Triunfal (A2a)",
+  "shiningrevelry(a2b)": "Festival Brillante (A2b)",
+  "celestialguardians(a3)": "Guardianes Celestiales (A3)",
   "promo-a(p-a)": "Promo-A (P-A)",
 
   "all": "Todas"

--- a/frontend/public/locales/es-ES/edit-profile.json
+++ b/frontend/public/locales/es-ES/edit-profile.json
@@ -10,5 +10,9 @@
   "usernameDescription": "Que coincida con tu nombre de Pokémon Pocket.",
   "friendID": "Código de amigo",
   "friendIDDescription": "Que coincida con tu código de amigo de Pokémon Pocket (sin guiones)",
+  "isPublicDescription": "Si desea compartir su colección o página de intercambio, puede hacerlo aquí.",
+  "isPublicButton": "Compartir colección",
+  "isPublicTradeButton": "Compartir página de intercambio",
+  "isPublicToggle": "Es público",
   "save": "Guardar"
 }

--- a/frontend/public/locales/es-ES/gradient-card.json
+++ b/frontend/public/locales/es-ES/gradient-card.json
@@ -1,3 +1,3 @@
 {
-  "text": "es el mejor sobre para abrir y obtener una nueva carta. Tienes un {{chancePercentage}}% de probabilidades de conseguir una nueva carta."
+  "text": "¡hay un <strong>{{PorcentajeDePosibilidades}}%</strong> de probabilidades de que aparezca una nueva carta!"
 }

--- a/frontend/public/locales/es-ES/gradient-card.json
+++ b/frontend/public/locales/es-ES/gradient-card.json
@@ -1,3 +1,4 @@
 {
-  "text": "¡hay un <strong>{{PorcentajeDePosibilidades}}%</strong> de probabilidades de que aparezca una nueva carta!"
+  "open": "Deberias abrir",
+  "text": "¡Hay un <strong>{{chancePercentage}}%</strong> de probabilidades de que aparezca una nueva carta!"
 }

--- a/frontend/public/locales/es-ES/hamburguer-menu.json
+++ b/frontend/public/locales/es-ES/hamburguer-menu.json
@@ -2,9 +2,9 @@
   "overview": "Inicio",
   "collection": "Colección",
   "trade": "Intercambios",
-  "community": "Comunidad",
+  "community": "Comunidad ↗",
   "toggle": "Menú desplegable",
   "editProfile": "Editar perfil",
   "login": "Iniciar sesión",
-  "logOut": "Cerrrar sesión"
+  "logOut": "Cerrar sesión"
 }

--- a/frontend/public/locales/es-ES/header.json
+++ b/frontend/public/locales/es-ES/header.json
@@ -10,7 +10,7 @@
     "fr-FR": "French",
     "it-IT": "Italiano"
   },
-  "community": "Comunidad",
+  "community": "Comunidad ↗",
   "login": "Iniciar sesión",
   "signup": "Iniciar sesión / Crear cuenta",
   "myAccount": "Mi cuenta",
@@ -19,5 +19,11 @@
   "install": "🌟 ¿Te encanta usar TCG Pocket Tracker? ¡Agrégalo a tu pantalla de inicio para acceder más rápido!",
   "accept": "🚀 Sí, ¡Instalar Ahora!",
   "cancel": "😊 No, Gracias",
-  "aboutUs": "Sobre nosotros"
+  "export": "Exportar",
+  "import": "Importar",
+  "aboutUs": "Sobre nosotros",
+  "aboutUsDialog": {
+    "title": "Sobre nosotros",
+    "content": "TCG Pocket Tracker es un proyecto gratuito y de código abierto que tiene como objetivo ayudarte a rastrear tu colección de Pokémon Pocket. Proporciona una interfaz fácil de usar para gestionar tu colección. El proyecto es de código abierto y da la bienvenida a contribuciones de la comunidad. Si tienes alguna pregunta o comentario, no dudes en contactarnos en <a href=\"https://community.tcgpocketcollectiontracker.com\" style=\"text-decoration: underline;\">nuestro foro comunitario</a> o <a href=\"https://github.com/marcelpanse/tcg-pocket-collection-tracker\" style=\"text-decoration: underline;\">GitHub</a>."
+  }
 }

--- a/frontend/public/locales/es-ES/pages/collection.json
+++ b/frontend/public/locales/es-ES/pages/collection.json
@@ -1,0 +1,4 @@
+{
+  "publicCollectionTitle": "Estás viendo una colección pública",
+  "publicCollectionDescription": "Estás viendo una colección pública. Haz clic en cualquiera de los elementos de navegación para volver a tu propia colección."
+}

--- a/frontend/public/locales/es-ES/pages/overview.json
+++ b/frontend/public/locales/es-ES/pages/overview.json
@@ -1,4 +1,8 @@
 {
+  "stats": {
+    "title": "Gracias por ser parte de nuestra comunidad",
+    "description": "En la actualidad, nuestra comunidad de {{usersCount}} usuarios ha rastreado colectivamente {{collectionCount}} cartas en total!"
+  },
   "dontHaveCards": {
     "title": "¡Todavía no tienes ninguna tarjeta!",
     "description": "Ve a la página de colección para añadir tu primera tarjeta o inicia sesión para crearte una cuenta."

--- a/frontend/public/locales/es-ES/trade-matches.json
+++ b/frontend/public/locales/es-ES/trade-matches.json
@@ -1,0 +1,10 @@
+{
+  "title": "Posibles intercambios",
+  "friendHas": "Cartas que necesitas (y tu amigo tiene)",
+  "youHave": "Cartas que tu amigo necesita (y tú tienes)",
+  "noPossibleTrades": "No se encontraron intercambios posibles.",
+  "noPossibleTradesDescription": "No hay intercambios entre tú y tu amigo en este momento.",
+  "featureDescription": "Este diálogo te mostrará los posibles intercambios entre tus cartas y las de la ID de amigo seleccionada. Te muestra cartas duplicadas que la otra parte aún no posee.",
+  "ownCollection": "Estás viendo tu propia colección.",
+  "ownCollectionDescription": "Considera compartir esta página con otros para que puedan encontrar posibles intercambios."
+}

--- a/frontend/public/locales/fr-FR/gradient-card.json
+++ b/frontend/public/locales/fr-FR/gradient-card.json
@@ -1,3 +1,4 @@
 {
-  "text": "est le meilleur paquet à ouvrir pour obtenir une nouvelle carte. Vous avez {{chancePercentage}}% de chances d'obtenir une nouvelle carte."
+  "open": "Vous devriez ouvrir",
+  "text": "il y a <strong>{{chancePercentage}}%</strong> de chances d'obtenir une nouvelle carte !"
 }

--- a/frontend/public/locales/fr-FR/header.json
+++ b/frontend/public/locales/fr-FR/header.json
@@ -10,7 +10,7 @@
     "fr-FR": "Français",
     "it-IT": "Italien"
   },
-  "community": "Communauté",
+  "community": "Communauté ↗",
   "login": "Se connecter",
   "signUp": "Se connecter / Créer un compte",
   "myAccount": "Mon compte",

--- a/frontend/public/locales/it-IT/gradient-card.json
+++ b/frontend/public/locales/it-IT/gradient-card.json
@@ -1,3 +1,4 @@
 {
-  "text": "è la migliore busta da aprire per ottenere una nuova carta. Hai una probabilità del {{chancePercentage}}% di ottenere una nuova carta."
+  "open": "Dovresti aprire",
+  "text": "c'è una probabilità del <strong>{{chancePercentage}}%</strong> di trovare una nuova carta!"
 }

--- a/frontend/public/locales/it-IT/header.json
+++ b/frontend/public/locales/it-IT/header.json
@@ -10,7 +10,7 @@
     "fr-FR": "Francese",
     "it-IT": "Italiano"
   },
-  "community": "Community",
+  "community": "Comunità ↗",
   "login": "Login",
   "signUp": "Login / Registrazione",
   "myAccount": "Il mio account",

--- a/frontend/public/locales/pt-BR/gradient-card.json
+++ b/frontend/public/locales/pt-BR/gradient-card.json
@@ -1,3 +1,4 @@
 {
-  "text": "é o melhor pacote para abrir e obter uma nova carta. Você tem {{chancePercentage}}% de chance de obter uma nova carta."
+  "open": "Você deveria abrir",
+  "text": "há <strong>{{chancePercentage}}%</strong> de chance de uma nova carta!"
 }

--- a/frontend/public/locales/pt-BR/header.json
+++ b/frontend/public/locales/pt-BR/header.json
@@ -10,7 +10,7 @@
     "fr-FR": "French",
     "it-IT": "Italiano"
   },
-  "community": "Comunidade",
+  "community": "Comunidade ↗",
   "login": "Entrar",
   "signUp": "Entrar / Cadastrar-se",
   "myAccount": "Minha conta",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -69,7 +69,7 @@ export function Header() {
             <PokemonCardDetector />
             <NavigationMenuLink asChild className="hidden sm:block">
               <Link to="https://community.tcgpocketcollectiontracker.com" className="hidden sm:block">
-                <Button variant="ghost">{t('Community ↗')}</Button>
+                <Button variant="ghost">{t('community')}</Button>
               </Link>
             </NavigationMenuLink>
           </NavigationMenuList>

--- a/frontend/src/pages/overview/components/GradientCard.tsx
+++ b/frontend/src/pages/overview/components/GradientCard.tsx
@@ -16,7 +16,9 @@ export function GradientCard({ title, percentage, className, backgroundColor }: 
       className={`${className} tex flex flex-col items-center justify-center rounded-4xl p-4 sm:p-8 transition-all duration-200`}
       style={{ backgroundColor }}
     >
-      <p className="mb-1 text-center text-md sm:text-xl text-slate-900">You should open a</p>
+      <p className="mb-1 text-center text-md sm:text-xl text-slate-900">
+        <Trans i18nKey="open" ns="gradient-card" />
+      </p>
       <header className="font-semibold text-center text-2xl sm:text-6xl text-slate-900">{t(title, { ns: 'common/packs' })}</header>
       <p className="mt-2 text-center text-md sm:text-xl text-slate-900">
         <Trans


### PR DESCRIPTION
Add new translations for public collection, packs, gradient card, hamburger menu, sets, overview, edit profile, trade matches, and header components. Correct typos and improve consistency in existing translations to enhance user experience for Spanish-speaking users.