### PR TITLE
Add true numerical ordering to sort by expansion

### DIFF
--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -179,7 +179,7 @@ const FilterPanel: FC<Props> = ({
           return expansionIndexA - expansionIndexB
         }
 
-        return a.card_id.localeCompare(b.card_id, i18n.language || "en", { numeric: true })
+        return a.card_id.localeCompare(b.card_id, i18n.language || 'en', { numeric: true })
       })
     }
 

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -179,7 +179,7 @@ const FilterPanel: FC<Props> = ({
           return expansionIndexA - expansionIndexB
         }
 
-        return a.card_id.localeCompare(b.card_id)
+        return a.card_id.localeCompare(b.card_id, i18n.language || "en", { numeric: true })
       })
     }
 


### PR DESCRIPTION
Fix card sorting to handle IDs in true numerical order.

Fixes #544 