### PR TITLE
fix: firefox 3D hover effect

### DIFF
--- a/frontend/src/components/FancyCard.tsx
+++ b/frontend/src/components/FancyCard.tsx
@@ -74,7 +74,7 @@ function FancyCard({ selected, setIsSelected, card, size = 'default', clickable 
       style={{
         flex: '1 0 20%',
         perspective: '1000px',
-        transformStyle: 'preserve-3d',
+        transformStyle: typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('firefox') ? 'flat' : 'preserve-3d', // Transform override to fix firefox issue
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',


### PR DESCRIPTION
Fixes #426 by adding transform override exclusive to firefox. 
The comparison of the old and updated behaviour can be seen in that Issue
