### PR TITLE
add a3a expansionid to missions

### DIFF
--- a/frontend/assets/themed-collections/A3a-missions.json
+++ b/frontend/assets/themed-collections/A3a-missions.json
@@ -1,5 +1,6 @@
 [
   {
+    "expansionId": "A3a",
     "name": "Ultra Beast Collection",
     "requiredCards": [
       {
@@ -50,6 +51,7 @@
     "reward": "Emblem Ticket (Extradimensional Crisis) ×25"
   },
   {
+    "expansionId": "A3a",
     "name": "Quick as Lightning",
     "requiredCards": [
       {
@@ -68,6 +70,7 @@
     "reward": "Emblem Ticket (Extradimensional Crisis) ×11"
   },
   {
+    "expansionId": "A3a",
     "name": "Lusamine, President of the Aether Foundation",
     "requiredCards": [
       {
@@ -86,6 +89,7 @@
     "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
   },
   {
+    "expansionId": "A3a",
     "name": "Type: Null's Bonds",
     "requiredCards": [
       {
@@ -104,6 +108,7 @@
     "reward": "Emblem Ticket (Extradimensional Crisis) ×3"
   },
   {
+    "expansionId": "A3a",
     "name": "Meditation Masters",
     "requiredCards": [
       {
@@ -122,6 +127,7 @@
     "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
   },
   {
+    "expansionId": "A3a",
     "name": "Pokémon that Get Nutrition from Minerals",
     "requiredCards": [
       {
@@ -148,6 +154,7 @@
     "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×2"
   },
   {
+    "expansionId": "A3a",
     "name": "A Dangerous Forest with No Way Out",
     "requiredCards": [
       {
@@ -170,6 +177,7 @@
     "reward": "Emblem Ticket (Extradimensional Crisis) ×3"
   },
   {
+    "expansionId": "A3a",
     "name": "Pokémon with Black around their Eyes",
     "requiredCards": [
       {
@@ -196,6 +204,7 @@
     "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×2"
   },
   {
+    "expansionId": "A3a",
     "name": "Well-Coordinated Team Play",
     "requiredCards": [
       {
@@ -206,6 +215,7 @@
     "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
   },
   {
+    "expansionId": "A3a",
     "name": "Fur that's Pleasant to Touch",
     "requiredCards": [
       {
@@ -220,6 +230,7 @@
     "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
   },
   {
+    "expansionId": "A3a",
     "name": "Collect 5 Nihilego cards",
     "requiredCards": [
       {
@@ -230,6 +241,7 @@
     "reward": "Nihilego (profile icon)"
   },
   {
+    "expansionId": "A3a",
     "name": "Extradimensional Crisis Museum 1",
     "requiredCards": [
       {
@@ -260,6 +272,7 @@
     "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
   },
   {
+    "expansionId": "A3a",
     "name": "Extradimensional Crisis Museum 2",
     "requiredCards": [
       {
@@ -282,6 +295,7 @@
     "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
   },
   {
+    "expansionId": "A3a",
     "name": "A Trio with Impressive Whiskers",
     "requiredCards": [
       {

--- a/scripts/scrape-missions.js
+++ b/scripts/scrape-missions.js
@@ -4,7 +4,7 @@ import * as cheerio from 'cheerio'
 import fetch from 'node-fetch'
 
 const BASE_URL = 'https://bulbapedia.bulbagarden.net/wiki'
-const targetDir = 'frontend/assets/themed-collections/'
+const targetDir = '../frontend/assets/themed-collections/'
 const expansions = ['A3a']
 // const expansions = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'A3a']
 const expansionToName = {


### PR DESCRIPTION
Adds expansion id to a3a missions. I had adding a3a missions and adding expansion ids in two diff changes and forgot to account for that.