### PR TITLE
Improve trade match mouse selection

### DIFF
--- a/frontend/src/pages/collection/TradeMatches.tsx
+++ b/frontend/src/pages/collection/TradeMatches.tsx
@@ -260,12 +260,12 @@ const TradeMatches: FC<Props> = ({ ownedCards, friendCards, ownCollection, frien
                   <ul className="space-y-1">
                     {friendExtraCards[rarity].map((card) => (
                       <li key={card.card_id} className="flex justify-between">
-                        <div className="flex items-center">
-                          <div className="min-w-14 me-4">{card.card_id}</div>
-                          <div>{card.name}</div>
-                        </div>
+                        <span className="flex items-center">
+                          <span className="min-w-14 me-4">{card.card_id} </span>
+                          <span>{card.name}</span>
+                        </span>
                         <span title="Amount you own" className="text-gray-500">
-                          ×{ownedCards.find((c) => c.card_id === card.card_id)?.amount_owned || 0}
+                          <span style={{ userSelect: 'none' }}>×{ownedCards.find((c) => c.card_id === card.card_id)?.amount_owned || 0}</span>
                         </span>
                       </li>
                     ))}
@@ -278,12 +278,12 @@ const TradeMatches: FC<Props> = ({ ownedCards, friendCards, ownCollection, frien
                   <ul className="space-y-1">
                     {userExtraCards[rarity].map((card) => (
                       <li key={card.card_id} className="flex justify-between">
-                        <div className="flex items-center">
-                          <div className="min-w-14 me-4">{card.card_id}</div>
-                          <div>{card.name}</div>
-                        </div>
+                        <span className="flex items-center">
+                          <span className="min-w-14 me-4">{card.card_id}</span>
+                          <span>{card.name}</span>
+                        </span>
                         <span title="Amount your friend owns" className="text-gray-500">
-                          ×{card.amount_owned}
+                          <span style={{ userSelect: 'none' }}>×{card.amount_owned}</span>
                         </span>
                       </li>
                     ))}


### PR DESCRIPTION
This improves how trade matches are selected and copied. The `style={{ userSelect: 'none' }}` is added to a nested span because adding it to the existing one removes the new lines between rows.

## Before

![image](https://github.com/user-attachments/assets/1e255bc3-6587-456a-81c4-973b751eee23)
Coping this selection results in the clipboard content of:
```
A1-124
Drowzee
×0
A1-154
Hitmonlee
×0
A1-217
Dome Fossil
×0
A1-72
Goldeen
×0
```

## After

![image](https://github.com/user-attachments/assets/59b6d245-a89c-4456-b110-ddfb176c5b0f)
Coping this selection results in the clipboard content of:
```
A1-124 Drowzee
A1-154 Hitmonlee
A1-217 Dome Fossil
A1-72 Goldeen
```