### PR TITLE
Fix smeargle mission

### DIFF
--- a/frontend/assets/themed-collections/A4-missions.json
+++ b/frontend/assets/themed-collections/A4-missions.json
@@ -681,127 +681,39 @@
     "name": "Smeargle's Colorful Collection",
     "requiredCards": [
       {
-        "options": ["A4-162"],
+        "options": ["A4-162", "A4-163", "A4-164", "A4-202"],
         "amount": 1
       },
       {
-        "options": ["A4-163"],
+        "options": ["A4-165", "A4-166"],
         "amount": 1
       },
       {
-        "options": ["A4-164"],
+        "options": ["A4-167", "A4-168", "A4-169", "A4-170", "A4-203"],
         "amount": 1
       },
       {
-        "options": ["A4-202"],
+        "options": ["A4-171", "A4-172", "A4-204"],
         "amount": 1
       },
       {
-        "options": ["A4-165"],
+        "options": ["A4-173", "A4-174", "A4-175", "A4-205"],
         "amount": 1
       },
       {
-        "options": ["A4-166"],
+        "options": ["A4-176", "A4-206"],
         "amount": 1
       },
       {
-        "options": ["A4-167"],
+        "options": ["A4-177", "A4-178", "A4-179", "A4-207", "A4-208"],
         "amount": 1
       },
       {
-        "options": ["A4-168"],
+        "options": ["A4-180", "A4-209"],
         "amount": 1
       },
       {
-        "options": ["A4-169"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-170"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-203"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-171"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-172"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-204"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-173"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-174"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-175"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-205"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-176"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-206"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-177"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-178"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-179"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-207"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-208"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-180"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-209"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-181"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-182"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-103"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-185"],
+        "options": ["A4-181", "A4-182", "A4-183", "A4-185"],
         "amount": 1
       },
       {


### PR DESCRIPTION
Formatting on the smeargle mission on bulbapedia is abnormal, so manually fixing it faster than reworking the scraper. Especially since we likely shouldn't need to rerun the scraper for this expansion again.