### PR TITLE
feat: rework filter clear button for better UX

### DIFF
--- a/frontend/public/locales/en-US/pages/collection.json
+++ b/frontend/public/locales/en-US/pages/collection.json
@@ -10,6 +10,7 @@
   "filters": {
     "allFilters": "All filters",
     "filtersCount": "Filters ({{count}})",
+    "clear": "Clear filters",
     "share": "Share"
   }
 }

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -202,22 +202,6 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
                 {filtersDialog.search && (
                   <div className="flex items-center gap-2">
                     <SearchInput setSearchValue={setSearchValue} fullWidth />
-                    <Button
-                      variant="outline"
-                      onClick={() => {
-                        setSearchValue('')
-                        setExpansionFilter('all')
-                        setPackFilter('all')
-                        setCardTypeFilter([])
-                        setRarityFilter([])
-                        setOwnedFilter('all')
-                        setSortBy('default')
-                        setNumberFilter(0)
-                        setMaxNumberFilter(100)
-                      }}
-                    >
-                      ↩️
-                    </Button>
                   </div>
                 )}
                 {filtersDialog.expansions && (
@@ -244,6 +228,23 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
                     />
                   </>
                 )}
+                <Button
+                  variant="outline"
+                  className="!text-red-700"
+                  onClick={() => {
+                    setSearchValue('')
+                    setExpansionFilter('all')
+                    setPackFilter('all')
+                    setCardTypeFilter([])
+                    setRarityFilter([])
+                    setOwnedFilter('all')
+                    setSortBy('default')
+                    setNumberFilter(0)
+                    setMaxNumberFilter(100)
+                  }}
+                >
+                  {t('filters.clear')}
+                </Button>
               </div>
             </DialogContent>
           </Dialog>

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -199,7 +199,27 @@ const FilterPanel: FC<Props> = ({ children, cards, onFiltersChanged, onChangeToM
                 <DialogTitle>{t('filters.filtersCount', { count: (getFilteredCards || []).filter((c) => !c.linkedCardID).length })}</DialogTitle>
               </DialogHeader>
               <div className="flex flex-col gap-3">
-                {filtersDialog.search && <SearchInput setSearchValue={setSearchValue} fullWidth />}
+                {filtersDialog.search && (
+                  <div className="flex items-center gap-2">
+                    <SearchInput setSearchValue={setSearchValue} fullWidth />
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        setSearchValue('')
+                        setExpansionFilter('all')
+                        setPackFilter('all')
+                        setCardTypeFilter([])
+                        setRarityFilter([])
+                        setOwnedFilter('all')
+                        setSortBy('default')
+                        setNumberFilter(0)
+                        setMaxNumberFilter(100)
+                      }}
+                    >
+                      ↩️
+                    </Button>
+                  </div>
+                )}
                 {filtersDialog.expansions && (
                   <ExpansionsFilter
                     expansionFilter={expansionFilter}


### PR DESCRIPTION
sorry for accidentally closing #501, I literally forgot I was gonna rework this.

anyway:
- Reworked button to clear all filters at once instead of having to click one by one
- Changed button text to red to improve clarity of action
- Added string in en-US localization

Quick question: when we add new strings intended for translation (like I did here), should we also update the other language files with English placeholders? Or is it expected that translators will review the English file and manually copy over any new strings into their own language files?

I’m asking because when I first started localizing into my language, I struggled to figure out why certain elements weren’t translatable. It turned out they were simply missing from the language files. I had to manually copy the missing strings from the English file to make them available.
Just wanna make sure I’m approaching this correctly moving forward. Thanks for your clarifications.