### PR TITLE
fix: improve layout with offset logic (no scrollbars)

### DIFF
--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -12,9 +12,10 @@ interface Props {
   cards: CardType[]
   resetScrollTrigger?: boolean
   showStats?: boolean
+  extraOffset: number
 }
 
-export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
+export function CardsTable({ cards, resetScrollTrigger, showStats, extraOffset }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const { width } = useWindowDimensions()
   const { t } = useTranslation('common/sets')
@@ -26,8 +27,8 @@ export function CardsTable({ cards, resetScrollTrigger, showStats }: Props) {
         const headerHeight = (document.querySelector('#header') as HTMLElement | null)?.offsetHeight || 0
         const filterbarHeight = (document.querySelector('#filterbar') as HTMLElement | null)?.offsetHeight || 0
         const isMobileDevice = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) // Detect phones and tablets using user agent
-        const extraOffset = isMobileDevice ? 0 : 24 // if not Mobile then applies -24 extraOffset to avoid scrollbars in Collection Page
-        const maxHeight = window.innerHeight - headerHeight - filterbarHeight - extraOffset
+        const offset = isMobileDevice ? 0 : extraOffset // Offset is ignored on mobile, but needed on desktop to keep CardsTable in the viewport. Collection uses 24, Trade uses 105.
+        const maxHeight = window.innerHeight - headerHeight - filterbarHeight - offset
         setScrollContainerHeight(`${maxHeight}px`)
       }
     }

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -115,8 +115,10 @@ function Collection() {
           )}
         </div>
       </FilterPanel>
-      <div>{filteredCards && !missions && <CardsTable cards={filteredCards} resetScrollTrigger={resetScrollTrigger} showStats />}</div>
-      {selectedCardId && <CardDetail cardId={selectedCardId} onClose={() => setSelectedCardId('')} />}
+      <div>
+        {filteredCards && !missions && <CardsTable cards={filteredCards} resetScrollTrigger={resetScrollTrigger} showStats extraOffset={24} />}
+        {selectedCardId && <CardDetail cardId={selectedCardId} onClose={() => setSelectedCardId('')} />}
+      </div>
       <div>{missions && <MissionsTable missions={missions} resetScrollTrigger={resetScrollTrigger} />}</div>
       {missions && <MissionDetail missionCardOptions={selectedMissionCardOptions} onClose={() => setSelectedMissionCardOptions([])} />}
       <TradeMatches ownedCards={ownedCards} friendCards={friendCards || []} ownAccount={account} friendAccount={friendAccount} />

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -178,13 +178,14 @@ function Trade() {
         </div>
         <div className="mx-auto max-w-[900px] ">
           <TabsContent value="looking_for">
-            {lookingForCards && lookingForCards.length > 0 ? <CardsTable cards={lookingForCardsFiltered} /> : <NoCardsNeeded />}
+            {lookingForCards && lookingForCards.length > 0 ? <CardsTable cards={lookingForCardsFiltered} extraOffset={105} /> : <NoCardsNeeded />}
           </TabsContent>
           <TabsContent value="for_trade">
-            {forTradeCards && forTradeCards.length > 0 ? <CardsTable cards={forTradeCardsFiltered} /> : <NoTradeableCards />}
+            {forTradeCards && forTradeCards.length > 0 ? <CardsTable cards={forTradeCardsFiltered} extraOffset={105} /> : <NoTradeableCards />}
           </TabsContent>
+
           <TabsContent value="buying_tokens">
-            {buyingTokensCards && buyingTokensCards.length > 0 ? <CardsTable cards={buyingTokensCardsFiltered} /> : <NoSellableCards />}
+            {buyingTokensCards && buyingTokensCards.length > 0 ? <CardsTable cards={buyingTokensCardsFiltered} extraOffset={105} /> : <NoSellableCards />}
           </TabsContent>
         </div>
       </Tabs>


### PR DESCRIPTION
- reworked extraOffset calculation in CardsTable to take into account the different needs in collection and trade pages

Now even Trade page is getting the offset treatment so that we don't have unneeded scrollbars, I'm hopeful someone more experienced is going to come up with something better in the future, but this will do for now :P 