### PR TITLE
change to P rarity for a3a promo cards

### DIFF
--- a/frontend/assets/cards/P-A.json
+++ b/frontend/assets/cards/P-A.json
@@ -2909,7 +2909,7 @@
     },
     "weakness": "fighting",
     "retreat": "1",
-    "rarity": "☆",
+    "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
@@ -2925,7 +2925,7 @@
       }
     ],
     "artist": "GIDORA",
-    "crafting_cost": 400
+    "crafting_cost": "Unknown"
   },
   {
     "id": "75",
@@ -2949,8 +2949,8 @@
     },
     "weakness": "fire",
     "retreat": "1",
-    "rarity": "◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -2965,7 +2965,7 @@
       }
     ],
     "artist": "Hasuno",
-    "crafting_cost": 35
+    "crafting_cost": "Unknown"
   },
   {
     "id": "76",
@@ -2989,8 +2989,8 @@
     },
     "weakness": "water",
     "retreat": "2",
-    "rarity": "◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3009,7 +3009,7 @@
       }
     ],
     "artist": "Hasuno",
-    "crafting_cost": 35
+    "crafting_cost": "Unknown"
   },
   {
     "id": "77",
@@ -3033,8 +3033,8 @@
     },
     "weakness": "fighting",
     "retreat": "2",
-    "rarity": "◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3049,7 +3049,7 @@
       }
     ],
     "artist": "Shin Nagasawa",
-    "crafting_cost": 35
+    "crafting_cost": "Unknown"
   },
   {
     "id": "78",
@@ -3073,8 +3073,8 @@
     },
     "weakness": "darkness",
     "retreat": "2",
-    "rarity": "◊◊◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3085,7 +3085,7 @@
       }
     ],
     "artist": "nagimiso",
-    "crafting_cost": 150
+    "crafting_cost": "Unknown"
   },
   {
     "id": "79",
@@ -3109,8 +3109,8 @@
     },
     "weakness": "fire",
     "retreat": "2",
-    "rarity": "◊◊◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3121,7 +3121,7 @@
       }
     ],
     "artist": "nagimiso",
-    "crafting_cost": 150
+    "crafting_cost": "Unknown"
   },
   {
     "id": "80",
@@ -3145,8 +3145,8 @@
     },
     "weakness": "fire",
     "retreat": "3",
-    "rarity": "◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3161,7 +3161,7 @@
       }
     ],
     "artist": "Shin Nagasawa",
-    "crafting_cost": 35
+    "crafting_cost": "Unknown"
   },
   {
     "id": "81",
@@ -3191,8 +3191,8 @@
     },
     "weakness": "none",
     "retreat": "2",
-    "rarity": "◊◊◊◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "yes",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3203,7 +3203,7 @@
       }
     ],
     "artist": "PLANETA Tsuji",
-    "crafting_cost": 500
+    "crafting_cost": "Unknown"
   },
   {
     "id": "82",
@@ -3227,8 +3227,8 @@
     },
     "weakness": "fighting",
     "retreat": "1",
-    "rarity": "◊◊◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3243,7 +3243,7 @@
       }
     ],
     "artist": "Megumi Mizutani",
-    "crafting_cost": 150
+    "crafting_cost": "Unknown"
   },
   {
     "id": "83",
@@ -3267,8 +3267,8 @@
     },
     "weakness": "fighting",
     "retreat": "2",
-    "rarity": "◊◊◊",
-    "fullart": "No",
+    "rarity": "P",
+    "fullart": "Yes",
     "ex": "no",
     "set_details": "promo-a",
     "pack": "everypack",
@@ -3283,6 +3283,6 @@
       }
     ],
     "artist": "Kanako Eo",
-    "crafting_cost": 150
+    "crafting_cost": "Unknown"
   }
 ]

--- a/scripts/scraper.js
+++ b/scripts/scraper.js
@@ -5,8 +5,8 @@ import fetch from 'node-fetch'
 
 const BASE_URL = 'https://pocket.limitlesstcg.com'
 const targetDir = 'frontend/assets/cards/'
-// const expansions = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'P-A']
-const expansions = ['A3a', 'P-A']
+// const expansions = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'A3a', 'P-A']
+const expansions = ['P-A']
 const packs = [
   'Pikachu pack',
   'Charizard pack',
@@ -162,7 +162,8 @@ function extractCardInfo($, cardUrl) {
   cardInfo.retreat = weaknessAndRetreat[1]?.split(': ')[1]?.toLowerCase().trim() || 'N/A'
 
   const raritySection = $('table.card-prints-versions tr.current')
-  cardInfo.rarity = raritySection.find('td:last-child').text().trim() || 'P'
+  cardInfo.rarity = cardUrl.toString().includes('P-A') ? 'P' : raritySection.find('td:last-child').text().trim() || 'P'
+
   cardInfo.fullart = fullArtRarities.includes(cardInfo.rarity) ? 'Yes' : 'No'
 
   cardInfo.ex = cardInfo.name.includes('ex') ? 'yes' : 'no'


### PR DESCRIPTION
Fixes https://community.tcgpocketcollectiontracker.com/t/new-promo-cards-have-wrong-rarity/4677

Looks like the site that cards are scraped from is now adding the rarities, so existing logic to apply P rarity to cards without a rarity didn't work. Modified scraper to just set all P-A cards to P rarity.