### PR TITLE
Expansions filter as dropdown

### DIFF
--- a/frontend/public/locales/en-US/common/sets.json
+++ b/frontend/public/locales/en-US/common/sets.json
@@ -1,4 +1,6 @@
 {
+  "expansion": "Expansion",
+
   "geneticapex": "Genetic Apex",
   "mythicalisland": "Mythical Island",
   "space-timesmackdown": "Space-Time Smackdown",

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -228,8 +228,8 @@ const FilterPanel: FC<Props> = ({
 
       {visibleFilters?.expansions && (
         <div className="flex gap-x-2 px-4 mb-2">
-          <ExpansionsFilter expansionFilter={filters.expansion} onChange={onExpansionChange} />
-          <PackFilter packFilter={filters.pack} setPackFilter={setPack} expansion={filters.expansion} />
+          <ExpansionsFilter value={filters.expansion} onChange={onExpansionChange} />
+          <PackFilter value={filters.pack} onChange={setPack} expansion={filters.expansion} />
         </div>
       )}
       <div className="items-center gap-2 flex-row gap-y-1 px-4 flex">
@@ -248,8 +248,8 @@ const FilterPanel: FC<Props> = ({
               </DialogHeader>
               <div className="flex flex-col gap-3">
                 {filtersDialog.search && <SearchInput setSearchValue={setSearchValue} fullWidth />}
-                {filtersDialog.expansions && <ExpansionsFilter expansionFilter={filters.expansion} onChange={onExpansionChange} />}
-                {filtersDialog.pack && <PackFilter packFilter={filters.pack} setPackFilter={setPack} expansion={filters.expansion} fullWidth />}
+                {filtersDialog.expansions && <ExpansionsFilter value={filters.expansion} onChange={onExpansionChange} />}
+                {filtersDialog.pack && <PackFilter value={filters.pack} onChange={setPack} expansion={filters.expansion} fullWidth />}
                 {filtersDialog.rarity && <RarityFilter rarityFilter={filters.rarity} setRarityFilter={setRarity} />}
                 {filtersDialog.cardType && <CardTypeFilter cardTypeFilter={filters.cardType} setCardTypeFilter={setCardType} />}
                 {filtersDialog.owned && <OwnedFilter ownedFilter={filters.owned} setOwnedFilter={setOwned} fullWidth />}

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -217,15 +217,21 @@ const FilterPanel: FC<Props> = ({
     await updateMultipleCards(cardIds, amount, ownedCards, setOwnedCards, user)
   }
 
+  function onExpansionChange(x: string) {
+    setExpansion(x)
+    setPack('all')
+  }
+
   return (
     <div id="filterbar" className="flex flex-col gap-x-2 flex-wrap">
       {children}
 
-      <div className="flex items-center gap-2 flex-col md:flex-row gap-y-1 px-4 mb-2">
-        {visibleFilters?.expansions && (
-          <ExpansionsFilter expansionFilter={filters.expansion} setExpansionFilter={setExpansion} setPackFilter={setPack} packFilter={filters.pack} showPacks />
-        )}
-      </div>
+      {visibleFilters?.expansions && (
+        <div className="flex gap-x-2 px-4 mb-2">
+          <ExpansionsFilter expansionFilter={filters.expansion} onChange={onExpansionChange} />
+          <PackFilter packFilter={filters.pack} setPackFilter={setPack} expansion={filters.expansion} />
+        </div>
+      )}
       <div className="items-center gap-2 flex-row gap-y-1 px-4 flex">
         {visibleFilters?.search && <SearchInput setSearchValue={setSearchValue} />}
         {visibleFilters?.owned && <OwnedFilter ownedFilter={filters.owned} setOwnedFilter={setOwned} />}
@@ -242,9 +248,7 @@ const FilterPanel: FC<Props> = ({
               </DialogHeader>
               <div className="flex flex-col gap-3">
                 {filtersDialog.search && <SearchInput setSearchValue={setSearchValue} fullWidth />}
-                {filtersDialog.expansions && (
-                  <ExpansionsFilter expansionFilter={filters.expansion} setExpansionFilter={setExpansion} setPackFilter={setPack} packFilter={filters.pack} />
-                )}
+                {filtersDialog.expansions && <ExpansionsFilter expansionFilter={filters.expansion} onChange={onExpansionChange} />}
                 {filtersDialog.pack && <PackFilter packFilter={filters.pack} setPackFilter={setPack} expansion={filters.expansion} fullWidth />}
                 {filtersDialog.rarity && <RarityFilter rarityFilter={filters.rarity} setRarityFilter={setRarity} />}
                 {filtersDialog.cardType && <CardTypeFilter cardTypeFilter={filters.cardType} setCardTypeFilter={setCardType} />}

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -3,17 +3,16 @@ import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
-  expansionFilter: string
+  value: string
   onChange: (expansion: string) => void
-  className?: string
 }
-const ExpansionsFilter: FC<Props> = ({ expansionFilter, onChange }) => {
+const ExpansionsFilter: FC<Props> = ({ value, onChange }) => {
   const { t } = useTranslation('common/sets')
 
   return (
     <label className="flex items-baseline justify-between gap-5 px-3 my-auto border-1 border-neutral-700 rounded-md p-1 bg-neutral-800 text-neutral-400">
       <h2 className="h-full">Expansion</h2>
-      <select value={expansionFilter} onChange={(e) => onChange(e.target.value)} className="min-h-[2rem]">
+      <select value={value} onChange={(e) => onChange(e.target.value)} className="min-h-[2rem]">
         <option value="all">{t('all')}</option>
         {expansions.map((expansion) => (
           <option key={expansion.id} value={expansion.id}>

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -1,42 +1,27 @@
-import PackFilter from '@/components/filters/PackFilter.tsx'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs.tsx'
 import { expansions } from '@/lib/CardsDB.ts'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
   expansionFilter: string
-  setExpansionFilter: (expansionFilter: string) => void
-  packFilter: string
-  setPackFilter: (packFilter: string) => void
-  showPacks?: boolean
+  onChange: (expansion: string) => void
+  className?: string
 }
-const ExpansionsFilter: FC<Props> = ({ expansionFilter, setExpansionFilter, setPackFilter, packFilter, showPacks }) => {
+const ExpansionsFilter: FC<Props> = ({ expansionFilter, onChange }) => {
   const { t } = useTranslation('common/sets')
 
   return (
-    <div className="w-full flex flex-row gap-x-2 items-stretch">
-      <Tabs
-        value={expansionFilter}
-        onValueChange={(value) => {
-          setExpansionFilter(value)
-          setPackFilter('all')
-        }}
-        className="grow-3"
-      >
-        <TabsList className="w-full flex-wrap h-full border-1 border-neutral-700 rounded-md justify-center content-start">
-          <TabsTrigger value="all">{t('all')}</TabsTrigger>
-          {expansions.map((expansion) => (
-            <TabsTrigger key={`tab_trigger_${expansion.id}`} value={expansion.id}>
-              <div className="flex flex-col items-center gap-1">
-                <span>{t(expansion.name)}</span>
-              </div>
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </Tabs>
-      {showPacks && <PackFilter packFilter={packFilter} setPackFilter={setPackFilter} expansion={expansionFilter} />}
-    </div>
+    <label className="flex items-baseline justify-between gap-5 px-3 my-auto border-1 border-neutral-700 rounded-md p-1 bg-neutral-800 text-neutral-400">
+      <h2 className="h-full">Expansion</h2>
+      <select value={expansionFilter} onChange={(e) => onChange(e.target.value)} className="min-h-[2rem]">
+        <option value="all">{t('all')}</option>
+        {expansions.map((expansion) => (
+          <option key={expansion.id} value={expansion.id}>
+            {t(expansion.name)}
+          </option>
+        ))}
+      </select>
+    </label>
   )
 }
 

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -11,7 +11,7 @@ const ExpansionsFilter: FC<Props> = ({ value, onChange }) => {
 
   return (
     <label className="flex items-baseline justify-between gap-5 px-3 my-auto border-1 border-neutral-700 rounded-md p-1 bg-neutral-800 text-neutral-400">
-      <h2 className="h-full">Expansion</h2>
+      <h2 className="h-full">{t('expansion')}</h2>
       <select value={value} onChange={(e) => onChange(e.target.value)} className="min-h-[2rem]">
         <option value="all">{t('all')}</option>
         {expansions.map((expansion) => (

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -11,8 +11,8 @@ const ExpansionsFilter: FC<Props> = ({ value, onChange }) => {
 
   return (
     <label className="flex items-baseline justify-between gap-5 px-3 my-auto border-1 border-neutral-700 rounded-md p-1 bg-neutral-800 text-neutral-400">
-      <h2 className="h-full">{t('expansion')}</h2>
-      <select value={value} onChange={(e) => onChange(e.target.value)} className="min-h-[2rem]">
+      <div className="text-sm">{t('expansion')}</div>
+      <select value={value} onChange={(e) => onChange(e.target.value)} className="min-h-[27px] text-sm">
         <option value="all">{t('all')}</option>
         {expansions.map((expansion) => (
           <option key={expansion.id} value={expansion.id}>

--- a/frontend/src/components/filters/PackFilter.tsx
+++ b/frontend/src/components/filters/PackFilter.tsx
@@ -4,12 +4,12 @@ import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
-  packFilter: string
-  setPackFilter: (packFilter: string) => void
+  value: string
+  onChange: (v: string) => void
   expansion: string
   fullWidth?: boolean
 }
-const PackFilter: FC<Props> = ({ packFilter, setPackFilter, expansion, fullWidth }) => {
+const PackFilter: FC<Props> = ({ value, onChange, expansion, fullWidth }) => {
   const { t } = useTranslation('common/packs')
 
   let packsToShow = getExpansionById(expansion)?.packs
@@ -23,7 +23,7 @@ const PackFilter: FC<Props> = ({ packFilter, setPackFilter, expansion, fullWidth
   }
 
   return (
-    <Tabs value={packFilter} onValueChange={(value) => setPackFilter(value)} className={`h-auto ${fullWidth ? 'w-full' : 'w-[440px]'}`}>
+    <Tabs value={value} onValueChange={onChange} className={`h-auto ${fullWidth ? 'w-full' : 'w-[440px]'}`}>
       <TabsList className="h-full flex-wrap w-full border-1 border-neutral-700 rounded-md flex-row justify-start content-start">
         <TabsTrigger value="all">{t('all')}</TabsTrigger>
         {packsToShow

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -136,7 +136,7 @@ function Overview() {
       </article>
 
       <article className="flex mx-auto max-w-7xl px-8 pt-10">
-        <ExpansionsFilter expansionFilter={expansionFilter} onChange={setExpansionFilter} />
+        <ExpansionsFilter value={expansionFilter} onChange={setExpansionFilter} />
       </article>
 
       <article className="mx-auto max-w-7xl sm:p-6 p-0 pt-6 grid grid-cols-8 gap-6">

--- a/frontend/src/pages/overview/Overview.tsx
+++ b/frontend/src/pages/overview/Overview.tsx
@@ -136,7 +136,7 @@ function Overview() {
       </article>
 
       <article className="flex mx-auto max-w-7xl px-8 pt-10">
-        <ExpansionsFilter expansionFilter={expansionFilter} setExpansionFilter={setExpansionFilter} setPackFilter={() => {}} packFilter={'all'} />
+        <ExpansionsFilter expansionFilter={expansionFilter} onChange={setExpansionFilter} />
       </article>
 
       <article className="mx-auto max-w-7xl sm:p-6 p-0 pt-6 grid grid-cols-8 gap-6">


### PR DESCRIPTION
As there are more and more expansions, the tabs filter becomes less and less viable, which eventually would need to be addressed. This PR does it by changing it from tabs to dropdown.

<img width="968" height="271" alt="image" src="https://github.com/user-attachments/assets/2dbaf589-d0ca-4749-a638-b501eb977719" />
<img width="959" height="288" alt="image" src="https://github.com/user-attachments/assets/6a828e45-9678-4ada-beb0-0800e0c8d0a7" />
<img width="545" height="239" alt="image" src="https://github.com/user-attachments/assets/fcaa75bb-db88-4cfd-af9b-6d36a093e140" />
<img width="524" height="337" alt="image" src="https://github.com/user-attachments/assets/2ee5e21a-c609-4385-b263-76974a64dde7" />
<img width="1339" height="590" alt="image" src="https://github.com/user-attachments/assets/ade8319e-67af-4598-b312-02542cb1cc8d" />
