### PR TITLE
add footer on homepage + modal with licenses disclaimer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import loadable from '@loadable/component'
 import { useEffect, useMemo, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { Route, Routes, useLocation } from 'react-router'
+import Footer from './components/Footer.tsx'
 import { Header } from './components/Header.tsx'
 import { Toaster } from './components/ui/toaster.tsx'
 import { CollectionContext } from './lib/context/CollectionContext.ts'
@@ -22,6 +23,7 @@ const EditProfile = loadable(() => import('./components/EditProfile.tsx'))
 function App() {
   const { toast } = useToast()
   const location = useLocation()
+  const isOverviewPage = location.pathname === '/'
 
   const [user, setUser] = useState<User | null>(null)
   const [account, setAccount] = useState<AccountRow | null>(null)
@@ -103,6 +105,7 @@ function App() {
           </Routes>
           <EditProfile account={account} setAccount={setAccount} isProfileDialogOpen={isProfileDialogOpen} setIsProfileDialogOpen={setIsProfileDialogOpen} />
           <InstallPrompt />
+          {isOverviewPage && <Footer />}
         </ErrorBoundary>
       </CollectionContext.Provider>
     </UserContext.Provider>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import { LicenseModal } from './LicenseModal'
+
+export default function Footer() {
+  const [showLicense, setShowLicense] = useState(false)
+
+  return (
+    <>
+      <footer className="text-center py-2 bg-[#1a1a1a] text-gray-400 text-xs leading-snug">
+        <p className="m-0">
+          © 2025 TCG Pocket Collection Tracker.{' '}
+          <button
+            type="button"
+            onClick={() => setShowLicense(true)}
+            className="text-blue-500 underline hover:text-blue-600 bg-transparent border-none cursor-pointer p-0"
+          >
+            License & Disclaimer
+          </button>
+        </p>
+        <p className="m-0 mt-1">
+          Not affiliated with Nintendo, Creatures Inc., GAME FREAK Inc., or DeNA Co., Ltd. All trademarks and assets belong to their respective owners.
+        </p>
+      </footer>
+
+      {showLicense && <LicenseModal onClose={() => setShowLicense(false)} />}
+    </>
+  )
+}

--- a/frontend/src/components/LicenseModal.tsx
+++ b/frontend/src/components/LicenseModal.tsx
@@ -1,0 +1,25 @@
+export function LicenseModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white text-gray-800 p-6 rounded-lg shadow-lg max-w-lg w-full overflow-y-auto max-h-[80vh] leading-relaxed">
+        <h2 className="text-xl font-semibold mb-4">License & Legal Disclaimer</h2>
+        <p className="text-sm mb-2">
+          This project, <strong>TCG Pocket Collection Tracker</strong>, is open source and licensed under the{' '}
+          <a href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank" rel="noopener noreferrer" className="underline text-blue-600">
+            GNU General Public License v3.0
+          </a>
+          . You are free to use, modify, and distribute this software under the terms of that license, as long as you also share your changes under the same
+          license.
+        </p>
+        <p className="text-sm mb-2">
+          <strong>Disclaimer:</strong> This project is not affiliated with, endorsed by, or sponsored by Nintendo, Creatures Inc., GAME FREAK Inc., or DeNA Co.,
+          Ltd. All Pokémon-related assets, names, and trademarks are the property of their respective owners.
+        </p>
+        <p className="text-sm">All original code and content in this project is © 2025 TCG Pocket Collection Tracker.</p>
+        <button type="button" onClick={onClose} className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/LicenseModal.tsx
+++ b/frontend/src/components/LicenseModal.tsx
@@ -1,24 +1,32 @@
+import { useEffect } from 'react'
+
 export function LicenseModal({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const esc = (e: KeyboardEvent) => e.key === 'Escape' && onClose()
+    document.addEventListener('keydown', esc)
+    return () => document.removeEventListener('keydown', esc)
+  }, [onClose])
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white text-gray-800 p-6 rounded-lg shadow-lg max-w-lg w-full overflow-y-auto max-h-[80vh] leading-relaxed">
+    <div onClick={handleBackdropClick} className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-white text-gray-800 p-6 sm:p-8 rounded-lg shadow-lg w-full max-w-lg mx-4">
         <h2 className="text-xl font-semibold mb-4">License & Legal Disclaimer</h2>
         <p className="text-sm mb-2">
           This project, <strong>TCG Pocket Collection Tracker</strong>, is open source and licensed under the{' '}
           <a href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank" rel="noopener noreferrer" className="underline text-blue-600">
             GNU General Public License v3.0
           </a>
-          . You are free to use, modify, and distribute this software under the terms of that license, as long as you also share your changes under the same
-          license.
+          . You are free to use, modify, and distribute this software under the terms of such license.
         </p>
         <p className="text-sm mb-2">
           <strong>Disclaimer:</strong> This project is not affiliated with, endorsed by, or sponsored by Nintendo, Creatures Inc., GAME FREAK Inc., or DeNA Co.,
           Ltd. All Pokémon-related assets, names, and trademarks are the property of their respective owners.
         </p>
         <p className="text-sm">All original code and content in this project is © 2025 TCG Pocket Collection Tracker.</p>
-        <button type="button" onClick={onClose} className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
-          Close
-        </button>
       </div>
     </div>
   )

--- a/frontend/src/components/LicenseModal.tsx
+++ b/frontend/src/components/LicenseModal.tsx
@@ -16,7 +16,16 @@ export function LicenseModal({ onClose }: { onClose: () => void }) {
       <div className="bg-white text-gray-800 p-6 sm:p-8 rounded-lg shadow-lg w-full max-w-lg mx-4">
         <h2 className="text-xl font-semibold mb-4">License & Legal Disclaimer</h2>
         <p className="text-sm mb-2">
-          This project, <strong>TCG Pocket Collection Tracker</strong>, is open source and licensed under the{' '}
+          This project, <strong>TCG Pocket Collection Tracker</strong>, is open source (
+          <a
+            href="https://https://github.com/marcelpanse/tcg-pocket-collection-tracker"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-blue-600"
+          >
+            GitHub repoository
+          </a>
+          ) and licensed under the{' '}
           <a href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank" rel="noopener noreferrer" className="underline text-blue-600">
             GNU General Public License v3.0
           </a>


### PR DESCRIPTION
- added a footer on overview page to disclose the project is not affiliated to the parent companies of the game and declare their trademarks
- added modal component invoked with footer to fully disclose the project's GNU License, © of TCG Pocket Collection Tracker and a more robust disclaimer about the owners of the respective trademarks and assets
