### PR TITLE
fix phone scrolling + remove need for desktop scrollbar on collection page

### DIFF
--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -25,8 +25,9 @@ export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
       if (scrollRef.current) {
         const headerHeight = (document.querySelector('#header') as HTMLElement | null)?.offsetHeight || 0
         const filterbarHeight = (document.querySelector('#filterbar') as HTMLElement | null)?.offsetHeight || 0
-        const maxHeight = window.innerHeight - headerHeight - filterbarHeight
-
+        const isMobileDevice = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) // Detect phones and tablets using user agent
+        const extraOffset = isMobileDevice ? 0 : 24 // if not Mobile then applies -24 extraOffset to avoid scrollbars in Collection Page
+        const maxHeight = window.innerHeight - headerHeight - filterbarHeight - extraOffset
         setScrollContainerHeight(`${maxHeight}px`)
       }
     }
@@ -120,7 +121,7 @@ export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
   return (
     <div
       ref={scrollRef}
-      className="overflow-y-auto mt-2 sm:mt-4 px-4 flex flex-col justify-start"
+      className="overflow-y-auto overflow-x-hidden mt-2 sm:mt-4 px-4 flex flex-col justify-start w-full"
       style={{ scrollbarWidth: 'none', height: scrollContainerHeight }}
     >
       {showStats && (


### PR DESCRIPTION
- fix scrolling on phone to avoid side-wiggles
- extra offset to remove scrollbars on desktop's collection page since it served no purpose, and we scroll the cards table
  - this extra offset is not considered if mobile device is detected to avoid cutting off content visually on phones

I also tested this on 4K resolution, Android, iOS. 
It should work just fine but of course let me know if any change is needed or feel free to edit later.

Here's a video of a side by side comparison of the behaviour on live website vs my edits on desktop and a screen recording of the wiggling behaviour on phone also addressed in this commit.


https://github.com/user-attachments/assets/5525700d-97f2-4148-a3e1-847501fa8ca2


https://github.com/user-attachments/assets/412c6377-4594-4cc6-bd14-a68bbe5dba5c




