### PR TITLE
Fix card odds calculations to handle A4 baby pokemon

### DIFF
--- a/frontend/assets/cards/A4.json
+++ b/frontend/assets/cards/A4.json
@@ -24,7 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -62,7 +62,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -100,7 +100,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -143,7 +143,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -181,7 +181,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -219,7 +219,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -257,7 +257,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -295,7 +295,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -338,7 +338,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -376,7 +376,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -414,7 +414,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -452,7 +452,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -490,7 +490,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -528,7 +528,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -566,7 +566,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -604,7 +604,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -642,7 +642,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -680,7 +680,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -723,7 +723,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -761,7 +761,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -799,7 +799,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -847,7 +847,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -890,7 +890,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -928,7 +928,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -966,7 +966,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1004,7 +1004,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1042,7 +1042,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1085,7 +1085,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1123,7 +1123,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1161,7 +1161,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1199,7 +1199,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1237,7 +1237,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1280,7 +1280,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1318,7 +1318,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1371,7 +1371,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1409,7 +1409,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1447,7 +1447,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1485,7 +1485,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1523,7 +1523,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1561,7 +1561,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1599,7 +1599,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1637,7 +1637,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1675,7 +1675,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1723,7 +1723,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1761,7 +1761,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1804,7 +1804,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1847,7 +1847,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1885,7 +1885,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1923,7 +1923,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1961,7 +1961,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1999,7 +1999,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2037,7 +2037,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2075,7 +2075,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2118,7 +2118,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2156,7 +2156,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2194,7 +2194,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2237,7 +2237,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2280,7 +2280,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2318,7 +2318,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2356,7 +2356,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2394,7 +2394,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2432,7 +2432,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2470,7 +2470,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2508,7 +2508,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2546,7 +2546,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2594,7 +2594,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2637,7 +2637,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2675,7 +2675,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2713,7 +2713,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2756,7 +2756,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2794,7 +2794,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2832,7 +2832,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2870,7 +2870,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2908,7 +2908,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2946,7 +2946,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2984,7 +2984,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3022,7 +3022,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3060,7 +3060,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3103,7 +3103,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3141,7 +3141,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3179,7 +3179,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3217,7 +3217,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3260,7 +3260,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3308,7 +3308,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3346,7 +3346,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3384,7 +3384,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3427,7 +3427,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3465,7 +3465,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3503,7 +3503,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3541,7 +3541,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3579,7 +3579,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3617,7 +3617,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3655,7 +3655,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3693,7 +3693,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3736,7 +3736,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3774,7 +3774,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3812,7 +3812,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3850,7 +3850,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3888,7 +3888,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3926,7 +3926,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3974,7 +3974,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4012,7 +4012,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4050,7 +4050,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4088,7 +4088,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4126,7 +4126,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4164,7 +4164,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4202,7 +4202,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4240,7 +4240,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4278,7 +4278,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4326,7 +4326,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4369,7 +4369,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4407,7 +4407,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4455,7 +4455,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4498,7 +4498,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4536,7 +4536,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4579,7 +4579,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4617,7 +4617,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4655,7 +4655,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4693,7 +4693,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4736,7 +4736,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4774,7 +4774,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4812,7 +4812,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4850,7 +4850,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4893,7 +4893,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4941,7 +4941,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4979,7 +4979,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5017,7 +5017,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5055,7 +5055,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5093,7 +5093,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5131,7 +5131,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5169,7 +5169,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5207,7 +5207,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5250,7 +5250,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5288,7 +5288,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5331,7 +5331,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5369,7 +5369,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5407,7 +5407,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5445,7 +5445,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5488,7 +5488,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5526,7 +5526,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5569,7 +5569,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5607,7 +5607,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5645,7 +5645,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5683,7 +5683,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5721,7 +5721,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5759,7 +5759,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5797,7 +5797,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5840,7 +5840,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5883,7 +5883,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5936,7 +5936,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5964,7 +5964,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5992,7 +5992,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6020,7 +6020,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6048,7 +6048,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6076,7 +6076,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -6104,7 +6104,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6137,7 +6137,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6170,7 +6170,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6203,7 +6203,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6236,7 +6236,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6269,7 +6269,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6312,7 +6312,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6355,7 +6355,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6398,7 +6398,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6441,7 +6441,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6484,7 +6484,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6527,7 +6527,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6570,7 +6570,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6613,7 +6613,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6656,7 +6656,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6699,7 +6699,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "yes",
+    "baby": true,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6742,7 +6742,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6785,7 +6785,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6828,7 +6828,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6871,7 +6871,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6914,7 +6914,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6957,7 +6957,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7000,7 +7000,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7043,7 +7043,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7086,7 +7086,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7129,7 +7129,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7172,7 +7172,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7215,7 +7215,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7258,7 +7258,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7301,7 +7301,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7344,7 +7344,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7392,7 +7392,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7445,7 +7445,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7493,7 +7493,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7541,7 +7541,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7589,7 +7589,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7637,7 +7637,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7685,7 +7685,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7733,7 +7733,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7781,7 +7781,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7824,7 +7824,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7857,7 +7857,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7890,7 +7890,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7923,7 +7923,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7956,7 +7956,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7989,7 +7989,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8032,7 +8032,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8080,7 +8080,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8128,7 +8128,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8176,7 +8176,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8224,7 +8224,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8272,7 +8272,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8320,7 +8320,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8368,7 +8368,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8416,7 +8416,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8469,7 +8469,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8522,7 +8522,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8565,7 +8565,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8613,7 +8613,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8656,7 +8656,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8699,7 +8699,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8742,7 +8742,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8790,7 +8790,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8833,7 +8833,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8886,7 +8886,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8929,7 +8929,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8972,7 +8972,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9015,7 +9015,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9058,7 +9058,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9101,7 +9101,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9149,7 +9149,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9192,7 +9192,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9235,7 +9235,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9283,7 +9283,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9326,7 +9326,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9369,7 +9369,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9412,7 +9412,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9465,7 +9465,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9518,7 +9518,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9566,7 +9566,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9619,7 +9619,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9672,7 +9672,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9725,7 +9725,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9778,7 +9778,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9831,7 +9831,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -9884,7 +9884,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/A4.json
+++ b/frontend/assets/cards/A4.json
@@ -24,6 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -61,6 +62,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -98,6 +100,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -140,6 +143,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -177,6 +181,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -214,6 +219,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -251,6 +257,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -288,6 +295,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -330,6 +338,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -367,6 +376,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -404,6 +414,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -441,6 +452,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -478,6 +490,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -515,6 +528,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -552,6 +566,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -589,6 +604,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -626,6 +642,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -663,6 +680,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -705,6 +723,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -742,6 +761,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -779,6 +799,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -826,6 +847,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -868,6 +890,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -905,6 +928,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -942,6 +966,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -979,6 +1004,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1016,6 +1042,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1058,6 +1085,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1095,6 +1123,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1132,6 +1161,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1169,6 +1199,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1206,6 +1237,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1248,6 +1280,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1285,6 +1318,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1337,6 +1371,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1374,6 +1409,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1411,6 +1447,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1448,6 +1485,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1485,6 +1523,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1522,6 +1561,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1559,6 +1599,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1596,6 +1637,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1633,6 +1675,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1680,6 +1723,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1717,6 +1761,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1759,6 +1804,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1801,6 +1847,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1838,6 +1885,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1875,6 +1923,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1912,6 +1961,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -1949,6 +1999,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -1986,6 +2037,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2023,6 +2075,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2065,6 +2118,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2102,6 +2156,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2139,6 +2194,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2181,6 +2237,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2223,6 +2280,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2260,6 +2318,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2297,6 +2356,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2334,6 +2394,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2371,6 +2432,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2408,6 +2470,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2445,6 +2508,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2482,6 +2546,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2529,6 +2594,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2571,6 +2637,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2608,6 +2675,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2645,6 +2713,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2687,6 +2756,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2724,6 +2794,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2761,6 +2832,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2798,6 +2870,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2835,6 +2908,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2872,6 +2946,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -2909,6 +2984,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2946,6 +3022,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -2983,6 +3060,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3025,6 +3103,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3062,6 +3141,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3099,6 +3179,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3136,6 +3217,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3178,6 +3260,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3225,6 +3308,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3262,6 +3346,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3299,6 +3384,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -3341,6 +3427,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3378,6 +3465,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3415,6 +3503,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3452,6 +3541,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3489,6 +3579,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3526,6 +3617,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3563,6 +3655,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3600,6 +3693,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3642,6 +3736,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3679,6 +3774,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3716,6 +3812,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3753,6 +3850,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3790,6 +3888,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3827,6 +3926,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3874,6 +3974,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3911,6 +4012,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3948,6 +4050,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -3985,6 +4088,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4022,6 +4126,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4059,6 +4164,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4096,6 +4202,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4133,6 +4240,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4170,6 +4278,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4217,6 +4326,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4259,6 +4369,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4296,6 +4407,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4343,6 +4455,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4385,6 +4498,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4422,6 +4536,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4464,6 +4579,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4501,6 +4617,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4538,6 +4655,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4575,6 +4693,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4617,6 +4736,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4654,6 +4774,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4691,6 +4812,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4728,6 +4850,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -4770,6 +4893,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4817,6 +4941,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4854,6 +4979,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4891,6 +5017,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4928,6 +5055,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -4965,6 +5093,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5002,6 +5131,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5039,6 +5169,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5076,6 +5207,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5118,6 +5250,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5155,6 +5288,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5197,6 +5331,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5234,6 +5369,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5271,6 +5407,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5308,6 +5445,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5350,6 +5488,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5387,6 +5526,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5429,6 +5569,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5466,6 +5607,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5503,6 +5645,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5540,6 +5683,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5577,6 +5721,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5614,6 +5759,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5651,6 +5797,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5693,6 +5840,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5735,6 +5883,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5787,6 +5936,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5814,6 +5964,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5841,6 +5992,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5868,6 +6020,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5895,6 +6048,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -5922,6 +6076,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5949,6 +6104,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -5981,6 +6137,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6013,6 +6170,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6045,6 +6203,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6077,6 +6236,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6109,6 +6269,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6151,6 +6312,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6193,6 +6355,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6235,6 +6398,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6277,6 +6441,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6319,6 +6484,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6361,6 +6527,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6403,6 +6570,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6445,6 +6613,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6487,6 +6656,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6529,6 +6699,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "yes",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6571,6 +6742,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6613,6 +6785,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6655,6 +6828,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6697,6 +6871,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6739,6 +6914,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6781,6 +6957,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6823,6 +7000,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6865,6 +7043,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6907,6 +7086,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -6949,6 +7129,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -6991,6 +7172,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7033,6 +7215,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7075,6 +7258,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7117,6 +7301,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7159,6 +7344,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7206,6 +7392,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7258,6 +7445,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7305,6 +7493,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7352,6 +7541,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7399,6 +7589,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7446,6 +7637,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7493,6 +7685,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7540,6 +7733,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7587,6 +7781,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7629,6 +7824,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7661,6 +7857,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7693,6 +7890,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7725,6 +7923,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7757,6 +7956,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7789,6 +7989,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -7831,6 +8032,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7878,6 +8080,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7925,6 +8128,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -7972,6 +8176,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8019,6 +8224,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8066,6 +8272,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8113,6 +8320,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8160,6 +8368,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8207,6 +8416,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8259,6 +8469,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8311,6 +8522,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8353,6 +8565,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8400,6 +8613,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8442,6 +8656,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8484,6 +8699,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8526,6 +8742,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8573,6 +8790,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8615,6 +8833,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8667,6 +8886,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8709,6 +8929,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8751,6 +8972,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8793,6 +9015,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8835,6 +9058,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8877,6 +9101,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -8924,6 +9149,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -8966,6 +9192,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9008,6 +9235,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9055,6 +9283,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9097,6 +9326,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9139,6 +9369,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9181,6 +9412,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9233,6 +9465,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9285,6 +9518,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9332,6 +9566,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9384,6 +9619,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9436,6 +9672,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9488,6 +9725,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "lugiapack",
     "alternate_versions": [
@@ -9540,6 +9778,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "ho-ohpack",
     "alternate_versions": [
@@ -9592,6 +9831,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [
@@ -9644,6 +9884,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "wisdomofseaandsky(a4)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/P-A.json
+++ b/frontend/assets/cards/P-A.json
@@ -14,7 +14,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -42,7 +42,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -70,7 +70,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -98,7 +98,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -131,7 +131,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -164,7 +164,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -192,7 +192,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -220,7 +220,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -263,7 +263,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -316,7 +316,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -359,7 +359,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -402,7 +402,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -450,7 +450,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -493,7 +493,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -531,7 +531,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -584,7 +584,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -627,7 +627,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -665,7 +665,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -713,7 +713,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -761,7 +761,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -799,7 +799,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -842,7 +842,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -880,7 +880,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -933,7 +933,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -987,7 +987,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1045,7 +1045,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1098,7 +1098,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1136,7 +1136,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1179,7 +1179,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1227,7 +1227,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1265,7 +1265,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1308,7 +1308,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1356,7 +1356,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1409,7 +1409,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1452,7 +1452,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1495,7 +1495,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1538,7 +1538,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1576,7 +1576,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1614,7 +1614,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1657,7 +1657,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1700,7 +1700,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1743,7 +1743,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1796,7 +1796,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1839,7 +1839,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1882,7 +1882,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1920,7 +1920,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1963,7 +1963,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2001,7 +2001,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2049,7 +2049,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2098,7 +2098,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2156,7 +2156,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2199,7 +2199,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2242,7 +2242,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2280,7 +2280,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2323,7 +2323,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2371,7 +2371,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2409,7 +2409,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2452,7 +2452,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2500,7 +2500,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2548,7 +2548,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2591,7 +2591,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2639,7 +2639,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2687,7 +2687,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2725,7 +2725,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2768,7 +2768,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2811,7 +2811,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2854,7 +2854,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2902,7 +2902,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2945,7 +2945,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2993,7 +2993,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3036,7 +3036,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3079,7 +3079,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3117,7 +3117,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3155,7 +3155,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3198,7 +3198,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3241,7 +3241,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3289,7 +3289,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3332,7 +3332,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3370,7 +3370,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3408,7 +3408,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3457,7 +3457,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3495,7 +3495,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3538,7 +3538,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3587,7 +3587,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3640,7 +3640,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3683,7 +3683,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3736,7 +3736,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3779,7 +3779,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3817,7 +3817,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3855,7 +3855,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3898,7 +3898,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3941,7 +3941,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
-    "baby": "no",
+    "baby": false,
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/P-A.json
+++ b/frontend/assets/cards/P-A.json
@@ -14,6 +14,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -41,6 +42,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -68,6 +70,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -95,6 +98,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -127,6 +131,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -159,6 +164,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -186,6 +192,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -213,6 +220,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -255,6 +263,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -307,6 +316,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -349,6 +359,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -391,6 +402,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -438,6 +450,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -480,6 +493,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -517,6 +531,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -569,6 +584,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -611,6 +627,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -648,6 +665,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -695,6 +713,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -742,6 +761,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -779,6 +799,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -821,6 +842,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -858,6 +880,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -910,6 +933,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -963,6 +987,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1020,6 +1045,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1072,6 +1098,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1109,6 +1136,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1151,6 +1179,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1198,6 +1227,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1235,6 +1265,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1277,6 +1308,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1324,6 +1356,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1376,6 +1409,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1418,6 +1452,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1460,6 +1495,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1502,6 +1538,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1539,6 +1576,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1576,6 +1614,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1618,6 +1657,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1660,6 +1700,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1702,6 +1743,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1754,6 +1796,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1796,6 +1839,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1838,6 +1882,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1875,6 +1920,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1917,6 +1963,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -1954,6 +2001,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2001,6 +2049,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2049,6 +2098,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2106,6 +2156,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2148,6 +2199,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2190,6 +2242,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2227,6 +2280,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2269,6 +2323,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2316,6 +2371,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2353,6 +2409,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2395,6 +2452,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2442,6 +2500,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2489,6 +2548,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2531,6 +2591,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2578,6 +2639,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2625,6 +2687,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2662,6 +2725,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2704,6 +2768,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2746,6 +2811,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2788,6 +2854,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2835,6 +2902,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2877,6 +2945,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2924,6 +2993,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -2966,6 +3036,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3008,6 +3079,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3045,6 +3117,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3082,6 +3155,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3124,6 +3198,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3166,6 +3241,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3213,6 +3289,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3255,6 +3332,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3292,6 +3370,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3329,6 +3408,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3377,6 +3457,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3414,6 +3495,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3456,6 +3538,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3504,6 +3587,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3556,6 +3640,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3598,6 +3683,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3650,6 +3736,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3692,6 +3779,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3729,6 +3817,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3766,6 +3855,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3808,6 +3898,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [
@@ -3850,6 +3941,7 @@
     "rarity": "P",
     "fullart": "Yes",
     "ex": "no",
+    "baby": "no",
     "set_details": "promo-a",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/public/locales/en-US/pages/card-detail.json
+++ b/frontend/public/locales/en-US/pages/card-detail.json
@@ -6,6 +6,7 @@
     "cardType": "Card Type",
     "evolutionType": "Evolution Type",
     "ex": "EX",
+    "baby": "Baby",
     "craftingCost": "Crafting Cost",
     "artist": "Artist",
     "setDetails": "Set Details",

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -536,7 +536,6 @@ const pullRateForCardSubset = (missingCards: Card[], expansion: Expansion, cards
 
         chanceToGetThisCardBaby += probabilityPerRarityBaby[rarity] / 100 / nrOfcardsOfThisRarity
       } else {
-        // specify baby !== 'yes' to handle issue where baby field is undefined
         const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity && !c.baby).length
 
         // the chance to get this card is the probability of getting this card in the pack divided by the number of cards of this rarity

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -530,14 +530,14 @@ const pullRateForCardSubset = (missingCards: Card[], expansion: Expansion, cards
     let chanceToGetThisCardBaby = 0
 
     for (const rarity of rarityList) {
-      if (card.baby === 'yes') {
+      if (card.baby) {
         // if the card is a baby, we only consider 6-card packs
-        const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity && c.baby === 'yes').length
+        const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity && c.baby).length
 
         chanceToGetThisCardBaby += probabilityPerRarityBaby[rarity] / 100 / nrOfcardsOfThisRarity
       } else {
         // specify baby !== 'yes' to handle issue where baby field is undefined
-        const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity && c.baby !== 'yes').length
+        const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity && !c.baby).length
 
         // the chance to get this card is the probability of getting this card in the pack divided by the number of cards of this rarity
         chanceToGetThisCard1_3 += probabilityPerRarity1_3[rarity] / 100 / nrOfcardsOfThisRarity

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -185,6 +185,7 @@ export const expansions: Expansion[] = [
     missions: a4Missions,
     tradeable: false,
     containsShinies: true,
+    containsBabies: true,
   },
 
   {

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -400,6 +400,20 @@ const abilityByRarityToBeInRarePack: Record<Rarity, number> = {
   P: 0,
   '': 0,
 }
+const probabilityPerRarityBaby: Record<Rarity, number> = {
+  '◊': 0,
+  '◊◊': 0,
+  '◊◊◊': 87.1,
+  '◊◊◊◊': 0,
+  '☆': 12.9,
+  '☆☆': 0,
+  '☆☆☆': 0,
+  '✵': 0,
+  '✵✵': 0,
+  'Crown Rare': 0,
+  P: 0,
+  '': 0,
+}
 
 interface PullRateProps {
   ownedCards: CollectionRow[]
@@ -490,6 +504,7 @@ const pullRateForCardSubset = (missingCards: Card[], expansion: Expansion, cards
   let totalProbability4 = 0
   let totalProbability5 = 0
   let rareProbability1_5 = 0
+  let babyProbability = 0
   for (const card of missingCardsFromPack) {
     const rarityList = [card.rarity]
     // Skip cards that cannot be picked
@@ -512,20 +527,29 @@ const pullRateForCardSubset = (missingCards: Card[], expansion: Expansion, cards
     let chanceToGetThisCard4 = 0
     let chanceToGetThisCard5 = 0
     let chanceToGetThisCardRare1_5 = 0
+    let chanceToGetThisCardBaby = 0
 
     for (const rarity of rarityList) {
-      const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity).length
+      if (card.baby === 'yes') {
+        // if the card is a baby, we only consider 6-card packs
+        const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity && c.baby === 'yes').length
 
-      // the chance to get this card is the probability of getting this card in the pack divided by the number of cards of this rarity
-      chanceToGetThisCard1_3 += probabilityPerRarity1_3[rarity] / 100 / nrOfcardsOfThisRarity
-      if (expansion.containsShinies) {
-        chanceToGetThisCard4 += probabilityPerRarity4Shiny[rarity] / 100 / nrOfcardsOfThisRarity
-        chanceToGetThisCard5 += probabilityPerRarity5Shiny[rarity] / 100 / nrOfcardsOfThisRarity
+        chanceToGetThisCardBaby += probabilityPerRarityBaby[rarity] / 100 / nrOfcardsOfThisRarity
       } else {
-        chanceToGetThisCard4 += probabilityPerRarity4[rarity] / 100 / nrOfcardsOfThisRarity
-        chanceToGetThisCard5 += probabilityPerRarity5[rarity] / 100 / nrOfcardsOfThisRarity
+        // specify baby !== 'yes' to handle issue where baby field is undefined
+        const nrOfcardsOfThisRarity = cardsInPack.filter((c) => c.rarity === rarity && c.baby !== 'yes').length
+
+        // the chance to get this card is the probability of getting this card in the pack divided by the number of cards of this rarity
+        chanceToGetThisCard1_3 += probabilityPerRarity1_3[rarity] / 100 / nrOfcardsOfThisRarity
+        if (expansion.containsShinies) {
+          chanceToGetThisCard4 += probabilityPerRarity4Shiny[rarity] / 100 / nrOfcardsOfThisRarity
+          chanceToGetThisCard5 += probabilityPerRarity5Shiny[rarity] / 100 / nrOfcardsOfThisRarity
+        } else {
+          chanceToGetThisCard4 += probabilityPerRarity4[rarity] / 100 / nrOfcardsOfThisRarity
+          chanceToGetThisCard5 += probabilityPerRarity5[rarity] / 100 / nrOfcardsOfThisRarity
+        }
+        chanceToGetThisCardRare1_5 += abilityByRarityToBeInRarePack[rarity] / cardsInRarePack.length
       }
-      chanceToGetThisCardRare1_5 += abilityByRarityToBeInRarePack[rarity] / cardsInRarePack.length
     }
 
     // add up the chances to get this card
@@ -533,12 +557,25 @@ const pullRateForCardSubset = (missingCards: Card[], expansion: Expansion, cards
     totalProbability4 += chanceToGetThisCard4
     totalProbability5 += chanceToGetThisCard5
     rareProbability1_5 += chanceToGetThisCardRare1_5
+    babyProbability += chanceToGetThisCardBaby
   }
 
+  let chanceToGetNewCard = 0
+  let chanceToGetNewCardInRarePack = 0
+  let changeToGetNewCardIn6CardPack = 0
+
   // take the total probabilities per card draw (for the 1-3 you need to cube the probability) and multiply
-  const chanceToGetNewCard = 0.9995 * (1 - (1 - totalProbability1_3) ** 3 * (1 - totalProbability4) * (1 - totalProbability5))
-  const chanceToGetNewCardInRarePack = 0.0005 * (1 - (1 - rareProbability1_5) ** 5)
+  const chanceToGetInStandard5Cards = 1 - (1 - totalProbability1_3) ** 3 * (1 - totalProbability4) * (1 - totalProbability5)
+
+  if (expansion.containsBabies) {
+    chanceToGetNewCard = 0.9162 * chanceToGetInStandard5Cards
+    chanceToGetNewCardInRarePack = 0.0005 * (1 - (1 - rareProbability1_5) ** 5)
+    changeToGetNewCardIn6CardPack = 0.0833 * (1 - (1 - chanceToGetInStandard5Cards) * (1 - babyProbability))
+  } else {
+    chanceToGetNewCard = 0.9995 * chanceToGetInStandard5Cards
+    chanceToGetNewCardInRarePack = 0.0005 * (1 - (1 - rareProbability1_5) ** 5)
+  }
 
   // disjoint union of probabilities
-  return chanceToGetNewCard + chanceToGetNewCardInRarePack
+  return chanceToGetNewCard + chanceToGetNewCardInRarePack + changeToGetNewCardIn6CardPack
 }

--- a/frontend/src/pages/collection/CardDetail.tsx
+++ b/frontend/src/pages/collection/CardDetail.tsx
@@ -92,6 +92,9 @@ function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps
               <strong>{t('text.ex')}:</strong> {t(`ex.${card.ex}`)}
             </p>
             <p className="text-lg mb-1">
+              <strong>{t('text.baby')}:</strong> {t(`ex.${card.baby || 'no'}`)}
+            </p>
+            <p className="text-lg mb-1">
               <strong>{t('text.craftingCost')}:</strong> {card.crafting_cost}
             </p>
             <p className="text-lg mb-1">

--- a/frontend/src/pages/collection/CardDetail.tsx
+++ b/frontend/src/pages/collection/CardDetail.tsx
@@ -92,7 +92,7 @@ function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps
               <strong>{t('text.ex')}:</strong> {t(`ex.${card.ex}`)}
             </p>
             <p className="text-lg mb-1">
-              <strong>{t('text.baby')}:</strong> {t(`ex.${card.baby || 'no'}`)}
+              <strong>{t('text.baby')}:</strong> {t(`ex.${card.baby ? 'yes' : 'no'}`)}
             </p>
             <p className="text-lg mb-1">
               <strong>{t('text.craftingCost')}:</strong> {card.crafting_cost}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -35,6 +35,7 @@ export interface Expansion {
   tradeable?: boolean
   promo?: boolean
   containsShinies?: boolean
+  containsBabies?: boolean
 }
 
 export interface Pack {
@@ -67,6 +68,7 @@ export interface Card {
   rarity: Rarity
   fullart: string
   ex: string
+  baby: 'yes' | 'no'
   set_details: string
   pack: string
   alternate_versions: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,7 +68,7 @@ export interface Card {
   rarity: Rarity
   fullart: string
   ex: string
-  baby: 'yes' | 'no'
+  baby: boolean
   set_details: string
   pack: string
   alternate_versions: {

--- a/scripts/scraper.js
+++ b/scripts/scraper.js
@@ -212,7 +212,7 @@ async function extractCardInfo($, cardUrl) {
   cardInfo.ex = cardInfo.name.includes('ex') && !nonExCardsWithEx.includes(cardInfo.name) ? 'yes' : 'no'
 
   // Check if card is a baby pokemon (Not currently specified exactly on Limitless TCG page)
-  cardInfo.baby = cardInfo.weakness === 'none' && cardInfo.hp === '30' && cardInfo.energy !== 'Dragon' ? 'yes' : 'no'
+  cardInfo.baby = cardInfo.weakness === 'none' && cardInfo.hp === '30' && cardInfo.energy !== 'Dragon'
 
   const { setDetails, pack } = extractSetAndPackInfo($)
   cardInfo.set_details = setDetails

--- a/scripts/scraper.js
+++ b/scripts/scraper.js
@@ -211,6 +211,9 @@ async function extractCardInfo($, cardUrl) {
 
   cardInfo.ex = cardInfo.name.includes('ex') && !nonExCardsWithEx.includes(cardInfo.name) ? 'yes' : 'no'
 
+  // Check if card is a baby pokemon (Not currently specified exactly on Limitless TCG page)
+  cardInfo.baby = cardInfo.weakness === 'none' && cardInfo.hp === '30' && cardInfo.energy !== 'Dragon' ? 'yes' : 'no'
+
   const { setDetails, pack } = extractSetAndPackInfo($)
   cardInfo.set_details = setDetails
   cardInfo.pack = pack


### PR DESCRIPTION
Fixes #533

With the introduction of baby pokemon in A4, the way the odds for each card are calculated needed to be updated as there is now a new 6-card pack that has distinct from the regular and rare packs from previous expansions. Baby can strictly be found as the 6th card in a 6-card pack.

This PR updates the scraper.js script to add a "baby" field to each of the cards. Currently the Limitless TCG site doesn't have a baby field, but at the moment all baby pokemon are basic, have 30 health, and have no weaknesses.

The only cards with no weaknesses are dragon-type and babies for now, and there are no dragon-type baby pokemon, so this should be sufficient to distinguish the cards, but the basic and health criteria are added as extra security.

The odds calculator function has been updated to use the new odds if a pack has the new "containsBabies" field equal to true.

Finally a new "Baby: ___" line has been added to the expandable card details pane. However, translations have not been added for non-English languages yet.
