### PR TITLE
Add immersive mew mission

### DIFF
--- a/frontend/assets/themed-collections/A1-missions.json
+++ b/frontend/assets/themed-collections/A1-missions.json
@@ -490,11 +490,6 @@
     "reward": "Mewtwo (profile icon)"
   },
   {
-    "name": "Complete the Kanto Pokédex!",
-    "requiredCards": [],
-    "reward": "Mew<br />(#283) ×1"
-  },
-  {
     "name": "Genetic Apex Museum 1 (Mewtwo)",
     "requiredCards": [
       {

--- a/frontend/assets/themed-collections/A1-missions.json
+++ b/frontend/assets/themed-collections/A1-missions.json
@@ -685,5 +685,611 @@
       }
     ],
     "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×48<br />Shop Ticket ×20"
+  },
+  {
+    "name": "Complete the Kanto Pokedex",
+    "requiredCards": [
+      {
+        "options": ["A1-1", "A1-227"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-2"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-3", "A1-4", "A1-251"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-5"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-6"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-7"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-8"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-9"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-10"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-11"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-12", "A1-228"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-13"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-14"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-15"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-16"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-17"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-18"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-19"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-20"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-21"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-22", "A1-23", "A1-252"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-24"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-25"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-26", "A1-229"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-33", "A1-230"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-34"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-35", "A1-36", "A1-253", "A1-280", "A1-284"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-37"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-38"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-39"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-40", "A1-41", "A1-254"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-42"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-43", "A1-231"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-44"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-45"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-46", "A1-47", "A1-255", "A1-274"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-53", "A1-232"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-54"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-55", "A1-56", "A1-256"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-57"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-58"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-59"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-60"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-61"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-62"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-63"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-64"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-65"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-66"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-67"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-68"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-69"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-70"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-71"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-72"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-73"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-74"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-75", "A1-76", "A1-257"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-77"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-78", "A1-233"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-79", "A1-234"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-80"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-81"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-82"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-83", "A1-84", "A1-258", "A1-275"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-94", "A1-96", "A1-259", "A1-281", "A1-285"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-95"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-97"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-98"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-99"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-100", "A1-235"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-101"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-102"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-103", "A1-104", "A1-260", "A1-276"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-113"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-114"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-115"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-116"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-117", "A1-236"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-118", "A1-237"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-119"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-120"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-121"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-122", "A1-123", "A1-261", "A1-277"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-124"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-125"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-126"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-127"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-128", "A1-129", "A1-262", "A1-282", "A1-286"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-137"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-138"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-139", "A1-238"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-140"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-141"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-142"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-143"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-144"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-145", "A1-146", "A1-263", "A1-278"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-147"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-148"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-149"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-150"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-151", "A1-239"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-152", "A1-153", "A1-264"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-154"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-155"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-156"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-157"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-158"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-159"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-164"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-165"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-166"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-167"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-168", "A1-240"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-169"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-170"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-171", "A1-241"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-172"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-173", "A1-242"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-174"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-175"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-176"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-177", "A1-243"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-183"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-184"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-185", "A1-244"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-186"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-187"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-188", "A1-245"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-189"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-190"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-191"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-192"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-193"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-194", "A1-195", "A1-265", "A1-279"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-196", "A1-246"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-197"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-198"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-199"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-200"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-201"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-202"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-203"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-204"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-205", "A1-247"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-206", "A1-207", "A1-208", "A1-248"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-209", "A1-249"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-210"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-211", "A1-250"],
+        "amount": 1
+      }
+    ],
+    "reward": "Immersive Mew"
   }
 ]

--- a/frontend/assets/themed-collections/A1a-missions.json
+++ b/frontend/assets/themed-collections/A1a-missions.json
@@ -248,11 +248,6 @@
     "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mythical Island) ×2<br />Shop Ticket ×2"
   },
   {
-    "name": "Use pack stamina to open 60 Mythical Island booster packs",
-    "requiredCards": [],
-    "reward": "Mythical Island: Mew (playmat)<br />Mythical Island: Mew (card sleeve)<br />Mew (Pokémon coin)<br />Mythical Island: Mew (cover)"
-  },
-  {
     "name": "Collect 3 Mew cards",
     "requiredCards": [
       {

--- a/frontend/assets/themed-collections/A2a-missions.json
+++ b/frontend/assets/themed-collections/A2a-missions.json
@@ -1,10 +1,5 @@
 [
   {
-    "name": "Use pack stamina to open 4 Triumphant Light booster packs",
-    "requiredCards": [],
-    "reward": "Arceus<br />(#070) ×1"
-  },
-  {
     "name": "Pokémon with Abilities that \"Link\" with Arceus",
     "requiredCards": [
       {


### PR DESCRIPTION
This mission to get the immersive Mew by collecting the other 150 Kanto pokemon wasn't present on the site I scraped from. Luckily @PlayInKetchup wrote it up originally, so I recovered it and just tweaked to fit the format.

There are also some non-card missions which need removal.