### PR TITLE
fix: improve collection/trade page scrolling and add sticky filter bar (fixes #478)

### DIFF
--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -2,7 +2,7 @@ import useWindowDimensions from '@/lib/hooks/useWindowDimensionsHook.ts'
 import type { Card as CardType } from '@/types'
 import { type Row, createColumnHelper, getCoreRowModel, getGroupedRowModel, useReactTable } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card } from './Card.tsx'
 
@@ -18,30 +18,10 @@ export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const { width } = useWindowDimensions()
   const { t } = useTranslation('common/sets')
-  const [scrollContainerHeight, setScrollContainerHeight] = useState('auto')
-
-  useLayoutEffect(() => {
-    const updateScrollContainerHeight = () => {
-      if (scrollRef.current) {
-        const headerHeight = (document.querySelector('#header') as HTMLElement | null)?.offsetHeight || 0
-        const filterbarHeight = (document.querySelector('#filterbar') as HTMLElement | null)?.offsetHeight || 0
-        const maxHeight = window.innerHeight - headerHeight - filterbarHeight
-
-        setScrollContainerHeight(`${maxHeight}px`)
-      }
-    }
-
-    updateScrollContainerHeight() // initial calculation
-    window.addEventListener('resize', updateScrollContainerHeight)
-
-    return () => {
-      window.removeEventListener('resize', updateScrollContainerHeight)
-    }
-  }, []) // You can add dependencies here if needed
 
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = 0
+    if (resetScrollTrigger) {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }, [resetScrollTrigger])
 
@@ -118,11 +98,7 @@ export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
   })
 
   return (
-    <div
-      ref={scrollRef}
-      className="overflow-y-auto mt-2 sm:mt-4 px-4 flex flex-col justify-start"
-      style={{ scrollbarWidth: 'none', height: scrollContainerHeight }}
-    >
+    <div ref={scrollRef} className="mt-2 sm:mt-4 px-4 flex flex-col justify-start min-h-screen">
       {showStats && (
         <small className="text-left md:text-right mb-3 md:mb-[-25px] md:mt-[10px]">
           {cards.filter((c) => !c.linkedCardID).length} selected, {cards.filter((card) => (card.amount_owned ?? 0) > 0).length} uniques owned,{' '}

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -138,7 +138,7 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
   }
 
   return (
-    <div id="filterbar" className="flex flex-col gap-x-2 flex-wrap">
+    <div id="filterbar" className="sticky top-0 z-10 bg-neutral-900 border-b flex flex-col gap-x-2 flex-wrap">
       {children}
 
       <div className="flex items-center gap-2 flex-col md:flex-row gap-y-1 px-4 mb-2">
@@ -152,7 +152,7 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
           />
         )}
       </div>
-      <div className="items-center gap-2 flex-row gap-y-1 px-4 flex">
+      <div className="items-center gap-2 flex-row gap-y-1 px-4 flex pb-2">
         {visibleFilters?.search && <SearchInput setSearchValue={setSearchValue} />}
         {visibleFilters?.owned && <OwnedFilter ownedFilter={ownedFilter} setOwnedFilter={setOwnedFilter} />}
         {visibleFilters?.rarity && <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} collapse />}

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -138,7 +138,7 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
   }
 
   return (
-    <div id="filterbar" className="sticky top-0 z-10 bg-neutral-900 border-b flex flex-col gap-x-2 flex-wrap">
+    <div id="filterbar" className="sticky top-0 z-10 bg-neutral-900 border-b border-neutral-700 flex flex-col gap-x-2 flex-wrap">
       {children}
 
       <div className="flex items-center gap-2 flex-col md:flex-row gap-y-1 px-4 mb-2">

--- a/frontend/src/components/MissionsTable.tsx
+++ b/frontend/src/components/MissionsTable.tsx
@@ -1,5 +1,5 @@
 import type { Mission as MissionType } from '@/types'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { Mission } from './Mission.tsx'
 
 interface Props {
@@ -9,39 +9,15 @@ interface Props {
 
 export function MissionsTable({ missions, resetScrollTrigger }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null)
-  const [scrollContainerHeight, setScrollContainerHeight] = useState('auto')
-
-  useLayoutEffect(() => {
-    const updateScrollContainerHeight = () => {
-      if (scrollRef.current) {
-        const headerHeight = (document.querySelector('#header') as HTMLElement | null)?.offsetHeight || 0
-        const filterbarHeight = (document.querySelector('#filterbar') as HTMLElement | null)?.offsetHeight || 0
-        const maxHeight = window.innerHeight - headerHeight - filterbarHeight
-
-        setScrollContainerHeight(`${maxHeight}px`)
-      }
-    }
-
-    updateScrollContainerHeight()
-    window.addEventListener('resize', updateScrollContainerHeight)
-
-    return () => {
-      window.removeEventListener('resize', updateScrollContainerHeight)
-    }
-  }, [])
 
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = 0
+    if (resetScrollTrigger) {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }, [resetScrollTrigger])
 
   return (
-    <div
-      ref={scrollRef}
-      className="overflow-y-auto mt-2 sm:mt-4 px-4 flex flex-col justify-start"
-      style={{ scrollbarWidth: 'none', height: scrollContainerHeight }}
-    >
+    <div ref={scrollRef} className="mt-2 sm:mt-4 px-4 flex flex-col justify-start min-h-screen">
       {missions.map((mission) => (
         <Mission key={mission.name} mission={mission} />
       ))}

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -143,35 +143,37 @@ function Trade() {
   return (
     <div className="flex flex-col gap-y-4">
       <Tabs defaultValue={currentTab} onValueChange={(value) => setCurrentTab(value)}>
-        <div className="mx-auto max-w-[900px] flex flex-row flex-wrap align-center gap-x-4 gap-y-2 px-4">
-          <TabsList className="flex-grow m-auto flex-wrap h-auto border-1 border-neutral-700 rounded-md">
-            <TabsTrigger value="looking_for">Looking For</TabsTrigger>
-            <TabsTrigger value="for_trade">For Trade</TabsTrigger>
-            <TabsTrigger value="buying_tokens">Buying Tokens</TabsTrigger>
-          </TabsList>
-          <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
-          <div className="sm:mt-1 flex flex-row flex-wrap align-center gap-x-4 gap-y-1">
-            {currentTab === 'looking_for' && (
-              <NumberFilter numberFilter={forTradeMinCards} setNumberFilter={setForTradeMinCards} options={[0, 1, 2, 3, 4, 5]} labelKey="maxNum" />
-            )}
-            {currentTab === 'for_trade' && (
-              <NumberFilter numberFilter={lookingForMinCards} setNumberFilter={setLookingForMinCards} options={[2, 3, 4, 5]} labelKey="minNum" />
-            )}
-            {currentTab === 'buying_tokens' && (
-              <NumberFilter numberFilter={buyingTokensMinCards} setNumberFilter={setBuyingTokensMinCards} options={[2, 3, 4, 5]} labelKey="minNum" />
-            )}
-            <Button variant="outline" onClick={() => copyToClipboard()}>
-              Copy to clipboard
-            </Button>
-            {!account?.is_public ? (
-              <Button variant="outline" onClick={() => enableTradingPage()}>
-                Enable trading page
+        <div className="sticky top-0 z-10 bg-neutral-900 border-b pb-2">
+          <div className="mx-auto max-w-[900px] flex flex-row flex-wrap align-center gap-x-4 gap-y-2 px-4 pt-2">
+            <TabsList className="flex-grow m-auto flex-wrap h-auto border-1 border-neutral-700 rounded-md">
+              <TabsTrigger value="looking_for">Looking For</TabsTrigger>
+              <TabsTrigger value="for_trade">For Trade</TabsTrigger>
+              <TabsTrigger value="buying_tokens">Buying Tokens</TabsTrigger>
+            </TabsList>
+            <RarityFilter rarityFilter={rarityFilter} setRarityFilter={setRarityFilter} />
+            <div className="sm:mt-1 flex flex-row flex-wrap align-center gap-x-4 gap-y-1">
+              {currentTab === 'looking_for' && (
+                <NumberFilter numberFilter={forTradeMinCards} setNumberFilter={setForTradeMinCards} options={[0, 1, 2, 3, 4, 5]} labelKey="maxNum" />
+              )}
+              {currentTab === 'for_trade' && (
+                <NumberFilter numberFilter={lookingForMinCards} setNumberFilter={setLookingForMinCards} options={[2, 3, 4, 5]} labelKey="minNum" />
+              )}
+              {currentTab === 'buying_tokens' && (
+                <NumberFilter numberFilter={buyingTokensMinCards} setNumberFilter={setBuyingTokensMinCards} options={[2, 3, 4, 5]} labelKey="minNum" />
+              )}
+              <Button variant="outline" onClick={() => copyToClipboard()}>
+                Copy to clipboard
               </Button>
-            ) : (
-              <Button variant="outline" onClick={() => navigate(`/collection/${account?.friend_id}/trade`)}>
-                Open trading page
-              </Button>
-            )}
+              {!account?.is_public ? (
+                <Button variant="outline" onClick={() => enableTradingPage()}>
+                  Enable trading page
+                </Button>
+              ) : (
+                <Button variant="outline" onClick={() => navigate(`/collection/${account?.friend_id}/trade`)}>
+                  Open trading page
+                </Button>
+              )}
+            </div>
           </div>
         </div>
         <div className="mx-auto max-w-[900px] ">

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -143,7 +143,7 @@ function Trade() {
   return (
     <div className="flex flex-col gap-y-4">
       <Tabs defaultValue={currentTab} onValueChange={(value) => setCurrentTab(value)}>
-        <div className="sticky top-0 z-10 bg-neutral-900 border-b pb-2">
+        <div className="sticky top-0 z-10 bg-neutral-900 border-b border-neutral-700 pb-2">
           <div className="mx-auto max-w-[900px] flex flex-row flex-wrap align-center gap-x-4 gap-y-2 px-4 pt-2">
             <TabsList className="flex-grow m-auto flex-wrap h-auto border-1 border-neutral-700 rounded-md">
               <TabsTrigger value="looking_for">Looking For</TabsTrigger>


### PR DESCRIPTION
Here's my try on the scrolling behavior for the collection and trade page.

The whole page can now scroll the cards, the filter bar in the collection page becomes sticky and, when used, the page scroll to the top.

Height calculation logic has been removed.

I'll add the sticky bar in the trade page now (forgot it!).