### PR TITLE
trade match filters use min/max preferences

### DIFF
--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -119,12 +119,7 @@ function Collection() {
       <CardDetail cardId={selectedCardId} onClose={() => setSelectedCardId('')} />
       <div>{missions && <MissionsTable missions={missions} resetScrollTrigger={resetScrollTrigger} />}</div>
       {missions && <MissionDetail missionCardOptions={selectedMissionCardOptions} onClose={() => setSelectedMissionCardOptions([])} />}
-      <TradeMatches
-        ownedCards={ownedCards}
-        friendCards={friendCards || []}
-        ownCollection={params.friendId === account?.friend_id}
-        friendAccount={friendAccount}
-      />
+      <TradeMatches ownedCards={ownedCards} friendCards={friendCards || []} ownAccount={account} friendAccount={friendAccount} />
     </div>
   )
 }


### PR DESCRIPTION
I have both values set to 2, but the trade matches initially uses different values:
![image](https://github.com/user-attachments/assets/02eca2ea-b68d-4fe4-917f-0af25bb56b27)
This fixes it:
![image](https://github.com/user-attachments/assets/dadf4f25-7ba2-4679-9ce8-6f35f8134a08)
