### PR TITLE
Small syntax fix + removed redundancy

### DIFF
--- a/frontend/public/locales/it-IT/pages/overview.json
+++ b/frontend/public/locales/it-IT/pages/overview.json
@@ -1,7 +1,7 @@
 {
   "stats": {
     "title": "Grazie per essere parte della nostra community",
-    "description": "Al momento, la nostra comunità di {{usersCount}} utenti ha registrato collettivamente {collectionCount}} carte in totale!"
+    "description": "Al momento, la nostra comunità di {{usersCount}} utenti ha registrato ben {{collectionCount}} carte in totale!"
   },
   "dontHaveCards": {
     "title": "Non hai ancora registrato alcuna carta!",


### PR DESCRIPTION
Sorry for the additional pull request, but I didn't notice I missed a { in my earlier Pull 
- Fixed a typo in graph edit
- Replaced “collettivamente” with “ben” to avoid redundancy with “in totale” 