### PR TITLE
fix(decks): properly count alternate versions for deck validation

### DIFF
--- a/frontend/src/pages/decks/DeckItem.tsx
+++ b/frontend/src/pages/decks/DeckItem.tsx
@@ -26,9 +26,10 @@ export const DeckItem = ({ deck }: { deck: IDeck }) => {
 
   function isSelected(deckCards: string[], cardObj: Card, idx: number): boolean {
     const countInDeckSoFar = deckCards.slice(0, idx + 1).filter((id) => id === cardObj.card_id).length
-    const cardIdOrAlternate: string[] = cardObj.alternate_versions.map((av) => av.card_id)
-    const owned = ownedCards.find((c) => cardIdOrAlternate.some((id) => id === c.card_id.replace('_', '-')) && c.amount_owned > 0)
-    const ownedAmount = owned ? owned.amount_owned : 0
+    const allVersionIds = cardObj.alternate_versions.map((av) => av.card_id)
+    const ownedAmount = ownedCards
+      .filter((c) => allVersionIds.includes(c.card_id.replace('_', '-')) && c.amount_owned > 0)
+      .reduce((total, card) => total + card.amount_owned, 0)
     return countInDeckSoFar <= ownedAmount
   }
 


### PR DESCRIPTION
Fixes #557 

Reworked the `isSelected`. From what I tested, seems like we were stopping on first match and stopped counting successive alternate card matches.

From my card collection, I have 2 Darkrai Ex card, the basic one and the 2 :star: one. Before I had the second Darkrai missing, now both the card are marked owned. The missing count is also correct.

Before: <img width="2000" height="817" alt="image" src="https://github.com/user-attachments/assets/410e4e33-7fbb-4588-8f9d-623b6f243311" />

After: <img width="2000" height="827" alt="image" src="https://github.com/user-attachments/assets/e2fb69b5-4384-45aa-94c3-b0ff8c618b8c" />