### PR TITLE
UI-tweaks c7-10

### DIFF
--- a/frontend/src/components/BarChart.tsx
+++ b/frontend/src/components/BarChart.tsx
@@ -25,6 +25,19 @@ const chartConfig = {
     },
 } satisfies ChartConfig */
 
+const packNameMap: Record<string, string> = {
+  pikachupack: 'Pikachu',
+  charizardpack: 'Charizard',
+  mewtwopack: 'Mewtwo',
+  dialgapack: 'Dialga',
+  palkiapack: 'Palkia',
+  mewpack: 'Mew',
+  arceuspack: 'Arceus',
+  shiningrevelrypack: 'Shining Revelry',
+  lunalapack: 'Lunala',
+  solgaleopack: 'Solgaleo',
+}
+
 interface PercentageBarChartProps {
   title: string
   data: { packName: string; percentage: number; fill: string }[]
@@ -32,7 +45,7 @@ interface PercentageBarChartProps {
   footer?: string
 }
 export const BarChartComponent: FC<PercentageBarChartProps> = ({ title, data, config = {}, footer }) => (
-  <Card className="rounded-4xl border-2 border-slate-600 border-solid shadow-none">
+  <Card className="rounded-4xl border-2 border-slate-600 border-solid shadow-none dark:bg-neutral-800">
     <CardHeader className="text-balance text-center">
       <CardTitle>{title}</CardTitle>
     </CardHeader>
@@ -40,7 +53,7 @@ export const BarChartComponent: FC<PercentageBarChartProps> = ({ title, data, co
       <ChartContainer config={config}>
         <BarChart accessibilityLayer data={data.map((d) => ({ ...d, percentage: d.percentage * 100 }))}>
           <CartesianGrid vertical={false} />
-          <XAxis dataKey="packName" tickLine={false} tickMargin={10} axisLine={false} />
+          <XAxis dataKey="packName" tickLine={false} tickMargin={10} axisLine={false} tickFormatter={(value) => packNameMap[value] || value} />
           <YAxis type="number" domain={[0, 100]} width={25} />
           <ChartTooltip cursor={false} content={<CustomTooltipContent payload={[]} active={false} />} />
           <Bar dataKey="percentage" strokeWidth={2} radius={8} />

--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -150,7 +150,7 @@ export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
                   </h2>
                 </div>
               ) : (
-                <div className="flex justify-start gap-x-3">
+                <div className="flex justify-center gap-x-3">
                   {(row.data as { type: string; row: Row<CardType> }[]).map(({ row: subRow }) => (
                     <Card key={subRow.original.card_id} card={subRow.original} />
                   ))}

--- a/frontend/src/components/filters/SearchInput.tsx
+++ b/frontend/src/components/filters/SearchInput.tsx
@@ -12,7 +12,7 @@ const SearchInput: FC<Props> = ({ setSearchValue, fullWidth }) => {
     <Input
       type="search"
       placeholder="Search..."
-      className={`w-full ${!fullWidth ? 'sm:w-32' : ''} border-2 h-[38px]`}
+      className={`w-full ${!fullWidth ? 'sm:w-32' : ''} border-2 h-[38px] bg-neutral-800`}
       style={{ borderColor: '#45556C' }}
       onChange={(e) => {
         if (_searchDebounce) {

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -45,7 +45,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-square justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-black/70 [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex aspect-square justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-neutral-700/70 dark:[&_.recharts-cartesian-axis-tick_text]:fill-neutral-300 [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className,
         )}
         {...props}

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -43,7 +43,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckb
 
   return (
     <>
-      <h2 className="col-span-8 text-2xl pl-8 flex items-center">
+      <h2 className=" mt-6 col-span-8 text-3xl flex items-center">
         <img src={`/images/sets/${expansion.id}.webp`} alt={`${expansion.id}`} className="mr-2 inline" />
         {t(expansion.name, { ns: 'common/sets' })}
       </h2>

--- a/frontend/src/pages/overview/components/ExpansionOverview.tsx
+++ b/frontend/src/pages/overview/components/ExpansionOverview.tsx
@@ -43,7 +43,7 @@ export function ExpansionOverview({ expansion, rarityFilter, numberFilter, deckb
 
   return (
     <>
-      <h2 className=" mt-6 col-span-8 text-3xl flex items-center">
+      <h2 className="mt-6 col-span-8 text-3xl flex items-center">
         <img src={`/images/sets/${expansion.id}.webp`} alt={`${expansion.id}`} className="mr-2 inline" />
         {t(expansion.name, { ns: 'common/sets' })}
       </h2>


### PR DESCRIPTION

Commit #1: Centering Card Table
- change `justify-start` to `justify-center`

before:
![Screenshot 2025-05-10 at 10 27 43 AM](https://github.com/user-attachments/assets/b720ecfa-1d1d-4e05-b188-2484b4eb2849)

after:
![Screenshot 2025-05-10 at 10 27 31 AM](https://github.com/user-attachments/assets/ef1f962c-af22-449b-9338-98421b84c9c5)

---

Commit #2: Search Bar
- change search bar color to match other bg (`neutral-800`)

before:
![Screenshot 2025-05-10 at 1 37 07 PM](https://github.com/user-attachments/assets/1461a455-328c-4c51-9c30-2e3ec0fbcca4)

after:
![Screenshot 2025-05-10 at 1 37 15 PM](https://github.com/user-attachments/assets/6d64c1be-2f3e-4d04-8584-391579c4ce3c)

---

Commit #3: Expansion card updates
- give things some room to breathe + easier to digest

before:
![Screenshot 2025-05-10 at 1 42 33 PM](https://github.com/user-attachments/assets/1a42a44c-a6bb-4cb1-bfe0-95aadfb419c8)

after:
![Screenshot 2025-05-10 at 1 42 42 PM](https://github.com/user-attachments/assets/cf019d0f-d50c-494b-9da1-f2eb5b1b8b71)

---

Commit #4: Chart improvements
- change color to be `neutral-800` 
- let tick marks to be seen on dark mode
- fix names `pikachupack` -> `Pikachu` for readability

before:
![Screenshot 2025-05-10 at 2 14 19 PM](https://github.com/user-attachments/assets/9075131d-87fb-4949-a657-7a1747aefc18)

after:
![Screenshot 2025-05-10 at 2 14 10 PM](https://github.com/user-attachments/assets/a7f0677a-5db3-4b0e-bf4e-7f422504642d)