### PR TITLE
feat: add missing translatable strings in french and english locales

### DIFF
--- a/frontend/public/locales/en-US/bulk-update.json
+++ b/frontend/public/locales/en-US/bulk-update.json
@@ -1,0 +1,16 @@
+{
+  "buttonTitle": "Bulk update",
+  "title": "Bulk update cards",
+  "selectAll": "Select All",
+  "deselectAll": "Deselect All",
+  "enterAmount": "Enter amount",
+  "cancel": "Cancel",
+  "batchProcessing": "Batch processing...",
+  "batchUpdate": "Batch update",
+  "alert": {
+    "beforeCount": "You are about to batch update ",
+    "cards": "cards",
+    "afterCount": "based on your selected filters. Select the amount you'd like to set for each of the cards below. You can also select or deselect individual cards if you don’t want to update all of them. ",
+    "warning": "Beware that this will overwrite all current values of the selected cards!"
+  }
+}

--- a/frontend/public/locales/en-US/edit-profile.json
+++ b/frontend/public/locales/en-US/edit-profile.json
@@ -14,5 +14,9 @@
   "isPublicButton": "Share collection",
   "isPublicTradeButton": "Open trading page",
   "isPublicToggle": "Is public",
-  "save": "Save"
+  "save": "Save",
+  "usernameTooShort": "Username must be at least 2 characters.",
+  "friendIdInvalid": "Friend ID is not valid, it must be 16 digits without dashes.",
+  "accountSaved": "Account saved.",
+  "accountSavingError": "Error saving your account."
 }

--- a/frontend/public/locales/en-US/header.json
+++ b/frontend/public/locales/en-US/header.json
@@ -25,5 +25,6 @@
   "aboutUsDialog": {
     "title": "About us",
     "content": "TCG Pocket Tracker is a free and open-source project that aims to help you track your Pokémon Pocket collection. It provides a user-friendly interface to manage your collection. The project is open-source and welcomes contributions from the community. If you have any questions or feedback, please reach out to us on <a href=\"https://community.tcgpocketcollectiontracker.com\" style=\"text-decoration: underline;\">our community forum</a> or <a href=\"https://github.com/marcelpanse/tcg-pocket-collection-tracker\" style=\"text-decoration: underline;\">GitHub</a>."
-  }
+  },
+  "support": "The site is hosted on Github Pages and Supabase. Costs are covered by me as a hobby project. If you like the project, please consider supporting me using the coffee button in the bottom right corner."
 }

--- a/frontend/public/locales/en-US/login.json
+++ b/frontend/public/locales/en-US/login.json
@@ -3,5 +3,12 @@
   "validEmail": "Please enter a valid email address",
   "fill6Digit": "Please enter the 6-digit code here.",
   "fillEmail": "Enter your email and we’ll send you a login code. If you’re new, we’ll set up your account automatically.",
-  "button": "Continue"
+  "button": "Continue",
+  "emailRequired": "Email is required",
+  "emailInvalid": "Email must be valid",
+  "emailTooLong": "Email must be less than 255 characters",
+  "otpVerifyError": "There was an error verifying your OTP. Please try again.",
+  "otpSendError": "There was an error sending your OTP email. Please try again.",
+  "onlyEmail": "We'll only use your email for login.",
+  "email": "Email"
 }

--- a/frontend/public/locales/en-US/pages/card-detail.json
+++ b/frontend/public/locales/en-US/pages/card-detail.json
@@ -1,5 +1,6 @@
 {
   "text": {
+    "chanceToPull": "Chance to pull: {{percent}}%",
     "tradeTokens": "Trade tokens",
     "hp": "HP",
     "cardType": "Card Type",

--- a/frontend/public/locales/en-US/pages/collection.json
+++ b/frontend/public/locales/en-US/pages/collection.json
@@ -1,4 +1,15 @@
 {
   "publicCollectionTitle": "You are viewing the public collection of \"{{username}}\".",
-  "publicCollectionDescription": "You are currently viewing a public collection. Click any of the navigation items to return to your own collection."
+  "publicCollectionDescription": "You are currently viewing a public collection. Click any of the navigation items to return to your own collection.",
+  "showPossibleTrades": "Show possible trades",
+  "missionDetail": {
+    "eligibleCards-singular": "List of eligible cards: {{options}} option",
+    "eligibleCards-plural": "List of eligible cards: {{options}} options",
+    "chanceFrom": "Chance from {{pack}}: {{chance}}%"
+  },
+  "filters": {
+    "allFilters": "All filters",
+    "filtersCount": "Filters ({{count}})",
+    "share": "Share"
+  }
 }

--- a/frontend/public/locales/en-US/pages/export.json
+++ b/frontend/public/locales/en-US/pages/export.json
@@ -1,0 +1,9 @@
+{
+  "loggedOut": {
+    "title": "Sign up to export your collection",
+    "description": "To export your collection, please log in."
+  },
+  "title": "Export",
+  "description": "This will export your current collection to a CSV file.",
+  "downloadCSV": "Download CSV file"
+}

--- a/frontend/public/locales/en-US/pages/import.json
+++ b/frontend/public/locales/en-US/pages/import.json
@@ -1,0 +1,23 @@
+{
+  "title": "Import",
+  "description": "This will OVERWRITE your current collection with the values from the imported CSV file. ONLY do this process if your spreadsheet contains the exact count values you want in your collection.",
+  "fileWasAborted": "File Was Aborted",
+  "errorWithFile": "Error With File",
+  "errorProcessingExcel": "Error processing Excel file:",
+  "dragNDrop": "Drag 'n' drop some files here, or click to select files",
+  "loading": "Excel file is loading",
+  "dataUpdated": "Data updated:",
+  "expansionName": "Expansion Name",
+  "id": "ID",
+  "cardName": "Card Name",
+  "statusCount": "Status (Count)",
+  "added": "Added ({{count}})",
+  "updated": "Updated ({{count}})",
+  "removed": "Removed",
+  "unknown": "Unknown",
+  "noDataUpdated": "No Data Updated.",
+  "loggedOut": {
+    "title": "Sign up to import your cards",
+    "description": "To import your spreadsheet, please log in."
+  }
+}

--- a/frontend/public/locales/en-US/pages/trade.json
+++ b/frontend/public/locales/en-US/pages/trade.json
@@ -1,0 +1,32 @@
+{
+  "publicTradePage": "Public trade page:",
+  "friendID": "Friend ID:",
+  "lookingForCards": "Looking for cards:",
+  "forTradeCards": "For trade cards:",
+  "copiedInClipboard": "Copied cards for trading to clipboard!",
+  "lookingFor": "Looking For",
+  "forTrade": "For Trade",
+  "buyingTokens": "Buying Tokens",
+  "enableTradingPage": "Enable trading page",
+  "openTradingPage": "Open trading page",
+  "notLoggedIn": {
+    "title": "Sign up to view your tradeable cards",
+    "description": "By registering, you can keep track of your collection, trade with other users, and access exclusive features."
+  },
+  "noTradeableCards": {
+    "title": "You have no tradeable cards!",
+    "description": "Go to the collections page and input your collected cards to see what you can trade."
+  },
+  "noSellableCards": {
+    "title": "You have no sellable cards!",
+    "description": "If you believe you have sellable cards, go to the collections page and input your collected cards to see what you can sell."
+  },
+  "noCardsNeeded": {
+    "title": "You have all tradeable cards!",
+    "description": "Make sure you come back here when new rarities and packs are available for trade."
+  },
+  "goTrackYourCards": {
+    "title": "Go track your cards",
+    "description": "By tracking your cards, you can see what cards you still need to get, what cards you can trade with friends, and how many trade tokens you can earn with your current collection."
+  }
+}

--- a/frontend/public/locales/en-US/scan.json
+++ b/frontend/public/locales/en-US/scan.json
@@ -1,0 +1,21 @@
+{
+  "cancel": "Cancel",
+  "clickToSelect": "Click to select",
+  "close": "Close",
+  "description": "You can upload multiple images at once. The system will scan each image for Pokemon cards and display the results. You can verify the matches, select or deselect detected cards, and choose how much to increment the quantity for selected cards.",
+  "deselectAll": "Deselect all",
+  "enterAmount": "Enter amount",
+  "extractedCard": "Extracted Card",
+  "hideEditMatches": "Hide edit matches",
+  "loading": "Downloading and initializing scan model, please wait... ({{initProgress}})",
+  "otherPotentialMatch": "Other potential matches:",
+  "percentMatch": "{{match}}% match",
+  "scan": "Scan",
+  "selectAll": "Select all",
+  "selectImages": "Select images",
+  "selected": "Selected",
+  "setIncrement": "Set increment for selected cards",
+  "showEditMatches": "Show edit matches",
+  "title": "Pokemon card scanner",
+  "updateSelectedCards": "Update selected cards"
+}

--- a/frontend/public/locales/en-US/search-input.json
+++ b/frontend/public/locales/en-US/search-input.json
@@ -1,0 +1,3 @@
+{
+  "search": "Search..."
+}

--- a/frontend/public/locales/en-US/trade-matches.json
+++ b/frontend/public/locales/en-US/trade-matches.json
@@ -17,5 +17,9 @@
   "maxFilterTooltip": "The minimum amount of cards you need to own before appearing as a trade option.",
   "minInputTooltip": "The minimum amount of cards you want to trade down to.",
   "maxInputTooltip": "The maximum amount of cards you want to collect by trading.",
-  "activeTradingInputTooltip": "Tip: You can (temporarily) switch off your trading page in case you run out of trading tokens."
+  "activeTradingInputTooltip": "Tip: You can (temporarily) switch off your trading page in case you run out of trading tokens.",
+  "accountSaved": "Account saved.",
+  "errorSavingAccount": "Error saving your account.",
+  "amountYouOwn": "Amount you own",
+  "amountFriendOwns": "Amount your friend owns"
 }

--- a/frontend/public/locales/es-ES/common/packs.json
+++ b/frontend/public/locales/es-ES/common/packs.json
@@ -10,7 +10,7 @@
   "lunalapack": "Lunala",
   "solgaleopack": "Solgaleo",
   "buzzwolepack": "Buzzwole",
-  "eeveegrovepack": "Eevee Grove",
+  "eeveegrovepack": "Arboleda de Eevee",
   "everypack": "Todos los sobres",
   "all": "Todos los sobres",
   "missions": "Misiones"

--- a/frontend/public/locales/fr-FR/bulk-update.json
+++ b/frontend/public/locales/fr-FR/bulk-update.json
@@ -1,0 +1,16 @@
+{
+  "buttonTitle": "Mise à jour en masse",
+  "title": "Mise à jour en masse des cartes",
+  "selectAll": "Tout sélectionner",
+  "deselectAll": "Tout désélectionner",
+  "enterAmount": "Saisir la quantité",
+  "cancel": "Annuler",
+  "batchProcessing": "Traitement en masse en cours...",
+  "batchUpdate": "Mise à jour en masse",
+  "alert": {
+    "beforeCount": "Vous êtes sur le point de mettre à jour en masse ",
+    "cards": "cartes",
+    "afterCount": " en fonction de vos filtres sélectionnés. Sélectionnez la quantité que vous souhaitez définir pour chacune des cartes ci-dessous. Vous pouvez également sélectionner ou désélectionner des cartes individuellement si vous ne souhaitez pas toutes les mettre à jour. ",
+    "warning": "Attention, cette action écrasera toutes les valeurs actuelles des cartes sélectionnées !"
+  }
+}

--- a/frontend/public/locales/fr-FR/common/packs.json
+++ b/frontend/public/locales/fr-FR/common/packs.json
@@ -10,7 +10,7 @@
   "lunalapack": "Lunala",
   "solgaleopack": "Solgaleo",
   "buzzwolepack": "Mouscoto",
-  "eeveegrovepack": "Eevee Grove",
+  "eeveegrovepack": "La Clairière d'Évoli",
   "everypack": "Chaque booster",
   "all": "Tous les boosters",
   "missions": "Missions"

--- a/frontend/public/locales/fr-FR/edit-profile.json
+++ b/frontend/public/locales/fr-FR/edit-profile.json
@@ -14,5 +14,9 @@
   "isPublicButton": "Partager la collection",
   "isPublicTradeButton": "Ouvrir la page d'échanges",
   "isPublicToggle": "Public",
-  "save": "Enregistrer"
+  "save": "Enregistrer",
+  "usernameTooShort": "Le nom d'utilisateur doit contenir au moins 2 caractères.",
+  "friendIdInvalid": "L'ID d'ami(e) n'est pas valide, il doit contenir 16 chiffres sans tirets.",
+  "accountSaved": "Compte enregistré.",
+  "accountSavingError": "Erreur lors de l'enregistrement de votre compte."
 }

--- a/frontend/public/locales/fr-FR/header.json
+++ b/frontend/public/locales/fr-FR/header.json
@@ -25,5 +25,6 @@
   "aboutUsDialog": {
     "title": "À propos de nous",
     "content": "TCG Pocket Tracker est un projet gratuit et open-source qui vise à vous aider à suivre votre collection Pokémon Pocket. Il fournit une interface conviviale pour gérer votre collection. Le projet est open-source et les contributions de la communauté sont appreciées. Si vous avez des questions ou des commentaires, n'hésitez pas à nous contacter sur <a href=\"https://community.tcgpocketcollectiontracker.com\" style=\"text-decoration: underline;\">notre forum communautaire</a> ou sur <a href=\"https://github.com/marcelpanse/tcg-pocket-collection-tracker\" style=\"text-decoration: underline;\">GitHub</a>."
-  }
+  },
+  "support": "Le site est hébergé sur Github Pages et Supabase. Les frais sont couverts par mes soins, car il s'agit d'un projet personnel. Si le projet vous plaît, vous pouvez me soutenir en utilisant le bouton café en bas à droite."
 }

--- a/frontend/public/locales/fr-FR/login.json
+++ b/frontend/public/locales/fr-FR/login.json
@@ -3,5 +3,12 @@
   "validEmail": "Veuillez entrer une adresse mail valide",
   "fill6Digit": "Merci. Entrez le code à 6 chiffres envoyé par mail.",
   "fillEmail": "Entrez votre adresse mail afin d'obtenir un lien de connexion. Si vous n'avez pas encore de compte, nous allons en créer un automatiquement pour vous. Nous n'utiliserons pas votre adresse mail pour autre chose.",
-  "button": "Se connecter / Créer un compte"
+  "button": "Se connecter / Créer un compte",
+  "emailRequired": "Une adresse e-mail est requise",
+  "emailInvalid": "L'adresse e-mail doit être valide",
+  "emailTooLong": "L'adresse e-mail doit contenir moins de 255 caractères",
+  "otpVerifyError": "Une erreur s'est produite lors de la vérification de votre code OTP. Veuillez réessayer.",
+  "otpSendError": "Une erreur s'est produite lors de l'envoi de votre e-mail OTP. Veuillez réessayer.",
+  "onlyEmail": "Nous utiliserons votre e-mail uniquement pour la connexion.",
+  "email": "Email"
 }

--- a/frontend/public/locales/fr-FR/pages/card-detail.json
+++ b/frontend/public/locales/fr-FR/pages/card-detail.json
@@ -1,5 +1,6 @@
 {
   "text": {
+    "chanceToPull": "Chance de l'obtenir : {{percent}}%",
     "tradeTokens": "Jetons d'échange",
     "hp": "PV",
     "cardType": "Type de carte",

--- a/frontend/public/locales/fr-FR/pages/collection.json
+++ b/frontend/public/locales/fr-FR/pages/collection.json
@@ -1,4 +1,15 @@
 {
   "publicCollectionTitle": "Vous consultez la collection publique de « {{username}} ».",
-  "publicCollectionDescription": "Vous consultez actuellement une collection publique. Cliquez sur n'importe quel élément de navigation pour retourner à votre propre collection."
+  "publicCollectionDescription": "Vous consultez actuellement une collection publique. Cliquez sur n'importe quel élément de navigation pour retourner à votre propre collection.",
+  "showPossibleTrades": "Afficher les échanges possibles",
+  "missionDetail": {
+    "eligibleCards-singular": "Liste des cartes éligibles : {{options}} option",
+    "eligibleCards-plural": "Liste des cartes éligibles : {{options}} options",
+    "chanceFrom": "Chance dans {{pack}} : {{chance}}%"
+  },
+  "filters": {
+    "allFilters": "Tous les filtres",
+    "filtersCount": "Filtres ({{count}})",
+    "share": "Partager"
+  }
 }

--- a/frontend/public/locales/fr-FR/pages/export.json
+++ b/frontend/public/locales/fr-FR/pages/export.json
@@ -1,0 +1,9 @@
+{
+  "loggedOut": {
+    "title": "Inscrivez-vous pour exporter votre collection",
+    "description": "Pour exporter votre collection, veuillez vous connecter."
+  },
+  "title": "Exporter",
+  "description": "Cette action exportera votre collection actuelle dans un fichier CSV.",
+  "downloadCSV": "Télécharger le fichier CSV"
+}

--- a/frontend/public/locales/fr-FR/pages/import.json
+++ b/frontend/public/locales/fr-FR/pages/import.json
@@ -1,0 +1,23 @@
+{
+  "title": "Importer",
+  "description": "Cette action ÉCRASERA votre collection actuelle avec les valeurs du fichier CSV importé. N'effectuez cette opération SEULEMENT si votre feuille de calcul contient les quantités exactes que vous souhaitez dans votre collection.",
+  "fileWasAborted": "Chargement du fichier annulé",
+  "errorWithFile": "Erreur avec le fichier",
+  "errorProcessingExcel": "Erreur lors du traitement du fichier Excel :",
+  "dragNDrop": "Glissez-déposez des fichiers ici, ou cliquez pour sélectionner des fichiers",
+  "loading": "Chargement du fichier Excel en cours",
+  "dataUpdated": "Données mises à jour :",
+  "expansionName": "Nom de l'extension",
+  "id": "ID",
+  "cardName": "Nom de la carte",
+  "statusCount": "Statut (Quantité)",
+  "added": "Ajouté(s) ({{count}})",
+  "updated": "Mis à jour ({{count}})",
+  "removed": "Supprimé",
+  "unknown": "Inconnu",
+  "noDataUpdated": "Aucune donnée mise à jour.",
+  "loggedOut": {
+    "title": "Inscrivez-vous pour importer vos cartes",
+    "description": "Pour importer votre feuille de calcul, veuillez vous connecter."
+  }
+}

--- a/frontend/public/locales/fr-FR/pages/trade.json
+++ b/frontend/public/locales/fr-FR/pages/trade.json
@@ -1,0 +1,32 @@
+{
+  "publicTradePage": "Page d'échange publique :",
+  "friendID": "ID d'ami(e) :",
+  "lookingForCards": "Cartes recherchées :",
+  "forTradeCards": "Cartes à échanger :",
+  "copiedInClipboard": "Cartes à échanger copiées dans le presse-papiers !",
+  "lookingFor": "Recherche",
+  "forTrade": "À échanger",
+  "buyingTokens": "Achat de jetons",
+  "enableTradingPage": "Activer la page d'échanges",
+  "openTradingPage": "Ouvrir la page d'échanges",
+  "notLoggedIn": {
+    "title": "Inscrivez-vous pour voir vos cartes échangeables",
+    "description": "En vous inscrivant, vous pouvez suivre votre collection, échanger avec d'autres utilisateurs et accéder à des fonctionnalités exclusives."
+  },
+  "noTradeableCards": {
+    "title": "Vous n'avez aucune carte échangeable !",
+    "description": "Allez sur la page de collection et saisissez les cartes que vous avez collectées pour voir ce que vous pouvez échanger."
+  },
+  "noSellableCards": {
+    "title": "Vous n'avez aucune carte à vendre !",
+    "description": "Si vous pensez avoir des cartes à vendre, allez sur la page de collection et saisissez les cartes que vous avez collectées pour voir ce que vous pouvez vendre."
+  },
+  "noCardsNeeded": {
+    "title": "Vous avez toutes les cartes échangeables !",
+    "description": "N'oubliez pas de revenir ici lorsque de nouvelles raretés et de nouveaux boosters seront disponibles à l'échange."
+  },
+  "goTrackYourCards": {
+    "title": "Allez suivre vos cartes",
+    "description": "En suivant vos cartes, vous pouvez voir quelles cartes il vous manque, quelles cartes vous pouvez échanger avec des amis et combien de jetons d'échange vous pouvez gagner avec votre collection actuelle."
+  }
+}

--- a/frontend/public/locales/fr-FR/scan.json
+++ b/frontend/public/locales/fr-FR/scan.json
@@ -10,12 +10,12 @@
   "loading": "Téléchargement et initialisation du modèle de scan, veuillez patienter... ({{initProgress}})",
   "otherPotentialMatch": "Autres correspondances potentielles :",
   "percentMatch": "match de {{match}}%",
-  "scan": "Scanner",
+  "scan": "Scanneur",
   "selectAll": "Tout sélectionner",
   "selectImages": "Sélectionner des images",
   "selected": "Sélectionné",
   "setIncrement": "Définir l'incrément pour les cartes sélectionnées",
   "showEditMatches": "Afficher l'éditeur de correspondances",
-  "title": "Scanner de cartes Pokémon",
+  "title": "Scanneur de cartes Pokémon",
   "updateSelectedCards": "Mettre à jour les cartes sélectionnées"
 }

--- a/frontend/public/locales/fr-FR/scan.json
+++ b/frontend/public/locales/fr-FR/scan.json
@@ -1,0 +1,21 @@
+{
+  "cancel": "Annuler",
+  "clickToSelect": "Cliquez pour sélectionner",
+  "close": "Fermer",
+  "description": "Vous pouvez téléverser plusieurs images à la fois. Le système scannera chaque image à la recherche de cartes Pokémon et affichera les résultats. Vous pouvez vérifier les correspondances, sélectionner ou désélectionner les cartes détectées, et choisir de combien incrémenter la quantité pour les cartes sélectionnées.",
+  "deselectAll": "Tout désélectionner",
+  "enterAmount": "Saisir la quantité",
+  "extractedCard": "Carte extraite",
+  "hideEditMatches": "Masquer l'éditeur de correspondances",
+  "loading": "Téléchargement et initialisation du modèle de scan, veuillez patienter... ({{initProgress}})",
+  "otherPotentialMatch": "Autres correspondances potentielles :",
+  "percentMatch": "match de {{match}}%",
+  "scan": "Scanner",
+  "selectAll": "Tout sélectionner",
+  "selectImages": "Sélectionner des images",
+  "selected": "Sélectionné",
+  "setIncrement": "Définir l'incrément pour les cartes sélectionnées",
+  "showEditMatches": "Afficher l'éditeur de correspondances",
+  "title": "Scanner de cartes Pokémon",
+  "updateSelectedCards": "Mettre à jour les cartes sélectionnées"
+}

--- a/frontend/public/locales/fr-FR/scan.json
+++ b/frontend/public/locales/fr-FR/scan.json
@@ -9,7 +9,7 @@
   "hideEditMatches": "Masquer l'éditeur de correspondances",
   "loading": "Téléchargement et initialisation du modèle de scan, veuillez patienter... ({{initProgress}})",
   "otherPotentialMatch": "Autres correspondances potentielles :",
-  "percentMatch": "match de {{match}}%",
+  "percentMatch": "concordance de {{match}}%",
   "scan": "Scanneur",
   "selectAll": "Tout sélectionner",
   "selectImages": "Sélectionner des images",

--- a/frontend/public/locales/fr-FR/search-input.json
+++ b/frontend/public/locales/fr-FR/search-input.json
@@ -1,0 +1,3 @@
+{
+  "search": "Rechercher..."
+}

--- a/frontend/public/locales/fr-FR/trade-matches.json
+++ b/frontend/public/locales/fr-FR/trade-matches.json
@@ -9,11 +9,17 @@
   "ownCollectionDescription": "Pensez à partager cette page avec d'autres personnes pour leur permettre de trouver des échanges possibles.",
   "isActiveTrading": "Statut de la page d'échanges",
   "minNumberOfCardsToKeep": "Nombre minimum de cartes à conserver",
+  "maxNumberOfCardsWanted": "Nombre maximum de cartes désirées",
   "inActiveTradePage": "L'utilisateur « {{username}} » n'accepte actuellement aucun échange.",
   "inActiveTradeDescription": "Leur page d'échanges est désactivée. Veuillez les contacter si vous souhaitez faire un échange.",
   "friendAccountDetails": "ID de l'ami(e) : {{friend_id}} ({{username}}).",
   "minFilterTooltip": "La quantité maximale de cartes que vous souhaitez collectionner via les échanges.",
   "maxFilterTooltip": "La quantité minimale de cartes que vous devez posséder avant qu'elles n'apparaissent comme une option d'échange.",
   "minInputTooltip": "Le nombre minimum de cartes que vous souhaitez conserver après l'échange.",
-  "activeTradingInputTooltip": "Astuce : Vous pouvez désactiver (temporairement) votre page d'échanges si vous manquez de jetons d'échange."
+  "maxInputTooltip": "Le nombre maximum de cartes que vous souhaitez collectionner avec les échanges.",
+  "activeTradingInputTooltip": "Astuce : Vous pouvez désactiver (temporairement) votre page d'échanges si vous manquez de jetons d'échange.",
+  "accountSaved": "Compte enregistré.",
+  "errorSavingAccount": "Erreur lors de l'enregistrement de votre compte.",
+  "amountYouOwn": "Quantité que vous possédez",
+  "amountFriendOwns": "Quantité que votre ami(e) possède"
 }

--- a/frontend/public/locales/it-IT/common/packs.json
+++ b/frontend/public/locales/it-IT/common/packs.json
@@ -10,7 +10,7 @@
   "lunalapack": "Lunala",
   "solgaleopack": "Solgaleo",
   "buzzwolepack": "Buzzwole",
-  "eeveegrovepack": "Eevee Grove",
+  "eeveegrovepack": "Il Bosco di Eevee",
   "everypack": "Ogni busta",
   "all": "Tutte le buste",
   "missions": "Missioni"

--- a/frontend/src/components/BatchUpdateDialog.tsx
+++ b/frontend/src/components/BatchUpdateDialog.tsx
@@ -7,6 +7,7 @@ import type { Card } from '@/types'
 import { MinusIcon, PlusIcon } from 'lucide-react'
 // src/components/BatchUpdateDialog.tsx
 import { useEffect, useMemo, useState } from 'react' // Add useEffect
+import { useTranslation } from 'react-i18next'
 
 interface BatchUpdateDialogProps {
   filteredCards: Card[]
@@ -15,6 +16,7 @@ interface BatchUpdateDialogProps {
 }
 
 export function BatchUpdateDialog({ filteredCards, onBatchUpdate }: BatchUpdateDialogProps) {
+  const { t } = useTranslation('bulk-update')
   const [isOpen, setIsOpen] = useState(false)
   const [amount, setAmount] = useState(0)
   const [selectedCards, setSelectedCards] = useState<Record<string, boolean>>({})
@@ -123,18 +125,18 @@ export function BatchUpdateDialog({ filteredCards, onBatchUpdate }: BatchUpdateD
   return (
     <>
       <Button className="hidden sm:block" variant="outline" onClick={() => setIsOpen(true)} disabled={isBatchUpdateDisabled}>
-        Bulk update
+        {t('buttonTitle')}
       </Button>
 
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>Bulk update cards</DialogTitle>
+            <DialogTitle>{t('title')}</DialogTitle>
           </DialogHeader>
 
           <Alert variant="destructive">
             <AlertDescription>
-              You are about to batch update{' '}
+              {t('alert.beforeCount')}
               <strong>
                 <span
                   style={{
@@ -147,18 +149,18 @@ export function BatchUpdateDialog({ filteredCards, onBatchUpdate }: BatchUpdateD
                 >
                   {selectedCount}
                 </span>{' '}
-                cards
+                {t('alert.cards')}
               </strong>{' '}
-              based on your selected filters. Select the amount you'd like to set for each of the cards below. You can also select or deselect individual cards
-              if you don’t want to update all of them. <strong>Beware that this will overwrite all current values of the selected cards!</strong>{' '}
+              {t('alert.afterCount')}
+              <strong>{t('alert.warning')}</strong>
             </AlertDescription>
           </Alert>
           <div className="flex gap-2 justify-between">
             <Button variant="outline" onClick={handleDeselectAll}>
-              Deselect All
+              {t('deselectAll')}
             </Button>
             <Button variant="outline" onClick={handleSelectAll}>
-              Select All
+              {t('selectAll')}
             </Button>
           </div>
 
@@ -179,7 +181,7 @@ export function BatchUpdateDialog({ filteredCards, onBatchUpdate }: BatchUpdateD
               min="0"
               value={amount ?? 0}
               onChange={handleInputChange}
-              placeholder="Enter amount"
+              placeholder={t('enterAmount')}
               className="w-7 text-center border-none rounded"
               onFocus={(event) => event.target.select()}
             />
@@ -190,7 +192,7 @@ export function BatchUpdateDialog({ filteredCards, onBatchUpdate }: BatchUpdateD
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsOpen(false)}>
-              Cancel
+              {t('cancel')}
             </Button>
             <Button onClick={handleConfirm} disabled={selectedCount === 0 || isProcessing || !changesMade} variant="default">
               {isProcessing && (
@@ -211,7 +213,7 @@ export function BatchUpdateDialog({ filteredCards, onBatchUpdate }: BatchUpdateD
                   />
                 </svg>
               )}
-              Batch {isProcessing ? 'processing...' : 'update'}
+              {isProcessing ? t('batchProcessing') : t('batchUpdate')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/EditProfile.tsx
+++ b/frontend/src/components/EditProfile.tsx
@@ -31,10 +31,10 @@ const EditProfile: FC<Props> = ({ account, setAccount, isProfileDialogOpen, setI
 
   const formSchema = z.object({
     username: z.string().min(2, {
-      message: 'Username must be at least 2 characters.',
+      message: t('usernameTooShort'),
     }),
     friend_id: z.string().regex(/^[0-9]{16}$/, {
-      message: 'Friend ID is not valid, it must be 16 digits without dashes.',
+      message: t('friendIdInvalid'),
     }),
     is_public: z.boolean().optional(),
   })
@@ -63,10 +63,10 @@ const EditProfile: FC<Props> = ({ account, setAccount, isProfileDialogOpen, setI
 
       setAccount(account.data as AccountRow)
 
-      toast({ title: 'Account saved.', variant: 'default' })
+      toast({ title: t('accountSaved'), variant: 'default' })
     } catch (e) {
       console.error('error saving account', e)
-      toast({ title: 'Error saving your account.', variant: 'destructive' })
+      toast({ title: t('accountSavingError'), variant: 'destructive' })
     }
   }
 
@@ -93,7 +93,7 @@ const EditProfile: FC<Props> = ({ account, setAccount, isProfileDialogOpen, setI
                 <FormItem>
                   <FormLabel>{t('email')}</FormLabel>
                   <FormControl className="mt-2">
-                    <Input placeholder="Email" disabled value={user?.user.email} />
+                    <Input placeholder={t('email')} disabled value={user?.user.email} />
                   </FormControl>
                   <FormDescription>{t('registeredEmail')}</FormDescription>
                 </FormItem>
@@ -106,7 +106,7 @@ const EditProfile: FC<Props> = ({ account, setAccount, isProfileDialogOpen, setI
                 <FormItem>
                   <FormLabel>{t('username')}</FormLabel>
                   <FormControl className="mt-2">
-                    <Input placeholder="Username" {...field} />
+                    <Input placeholder={t('username')} {...field} />
                   </FormControl>
                   <FormDescription>{t('usernameDescription')}</FormDescription>
                   <FormMessage />
@@ -120,7 +120,7 @@ const EditProfile: FC<Props> = ({ account, setAccount, isProfileDialogOpen, setI
                 <FormItem>
                   <FormLabel>{t('friendID')}</FormLabel>
                   <FormControl className="mt-2">
-                    <Input placeholder="Friend ID" {...field} />
+                    <Input placeholder={t('friendID')} {...field} />
                   </FormControl>
                   <FormDescription>{t('friendIDDescription')}</FormDescription>
                   <FormMessage />

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -15,6 +15,7 @@ import { getCardNameByLang } from '@/lib/utils'
 import type { Card, CollectionRow, Mission, Rarity } from '@/types'
 import i18n from 'i18next'
 import { type FC, type JSX, useContext, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   children?: JSX.Element
@@ -43,6 +44,7 @@ interface Props {
 }
 
 const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToMissions, visibleFilters, filtersDialog, batchUpdate, share }: Props) => {
+  const { t } = useTranslation(['pages/collection'])
   const { user, setIsProfileDialogOpen } = useContext(UserContext)
   const { ownedCards, setOwnedCards } = useContext(CollectionContext)
 
@@ -160,11 +162,11 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
         {filtersDialog && (
           <Dialog>
             <DialogTrigger asChild>
-              <Button variant="outline">All filters</Button>
+              <Button variant="outline">{t('filters.allFilters')}</Button>
             </DialogTrigger>
             <DialogContent className="border-1 border-neutral-700 shadow-none">
               <DialogHeader>
-                <DialogTitle>Filters ({(getFilteredCards || []).filter((c) => !c.linkedCardID).length})</DialogTitle>
+                <DialogTitle>{t('filters.filtersCount', { count: (getFilteredCards || []).filter((c) => !c.linkedCardID).length })}</DialogTitle>
               </DialogHeader>
               <div className="flex flex-col gap-3">
                 {filtersDialog.search && <SearchInput setSearchValue={setSearchValue} fullWidth />}
@@ -205,7 +207,7 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
 
         {share && (
           <Button variant="outline" onClick={() => setIsProfileDialogOpen(true)}>
-            Share
+            {t('filters.share')}
           </Button>
         )}
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -184,8 +184,7 @@ export function Header() {
             <span className="text-md">
               <br />
               <br />
-              The site is hosted on Github Pages and Supabase. Costs are covered by me as a hobby project. If you like the project, please consider supporting
-              me using the coffee button in the bottom right corner.
+              {t('support')}
             </span>
 
             <span className="flex mt-6 justify-center gap-4">

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -8,12 +8,12 @@ import { z } from 'zod'
 import { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot } from './ui/input-otp.tsx'
 import { Input } from './ui/input.tsx'
 
-const EmailSchema = z.string().nonempty('Email is required').email('Email must be valid').max(255, 'Email must be less than 255 characters')
-
 export const Login = () => {
   const { setIsLoginDialogOpen } = use(UserContext)
   const { toast } = useToast()
   const { t } = useTranslation('login')
+
+  const EmailSchema = z.string().nonempty(t('emailRequired')).email(t('emailInvalid')).max(255, t('emailTooLong'))
 
   const [emailInput, setEmailInput] = useState('')
   const [emailSubmitted, setEmailSubmitted] = useState(false)
@@ -31,7 +31,7 @@ export const Login = () => {
 
       if (error) {
         console.log('supa OTP error', error)
-        toast({ title: 'There was an error verifying your OTP. Please try again.', variant: 'destructive' })
+        toast({ title: t('otpVerifyError'), variant: 'destructive' })
       } else {
         console.log('supa session', session)
         setIsLoginDialogOpen(false)
@@ -51,7 +51,7 @@ export const Login = () => {
     const { error } = await supabase.auth.signInWithOtp({ email: emailInput })
     if (error) {
       console.log('supa OTP error', error)
-      toast({ title: 'There was an error sending your OTP email. Please try again.', variant: 'destructive' })
+      toast({ title: t('otpSendError'), variant: 'destructive' })
     } else {
       setEmailSubmitted(true)
     }
@@ -87,7 +87,7 @@ export const Login = () => {
       <div className="flex justify-center gap-2 pt-4 align-center">
         <Input
           type="email"
-          placeholder="Email"
+          placeholder={t('email')}
           onChange={(e) => setEmailInput(e.target.value)}
           onKeyDown={async (e) => {
             if (e.key === 'Enter') {
@@ -99,7 +99,7 @@ export const Login = () => {
         <Button onClick={submitEmail}>{t('button')}</Button>
       </div>
 
-      <p className="mt-3 text-sm text-white/25">We'll only use your email for login.</p>
+      <p className="mt-3 text-sm text-white/25">{t('onlyEmail')}</p>
     </div>
   )
 }

--- a/frontend/src/components/PokemonCardDetectorComponent.tsx
+++ b/frontend/src/components/PokemonCardDetectorComponent.tsx
@@ -14,6 +14,7 @@ import i18n from 'i18next'
 import { MinusIcon, PlusIcon } from 'lucide-react'
 import type { ChangeEvent, FC } from 'react'
 import { use, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface PokemonCardDetectorProps {
   onDetectionComplete?: (results: DetectionResult[]) => void
@@ -38,6 +39,7 @@ interface ExtractedCard {
 }
 
 const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete, modelPath = '/model/model.json' }) => {
+  const { t } = useTranslation('scan')
   const { user } = use(UserContext)
   const { ownedCards, setOwnedCards } = use(CollectionContext)
 
@@ -382,7 +384,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
           {/* Selection indicator */}
           {card.matchedCard && card.topMatches && showPotentialMatches && (
             <div className="mt-2 mb-2 w-full">
-              <p className="text-sm font-medium mb-4">Other potential matches:</p>
+              <p className="text-sm font-medium mb-4">{t('otherPotentialMatch')}</p>
               <div className="grid grid-cols-4 gap-1">
                 {card.topMatches
                   .filter((match) => match.id !== card.matchedCard?.id)
@@ -413,7 +415,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
             {/* Extracted card */}
             <div className="w-1/2 relative">
               <img src={card.imageUrl} alt={`Detected card ${index + 1}`} className="w-full h-auto object-contain" />
-              <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-xs px-1 py-0.5 text-center">Extracted Card</div>
+              <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-xs px-1 py-0.5 text-center">{t('extractedCard')}</div>
             </div>
 
             {/* Best match card */}
@@ -421,7 +423,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
               <div className="w-1/2 relative">
                 <img src={getRightPathOfImage(card.matchedCard.imageUrl)} alt="Best match" className="w-full h-auto object-contain" />
                 <div className="absolute bottom-0 left-0 right-0 bg-green-500/80 text-white text-xs px-1 py-0.5 text-center">
-                  {(card.matchedCard.similarity * 100).toFixed(0)}% match
+                  {t('percentMatch', { match: (card.matchedCard.similarity * 100).toFixed(0) })}
                 </div>
               </div>
             )}
@@ -430,7 +432,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
           {/* Potential matches thumbnails */}
           <div className="flex justify-between items-center mb-2 w-full">
             <span className="text-sm font-medium">
-              {card.selected ? 'Selected' : 'Click to select'}{' '}
+              {card.selected ? t('selected') : t('clickToSelect')}{' '}
               {card.matchedCard &&
                 card.topMatches &&
                 card.topMatches
@@ -466,14 +468,14 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
   return (
     <div className="pokemon-card-detector flex justify-end">
       <Button onClick={() => setIsOpen(true)} variant="ghost">
-        Scan
+        {t('scan')}
       </Button>
 
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogOverlay className="DialogOverlay">
           <DialogContent className="DialogContent max-w-4xl">
             <DialogHeader>
-              <DialogTitle>Pokemon card scanner</DialogTitle>
+              <DialogTitle>{t('title')}</DialogTitle>
             </DialogHeader>
 
             {!isLoadingModel && !isGeneratingHashes && extractedCards.length === 0 && (
@@ -482,10 +484,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
                 onClick={() => fileInputRef.current?.click()}
               >
                 <AlertDescription>
-                  <p className="mb-4 text-center">
-                    You can upload multiple images at once. The system will scan each image for Pokemon cards and display the results. You can verify the
-                    matches, select or deselect detected cards, and choose how much to increment the quantity for selected cards.
-                  </p>
+                  <p className="mb-4 text-center">{t('description')}</p>
                 </AlertDescription>
                 <input
                   type="file"
@@ -497,7 +496,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
                   className="w-full hidden"
                 />
                 <Button variant="outline" className="mt-2" disabled={isUploadingImages}>
-                  {isUploadingImages && <Spinner />} Select images
+                  {isUploadingImages && <Spinner />} {t('selectImages')}
                 </Button>
               </div>
             )}
@@ -507,7 +506,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
                 <AlertDescription>
                   <div className="flex items-center space-x-2">
                     <Spinner />
-                    <p>Downloading and initializing scan model, please wait... ({initProgress})</p>
+                    <p>{t('loading', { initProgress })}</p>
                   </div>
                 </AlertDescription>
               </Alert>
@@ -517,13 +516,13 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
               <div>
                 <div className="flex gap-2 justify-between my-4 flex-wrap">
                   <Button variant="outline" onClick={handleDeselectAll} className="hidden sm:block">
-                    Deselect all
+                    {t('deselectAll')}
                   </Button>
                   <Button variant="outline" onClick={() => setShowPotentialMatches((prev) => !prev)}>
-                    {showPotentialMatches ? 'Hide' : 'Show'} edit matches
+                    {showPotentialMatches ? t('hideEditMatches') : t('showEditMatches')}
                   </Button>
                   <Button variant="outline" onClick={handleSelectAll} className="hidden sm:block">
-                    Select all
+                    {t('selectAll')}
                   </Button>
                 </div>
 
@@ -533,7 +532,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
 
                 {
                   <div className="flex flex-col items-center gap-2">
-                    <p className="text-sm font-medium pt-4">Set increment for selected cards</p>
+                    <p className="text-sm font-medium pt-4">{t('setIncrement')}</p>
                     <div className="flex items-center gap-x-1">
                       <Button variant="ghost" size="icon" onClick={handleDecrement} disabled={amount === 0} className="rounded-full">
                         <MinusIcon size={14} />
@@ -543,7 +542,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
                         min="0"
                         value={amount}
                         onChange={handleInputChange}
-                        placeholder="Enter amount"
+                        placeholder={t('enterAmount')}
                         className="w-10 text-center border-none rounded"
                         onFocus={(event) => event.target.select()}
                       />
@@ -568,7 +567,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
                   }
                 }}
               >
-                {extractedCards.length > 0 ? 'Cancel' : 'Close'}
+                {extractedCards.length > 0 ? t('cancel') : t('close')}
               </Button>
               {extractedCards.length > 0 && (
                 <Button onClick={handleConfirm} disabled={selectedCount === 0 || isProcessingCardUpdates || isLoadingModel} variant="default">
@@ -590,7 +589,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
                       />
                     </svg>
                   ) : (
-                    'Update selected cards'
+                    t('updateSelectedCards')
                   )}
                 </Button>
               )}

--- a/frontend/src/components/filters/SearchInput.tsx
+++ b/frontend/src/components/filters/SearchInput.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@/components/ui/input.tsx'
 import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 
 let _searchDebounce: number | null = null
 
@@ -8,10 +9,11 @@ type Props = {
   fullWidth?: boolean
 }
 const SearchInput: FC<Props> = ({ setSearchValue, fullWidth }) => {
+  const { t } = useTranslation('search-input')
   return (
     <Input
       type="search"
-      placeholder="Search..."
+      placeholder={t('search')}
       className={`w-full ${!fullWidth ? 'sm:w-32' : ''} border-2 h-[38px] bg-neutral-800`}
       style={{ borderColor: '#45556C' }}
       onChange={(e) => {

--- a/frontend/src/pages/collection/CardDetail.tsx
+++ b/frontend/src/pages/collection/CardDetail.tsx
@@ -42,7 +42,7 @@ function CardDetail({ cardId, onClose }: Readonly<CardDetailProps>) {
           <div className="p-4 w-full">
             {expansion && packName && (
               <p className="text-lg mb-1">
-                <strong>Chance to pull: {pullRateForSpecificCard(expansion, packName, card).toFixed(2)}%</strong>
+                <strong>{t('', { percent: pullRateForSpecificCard(expansion, packName, card).toFixed(2) })}</strong>
               </p>
             )}
             <p className="text-lg mb-1">

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -107,7 +107,7 @@ function Collection() {
                       navigate(`${location.pathname}/trade`)
                     }}
                   >
-                    Show possible trades
+                    {t('showPossibleTrades')}
                   </Button>
                 </div>
               </AlertDescription>

--- a/frontend/src/pages/collection/MissionDetail.tsx
+++ b/frontend/src/pages/collection/MissionDetail.tsx
@@ -11,7 +11,7 @@ interface MissionDetailProps {
 }
 
 function MissionDetail({ missionCardOptions, onClose }: MissionDetailProps) {
-  const { t } = useTranslation(['common/sets', 'common/packs'])
+  const { t } = useTranslation(['common/sets', 'common/packs', 'pages/collection'])
   const gettingExpansion = missionCardOptions[0] || ''
   const expansionId = gettingExpansion.length > 0 ? gettingExpansion.split('-')[0] : 'Unknown'
   const expansion = getExpansionById(expansionId) || expansions[0]
@@ -28,7 +28,9 @@ function MissionDetail({ missionCardOptions, onClose }: MissionDetailProps) {
       <SheetContent className="transition-all duration-300 ease-in-out border-slate-600 overflow-y-auto">
         <SheetHeader>
           <SheetTitle>
-            List of eligible cards: {missionCardOptions.length} option{missionCardOptions.length === 1 ? '' : 's'}
+            {missionCardOptions.length === 1
+              ? t('missionDetail.eligibleCards-singular', { options: 1 })
+              : t('missionDetail.eligibleCards-singular', { options: missionCardOptions.length })}
           </SheetTitle>
         </SheetHeader>
         {t(expansionName)}
@@ -43,7 +45,10 @@ function MissionDetail({ missionCardOptions, onClose }: MissionDetailProps) {
                 <p className="max-w-[130px] whitespace-nowrap font-semibold text-[12px] pt-2">
                   {cardId} - {getCardNameByLang(foundCard, i18n.language)}
                   <br />
-                  Chance from {t(foundCard.pack, { ns: 'common/packs' })}: {pullRateForSpecificCard(expansion, foundCard.pack, foundCard).toFixed(2)}%
+                  {t('missionDetail.chanceFrom', {
+                    pack: t(foundCard.pack, { ns: 'common/packs' }),
+                    chance: pullRateForSpecificCard(expansion, foundCard.pack, foundCard).toFixed(2),
+                  })}
                 </p>
               </div>
             )

--- a/frontend/src/pages/collection/TradeMatches.tsx
+++ b/frontend/src/pages/collection/TradeMatches.tsx
@@ -169,10 +169,10 @@ const TradeMatches: FC<Props> = ({ ownedCards, friendCards, ownAccount, friendAc
       }
       setAccount(updatedAccount.data as AccountRow)
 
-      toast({ title: 'Account saved.', variant: 'default' })
+      toast({ title: t('accountSaved'), variant: 'default' })
     } catch (e) {
       console.error('error saving account', e)
-      toast({ title: 'Error saving your account.', variant: 'destructive' })
+      toast({ title: t('errorSavingAccount'), variant: 'destructive' })
     }
   }
 
@@ -289,7 +289,7 @@ const TradeMatches: FC<Props> = ({ ownedCards, friendCards, ownAccount, friendAc
                           <span className="min-w-14 me-4">{card.card_id} </span>
                           <span>{card.name}</span>
                         </span>
-                        <span title="Amount you own" className="text-gray-500">
+                        <span title={t('amountYouOwn')} className="text-gray-500">
                           <span style={{ userSelect: 'none' }}>×{ownedCards.find((c) => c.card_id === card.card_id)?.amount_owned || 0}</span>
                         </span>
                       </li>
@@ -307,7 +307,7 @@ const TradeMatches: FC<Props> = ({ ownedCards, friendCards, ownAccount, friendAc
                           <span className="min-w-14 me-4">{card.card_id} </span>
                           <span>{card.name}</span>
                         </span>
-                        <span title="Amount your friend owns" className="text-gray-500">
+                        <span title={t('amountFriendOwns')} className="text-gray-500">
                           <span style={{ userSelect: 'none' }}>×{card.amount_owned}</span>
                         </span>
                       </li>

--- a/frontend/src/pages/export/Export.tsx
+++ b/frontend/src/pages/export/Export.tsx
@@ -1,18 +1,20 @@
 import { TitleCard } from '@/components/ui/title-card'
 import { UserContext } from '@/lib/context/UserContext'
 import { use } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ExportWriter } from './components/ExportWriter'
 
 function Export() {
+  const { t } = useTranslation('pages/export')
   const { user } = use(UserContext)
 
   if (!user) {
-    return <TitleCard title={'Sign up to export your collection'} paragraph={'To export your collection, please log in.'} className="bg-gray-400" />
+    return <TitleCard title={t('loggedOut.title')} paragraph={t('loggedOut.description')} className="bg-gray-400" />
   }
 
   return (
     <div className="flex flex-col gap-y-4 mx-auto">
-      <TitleCard title="Export" paragraph="This will export your current collection to a CSV file." className="bg-amber-600" />
+      <TitleCard title={t('title')} paragraph={t('description')} className="bg-amber-600" />
       <div className="w-full text-center">
         <ExportWriter />
       </div>

--- a/frontend/src/pages/export/components/ExportWriter.tsx
+++ b/frontend/src/pages/export/components/ExportWriter.tsx
@@ -3,9 +3,11 @@ import { allCards } from '@/lib/CardsDB'
 import { CollectionContext } from '@/lib/context/CollectionContext'
 import type { ImportExportRow } from '@/types'
 import { use } from 'react'
+import { useTranslation } from 'react-i18next'
 import XLSX from 'xlsx'
 
 export const ExportWriter = () => {
+  const { t } = useTranslation('pages/export')
   const { ownedCards } = use(CollectionContext)
 
   const createFile = () => {
@@ -28,7 +30,7 @@ export const ExportWriter = () => {
 
   return (
     <Button onClick={() => createFile()} type="submit" className="w-40">
-      Download CSV file
+      {t('downloadCSV')}
     </Button>
   )
 }

--- a/frontend/src/pages/import/Import.tsx
+++ b/frontend/src/pages/import/Import.tsx
@@ -1,22 +1,20 @@
 import { TitleCard } from '@/components/ui/title-card'
 import { UserContext } from '@/lib/context/UserContext'
 import { use } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ImportReader } from './components/ImportReader'
 
 function Import() {
+  const { t } = useTranslation('pages/import')
   const { user } = use(UserContext)
 
   if (!user) {
-    return <TitleCard title={'Sign up to import your cards'} paragraph={'To import your spreadsheet, please log in.'} className="bg-gray-400" />
+    return <TitleCard title={t('loggedOut.title')} paragraph={t('loggedOut.description')} className="bg-gray-400" />
   }
 
   return (
     <div className="flex flex-col gap-y-4 max-w-[900px] mx-auto">
-      <TitleCard
-        title="Import"
-        paragraph="This will OVERWRITE your current collection with the values from the imported CSV file. ONLY do this process if your spreadsheet contains the exact count values you want in your collection."
-        className="bg-amber-600"
-      />
+      <TitleCard title={t('title')} paragraph={t('description')} className="bg-amber-600" />
       <div className="w-full border-2 border-indigo-600 rounded-xl p-4 text-center">
         <ImportReader />
       </div>

--- a/frontend/src/pages/import/components/ImportReader.tsx
+++ b/frontend/src/pages/import/components/ImportReader.tsx
@@ -4,9 +4,11 @@ import { UserContext } from '@/lib/context/UserContext'
 import type { CollectionRow, ImportExportRow } from '@/types'
 import { use, useCallback, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
+import { useTranslation } from 'react-i18next'
 import XLSX from 'xlsx'
 
 export const ImportReader = () => {
+  const { t } = useTranslation('pages/import')
   const { user } = use(UserContext)
   const { ownedCards, setOwnedCards } = use(CollectionContext)
 
@@ -72,12 +74,12 @@ export const ImportReader = () => {
 
     reader.onabort = () => {
       setIsLoading(false)
-      setErrorMessage('File Was Aborted')
+      setErrorMessage(t('fileWasAborted'))
     }
 
     reader.onerror = () => {
       setIsLoading(false)
-      setErrorMessage('Error With File')
+      setErrorMessage(t('errorWithFile'))
     }
 
     reader.onload = async (e) => {
@@ -91,7 +93,7 @@ export const ImportReader = () => {
         console.log('Processed File Rows')
       } catch (error) {
         console.error('Error processing Excel file:', error)
-        setErrorMessage(`Error processing Excel file: ${error}`)
+        setErrorMessage(`${t('errorProcessingExcel')}: ${error}`)
       } finally {
         setIsLoading(false)
       }
@@ -105,11 +107,11 @@ export const ImportReader = () => {
     <>
       <div {...getRootProps()}>
         <input {...getInputProps()} />
-        <p>Drag 'n' drop some files here, or click to select files</p>
+        <p>{t('dragNDrop')}</p>
       </div>
       {isLoading && (
         <>
-          <p>Excel file is loading</p>
+          <p>{t('loading')}</p>
           <progress className="w-full" value={numberProcessed} />
         </>
       )}
@@ -119,14 +121,14 @@ export const ImportReader = () => {
         <div>
           {processedData.length > 0 ? (
             <pre>
-              Data updated:
+              {t('dataUpdated')}
               <table className="w-full text-left table-auto">
                 <thead>
                   <tr>
-                    <th>Expansion Name</th>
-                    <th>ID</th>
-                    <th>Card Name</th>
-                    <th>Status (Count)</th>
+                    <th>{t('expansionName')}</th>
+                    <th>{t('id')}</th>
+                    <th>{t('cardName')}</th>
+                    <th>{t('statusCount')}</th>
                   </tr>
                 </thead>
                 {processedData.map((d, index) => (
@@ -134,14 +136,22 @@ export const ImportReader = () => {
                     <tr>
                       <td>{d.Id}</td>
                       <td>{d.CardName}</td>
-                      <td>{d.added ? `Added (${d.NumberOwned})` : d.updated ? `Updated (${d.NumberOwned})` : d.removed ? 'Removed' : 'Unknown'}</td>
+                      <td>
+                        {d.added
+                          ? t('added', { count: d.NumberOwned })
+                          : d.updated
+                            ? t('updated', { count: d.NumberOwned })
+                            : d.removed
+                              ? t('removed')
+                              : t('unknown')}
+                      </td>
                     </tr>
                   </tbody>
                 ))}
               </table>
             </pre>
           ) : (
-            <pre>No Data Updated.</pre>
+            <pre>{t('noDataUpdated')}</pre>
           )}
         </div>
       )}

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -13,10 +13,12 @@ import { NoSellableCards } from '@/pages/trade/components/NoSellableCards.tsx'
 import { NoTradeableCards } from '@/pages/trade/components/NoTradeableCards.tsx'
 import type { Card, Rarity } from '@/types'
 import { use, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { UserNotLoggedIn } from './components/UserNotLoggedIn'
 
 function Trade() {
+  const { t } = useTranslation('pages/trade')
   const navigate = useNavigate()
   const { user, account, setIsProfileDialogOpen } = use(UserContext)
   const { ownedCards, selectedCardId, setSelectedCardId } = use(CollectionContext)
@@ -85,13 +87,13 @@ function Trade() {
     let cardValues = ''
 
     if (account?.is_public) {
-      cardValues += `Public trade page: https://tcgpocketcollectiontracker.com/#/collection/${account?.friend_id}/trade\n`
+      cardValues += `${t('publicTradePage')} https://tcgpocketcollectiontracker.com/#/collection/${account?.friend_id}/trade\n`
     }
     if (account?.username) {
-      cardValues += `Friend ID: ${account.friend_id} (${account.username})\n\n`
+      cardValues += `${t('friendID')} ${account.friend_id} (${account.username})\n\n`
     }
 
-    cardValues += 'Looking for cards:\n'
+    cardValues += `${t('lookingForCards')}\n`
 
     const lookingForCardsSorted = lookingForCardsFiltered.sort((a, b) => {
       const expansionComparison = a.expansion.localeCompare(b.expansion)
@@ -111,7 +113,7 @@ function Trade() {
 
     const raritiesLookingFor = lookingForCardsFiltered.map((c) => c.rarity)
 
-    cardValues += '\n\nFor trade cards:\n'
+    cardValues += `\n\n${t('forTradeCards')}\n`
     const forTradeCardsSorted = forTradeCardsFiltered.filter((c) => raritiesLookingFor.includes(c.rarity)).sort((a, b) => a.rarity.localeCompare(b.rarity))
 
     for (let i = 0; i < forTradeCardsSorted.length; i++) {
@@ -127,7 +129,7 @@ function Trade() {
 
   const copyToClipboard = async () => {
     const cardValues = getCardValues()
-    toast({ title: 'Copied cards for trading to clipboard!', variant: 'default', duration: 3000 })
+    toast({ title: t('copiedInClipboard'), variant: 'default', duration: 3000 })
 
     await navigator.clipboard.writeText(cardValues)
   }
@@ -145,9 +147,9 @@ function Trade() {
       <Tabs defaultValue={currentTab} onValueChange={(value) => setCurrentTab(value)}>
         <div className="mx-auto max-w-[900px] flex flex-row flex-wrap align-center gap-x-4 gap-y-2 px-4">
           <TabsList className="flex-grow m-auto flex-wrap h-auto border-1 border-neutral-700 rounded-md">
-            <TabsTrigger value="looking_for">Looking For</TabsTrigger>
-            <TabsTrigger value="for_trade">For Trade</TabsTrigger>
-            <TabsTrigger value="buying_tokens">Buying Tokens</TabsTrigger>
+            <TabsTrigger value="looking_for">{t('lookingFor')}</TabsTrigger>
+            <TabsTrigger value="for_trade">{t('forTrade')}</TabsTrigger>
+            <TabsTrigger value="buying_tokens">{t('buyingTokens')}</TabsTrigger>
           </TabsList>
           <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
           <div className="sm:mt-1 flex flex-row flex-wrap align-center gap-x-4 gap-y-1">
@@ -165,11 +167,11 @@ function Trade() {
             </Button>
             {!account?.is_public ? (
               <Button variant="outline" onClick={() => enableTradingPage()}>
-                Enable trading page
+                {t('enableTradingPage')}
               </Button>
             ) : (
               <Button variant="outline" onClick={() => navigate(`/collection/${account?.friend_id}/trade`)}>
-                Open trading page
+                {t('openTradingPage')}
               </Button>
             )}
           </div>

--- a/frontend/src/pages/trade/components/GoTrackYourCards.tsx
+++ b/frontend/src/pages/trade/components/GoTrackYourCards.tsx
@@ -1,16 +1,15 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx'
 import { Siren } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 export function GoTrackYourCards() {
+  const { t } = useTranslation('pages/trade')
   return (
     <article className="mx-auto grid max-w-4xl gap-5">
       <Alert className="mb-8 border-1 border-neutral-700 shadow-none">
         <Siren className="h-4 w-4" />
-        <AlertTitle>Go track your cards</AlertTitle>
-        <AlertDescription>
-          By tracking your cards, you can see what cards you still need to get, what cards you can trade with friends, and how many trade tokens you can earn
-          with your current collection.
-        </AlertDescription>
+        <AlertTitle>{t('goTrackYourCards.title')}</AlertTitle>
+        <AlertDescription>{t('goTrackYourCards.description')}</AlertDescription>
       </Alert>
     </article>
   )

--- a/frontend/src/pages/trade/components/NoCardsNeeded.tsx
+++ b/frontend/src/pages/trade/components/NoCardsNeeded.tsx
@@ -1,13 +1,15 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx'
 import { Siren } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 export function NoCardsNeeded() {
+  const { t } = useTranslation('pages/trade')
   return (
     <article className="mx-auto grid max-w-4xl gap-5">
       <Alert className="mb-8 border-1 border-neutral-700 shadow-none">
         <Siren className="h-4 w-4" />
-        <AlertTitle>You have all tradeable cards!</AlertTitle>
-        <AlertDescription>Make sure you come back here when new rarities and packs are available for trade.</AlertDescription>
+        <AlertTitle>{t('noCardsNeeded.title')}</AlertTitle>
+        <AlertDescription>{t('noCardsNeeded.description')}</AlertDescription>
       </Alert>
     </article>
   )

--- a/frontend/src/pages/trade/components/NoSellableCards.tsx
+++ b/frontend/src/pages/trade/components/NoSellableCards.tsx
@@ -1,15 +1,15 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx'
 import { Siren } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 export function NoSellableCards() {
+  const { t } = useTranslation('pages/trade')
   return (
     <article className="mx-auto grid max-w-4xl gap-5">
       <Alert className="mb-8 border-1 border-neutral-700 shadow-none">
         <Siren className="h-4 w-4" />
-        <AlertTitle>You have no sellable cards!</AlertTitle>
-        <AlertDescription>
-          If you believe you have sellable cards, go to the collections page and input your collected cards to see what you can sell.
-        </AlertDescription>
+        <AlertTitle>{t('noSellableCards.title')}</AlertTitle>
+        <AlertDescription>{t('noSellableCards.description')}</AlertDescription>
       </Alert>
     </article>
   )

--- a/frontend/src/pages/trade/components/NoTradeableCards.tsx
+++ b/frontend/src/pages/trade/components/NoTradeableCards.tsx
@@ -1,13 +1,15 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx'
 import { Siren } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 export function NoTradeableCards() {
+  const { t } = useTranslation('pages/trade')
   return (
     <article className="mx-auto grid max-w-4xl gap-5">
       <Alert className="mb-8 border-1 border-neutral-700 shadow-none">
         <Siren className="h-4 w-4" />
-        <AlertTitle>You have no tradeable cards!</AlertTitle>
-        <AlertDescription>Go to the collections page and input your collected cards to see what you can trade.</AlertDescription>
+        <AlertTitle>{t('noTradeableCards.title')}</AlertTitle>
+        <AlertDescription>{t('noTradeableCards.description')}</AlertDescription>
       </Alert>
     </article>
   )

--- a/frontend/src/pages/trade/components/UserNotLoggedIn.tsx
+++ b/frontend/src/pages/trade/components/UserNotLoggedIn.tsx
@@ -1,13 +1,15 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx'
 import { Siren } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 export function UserNotLoggedIn() {
+  const { t } = useTranslation('pages/trade')
   return (
     <article className="mx-auto grid max-w-4xl gap-5">
       <Alert className="mb-8 border-1 border-neutral-700 shadow-none">
         <Siren className="h-4 w-4" />
-        <AlertTitle>Sign up to view your tradeable cards</AlertTitle>
-        <AlertDescription>By registering, you can keep track of your collection, trade with other users, and access exclusive features.</AlertDescription>
+        <AlertTitle>{t('notLoggedIn.title')}</AlertTitle>
+        <AlertDescription>{t('notLoggedIn.description')}</AlertDescription>
       </Alert>
     </article>
   )


### PR DESCRIPTION
I added missing translatable strings that I found across the frontend in en-US locales and their French translations in fr-FR locales.

I hope I did not miss any strings. 
I wanted to add the rule `react/jsx-no-literals` from [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react) but it does not seem to exist an equivalent with biomejs ([https://github.com/biomejs/biome/discussions/4999](https://github.com/biomejs/biome/discussions/4999))