### PR TITLE
Improve scanning hashes

### DIFF
--- a/frontend/src/components/PokemonCardDetectorComponent.tsx
+++ b/frontend/src/components/PokemonCardDetectorComponent.tsx
@@ -24,7 +24,7 @@ interface PokemonCardDetectorProps {
 interface ExtractedCard {
   imageUrl: string
   confidence: number
-  hash?: string
+  hash?: ArrayBuffer
   matchedCard?: {
     id: string
     distance: number
@@ -109,13 +109,14 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
       await hashStorageService.initDB()
       const storedHashCount = await hashStorageService.getHashCount()
 
-      if (storedHashCount !== uniqueCards.length) {
+      const foo = true
+      if (storedHashCount !== uniqueCards.length || foo) {
         console.log('Checking and generating missing card hashes...')
 
-        const batchSize = 80
+        const batchSize = 32
         const totalCards = uniqueCards.length
         const allHashes = []
-        const existingHashes = await hashStorageService.getAllHashes()
+        // const existingHashes = await hashStorageService.getAllHashes()
 
         for (let i = 0; i < totalCards; i += batchSize) {
           const batch = uniqueCards.slice(i, i + batchSize)
@@ -124,10 +125,10 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
           const batchPromises = batch.map(async (card) => {
             try {
               // Check if hash already exists for this card
-              const existingHash = existingHashes.find((h) => h.id === card.card_id)
-              if (existingHash) {
-                return existingHash
-              }
+              // const existingHash = existingHashes.find((h) => h.id === card.card_id)
+              // if (existingHash) {
+              //   return existingHash
+              // }
 
               const resolvedImagePath = getRightPathOfImage(card.image)
               const hash = await hashingService.calculatePerceptualHash(resolvedImagePath)
@@ -139,7 +140,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
           })
 
           const batchResults = await Promise.all(batchPromises)
-          const validResults = batchResults.filter((hash): hash is { id: string; hash: string } => hash !== null)
+          const validResults = batchResults.filter((hash): hash is { id: string; hash: ArrayBuffer } => hash !== null)
           allHashes.push(...validResults)
 
           // Allow UI to update between batches
@@ -402,7 +403,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
                         alt={getCardNameByLang(match.card, i18n.language)}
                         className="w-full h-auto object-contain"
                       />
-                      <div className="text-xs text-center mt-1 bg-black/60 text-white py-0.5 rounded">{(100 - (match.distance / 128) * 100).toFixed(0)}%</div>
+                      <div className="text-xs text-center mt-1 bg-black/60 text-white py-0.5 rounded">{(100 - (match.distance / 192) * 100).toFixed(0)}%</div>
                     </div>
                   ))}
               </div>
@@ -422,7 +423,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
               <div className="w-1/2 relative">
                 <img src={getRightPathOfImage(card.matchedCard.imageUrl)} alt="Best match" className="w-full h-auto object-contain" />
                 <div className="absolute bottom-0 left-0 right-0 bg-green-500/80 text-white text-xs px-1 py-0.5 text-center">
-                  {(100 - (card.matchedCard.distance / 128) * 100).toFixed(0)}% match
+                  {(100 - (card.matchedCard.distance / 192) * 100).toFixed(0)}% match
                 </div>
               </div>
             )}

--- a/frontend/src/components/PokemonCardDetectorComponent.tsx
+++ b/frontend/src/components/PokemonCardDetectorComponent.tsx
@@ -116,7 +116,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
         const batchSize = 32
         const totalCards = uniqueCards.length
         const allHashes = []
-        // const existingHashes = await hashStorageService.getAllHashes()
+        const existingHashes = await hashStorageService.getAllHashes()
 
         for (let i = 0; i < totalCards; i += batchSize) {
           const batch = uniqueCards.slice(i, i + batchSize)
@@ -125,10 +125,10 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
           const batchPromises = batch.map(async (card) => {
             try {
               // Check if hash already exists for this card
-              // const existingHash = existingHashes.find((h) => h.id === card.card_id)
-              // if (existingHash) {
-              //   return existingHash
-              // }
+              const existingHash = existingHashes.find((h) => h.id === card.card_id)
+              if (existingHash) {
+                return existingHash
+              }
 
               const resolvedImagePath = getRightPathOfImage(card.image)
               const hash = await hashingService.calculatePerceptualHash(resolvedImagePath)

--- a/frontend/src/components/PokemonCardDetectorComponent.tsx
+++ b/frontend/src/components/PokemonCardDetectorComponent.tsx
@@ -109,8 +109,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
       await hashStorageService.initDB()
       const storedHashCount = await hashStorageService.getHashCount()
 
-      const foo = true
-      if (storedHashCount !== uniqueCards.length || foo) {
+      if (storedHashCount !== uniqueCards.length) {
         console.log('Checking and generating missing card hashes...')
 
         const batchSize = 80

--- a/frontend/src/services/CardHashStorageService.ts
+++ b/frontend/src/services/CardHashStorageService.ts
@@ -32,7 +32,7 @@ export class CardHashStorageService {
     })
   }
 
-  public async storeHashes(hashes: { id: string; hash: string }[]): Promise<void> {
+  public async storeHashes(hashes: { id: string; hash: ArrayBuffer }[]): Promise<void> {
     if (!this.db) throw new Error('Database not initialized')
 
     const transaction = this.db.transaction(this.STORE_NAME, 'readwrite')
@@ -47,7 +47,7 @@ export class CardHashStorageService {
     })
   }
 
-  public async getAllHashes(): Promise<{ id: string; hash: string }[]> {
+  public async getAllHashes(): Promise<{ id: string; hash: ArrayBuffer }[]> {
     if (!this.db) throw new Error('Database not initialized')
 
     const transaction = this.db.transaction(this.STORE_NAME, 'readonly')

--- a/frontend/src/services/CardHashStorageService.ts
+++ b/frontend/src/services/CardHashStorageService.ts
@@ -2,7 +2,7 @@ export class CardHashStorageService {
   private static instance: CardHashStorageService
   private db: IDBDatabase | null = null
   private readonly DB_NAME = 'PokemonCardHashes'
-  private readonly STORE_NAME = 'cardHashes'
+  private readonly STORE_NAME = 'cardHashes2'
 
   private constructor() {}
 
@@ -15,7 +15,7 @@ export class CardHashStorageService {
 
   public async initDB(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.DB_NAME, 1)
+      const request = indexedDB.open(this.DB_NAME, 2)
 
       request.onerror = () => reject(request.error)
       request.onsuccess = () => {
@@ -25,6 +25,11 @@ export class CardHashStorageService {
 
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result
+        console.log(`Upgrading card hashes IndexedDB from version ${event.oldVersion} to ${db.version}`)
+
+        if (event.oldVersion < 2 && db.objectStoreNames.contains('cardHashes')) {
+          db.deleteObjectStore('cardHashes')
+        }
         if (!db.objectStoreNames.contains(this.STORE_NAME)) {
           db.createObjectStore(this.STORE_NAME, { keyPath: 'id' })
         }


### PR DESCRIPTION
I did some optimizations in the hashing. The time gains were so big, that allowed to increase the hash length by 4 while still being faster. The increased hash length makes the recognition *much* more accurate, and because the memory optimization (they are tightly packed in bit arrays) they should still take about 2 times less space.

The problem for me now is how to trigger recomputation of hashes for the users. I think it would be best to use a different store name and delete the old one (to avoid any complicated checking of hash version), but I couldn't figure out how to do this (I am not very familiar with js).

### Before & After
##### Before 1
![image](https://github.com/user-attachments/assets/f8c895c9-ace4-4b68-8bd8-364050729c4d)
##### After 1
![image](https://github.com/user-attachments/assets/d125313c-82c5-4272-995d-53be82141434)
##### Before 2
![image](https://github.com/user-attachments/assets/8391c889-466f-4608-87f8-39f03370a1b7)
##### After 2
![image](https://github.com/user-attachments/assets/36cfcff7-52a5-4676-aa58-51181ce4fae3)
##### Before 3
![image](https://github.com/user-attachments/assets/bd61a76a-8d44-492b-ba38-e318919b1dab)
##### After 3
![image](https://github.com/user-attachments/assets/74ee0981-1c55-4e2c-84df-f2fa496c0a35)
##### Before 4
![image](https://github.com/user-attachments/assets/9de5b93a-9070-4c09-b910-ab0f0ecf98a1)
##### After 4
![image](https://github.com/user-attachments/assets/9429a59f-ec20-4f0e-9306-1d718945cbd7)
