### PR TITLE
feat(cards): add baby field and update alternate versions

### DIFF
--- a/frontend/assets/cards/A1.json
+++ b/frontend/assets/cards/A1.json
@@ -24,6 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -76,6 +77,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -118,6 +120,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -171,6 +174,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -218,6 +222,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -255,6 +260,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -292,6 +298,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -334,6 +341,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -371,6 +379,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -408,6 +417,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -445,6 +455,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -482,6 +493,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -524,6 +536,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -561,6 +574,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -598,6 +612,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -635,6 +650,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -672,6 +688,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -709,6 +726,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -746,6 +764,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -783,6 +802,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -820,6 +840,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -857,6 +878,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -894,6 +916,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -941,6 +964,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -978,6 +1002,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -1015,6 +1040,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1057,6 +1083,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1094,6 +1121,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1131,6 +1159,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1168,6 +1197,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1205,6 +1235,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1242,6 +1273,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1279,6 +1311,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1326,6 +1359,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1363,6 +1397,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1406,6 +1441,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1458,6 +1494,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1495,6 +1532,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1532,6 +1570,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -1574,6 +1613,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -1616,6 +1656,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -1663,6 +1704,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1700,6 +1742,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1742,6 +1785,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1779,6 +1823,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1816,6 +1861,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1859,6 +1905,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -1916,6 +1963,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1953,6 +2001,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -1990,6 +2039,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -2027,6 +2077,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2064,6 +2115,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2101,6 +2153,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2153,6 +2206,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2195,6 +2249,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2248,6 +2303,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2295,6 +2351,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2332,6 +2389,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2369,6 +2427,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -2406,6 +2465,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -2443,6 +2503,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -2480,6 +2541,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -2517,6 +2579,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -2554,6 +2617,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2591,6 +2655,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2628,6 +2693,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -2665,6 +2731,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -2702,6 +2769,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -2739,6 +2807,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -2776,6 +2845,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2813,6 +2883,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2850,6 +2921,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2887,6 +2959,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -2924,6 +2997,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -2966,6 +3040,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3008,6 +3083,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3055,6 +3131,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3092,6 +3169,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3134,6 +3212,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3181,6 +3260,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -3188,6 +3268,11 @@
         "card_id": "A1-80",
         "version": "Genetic Apex #80",
         "rarity": "◊◊◊"
+      },
+      {
+        "card_id": "A4-216",
+        "version": "Wisdom of Sea and Sky #216",
+        "rarity": "☆"
       }
     ],
     "artist": "Kagemaru Himeno",
@@ -3218,6 +3303,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3255,6 +3341,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3292,6 +3379,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -3335,6 +3423,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -3387,6 +3476,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3424,6 +3514,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3461,6 +3552,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3508,6 +3600,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3550,6 +3643,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3597,6 +3691,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -3634,6 +3729,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3671,6 +3767,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3708,6 +3805,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3745,6 +3843,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3797,6 +3896,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3834,6 +3934,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3886,6 +3987,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3898,6 +4000,11 @@
         "card_id": "P-A-24",
         "version": "Promo-A #24",
         "rarity": ""
+      },
+      {
+        "card_id": "A4-217",
+        "version": "Wisdom of Sea and Sky #217",
+        "rarity": "☆"
       }
     ],
     "artist": "sowsow",
@@ -3928,6 +4035,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -3935,6 +4043,11 @@
         "card_id": "A1-98",
         "version": "Genetic Apex #98",
         "rarity": "◊◊◊"
+      },
+      {
+        "card_id": "A4-218",
+        "version": "Wisdom of Sea and Sky #218",
+        "rarity": "☆"
       }
     ],
     "artist": "kirisAki",
@@ -3965,6 +4078,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4002,6 +4116,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4044,6 +4159,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4081,6 +4197,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4118,6 +4235,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4161,6 +4279,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4213,6 +4332,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4250,6 +4370,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4287,6 +4408,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -4324,6 +4446,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -4361,6 +4484,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -4398,6 +4522,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4435,6 +4560,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4472,6 +4598,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4509,6 +4636,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4551,6 +4679,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4588,6 +4717,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -4625,6 +4755,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -4662,6 +4793,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -4704,6 +4836,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4746,6 +4879,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4783,6 +4917,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -4820,6 +4955,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -4862,6 +4998,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -4904,6 +5041,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -4956,6 +5094,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -4993,6 +5132,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -5030,6 +5170,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -5067,6 +5208,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -5109,6 +5251,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -5157,6 +5300,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -5214,6 +5358,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -5251,6 +5396,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -5288,6 +5434,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -5325,6 +5472,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5362,6 +5510,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5399,6 +5548,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5436,6 +5586,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5473,6 +5624,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5510,6 +5662,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5547,6 +5700,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -5589,6 +5743,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -5626,6 +5781,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -5663,6 +5819,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -5670,6 +5827,11 @@
         "card_id": "A1-142",
         "version": "Genetic Apex #142",
         "rarity": "◊◊"
+      },
+      {
+        "card_id": "A4-222",
+        "version": "Wisdom of Sea and Sky #222",
+        "rarity": "☆"
       }
     ],
     "artist": "Kagemaru Himeno",
@@ -5700,6 +5862,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -5742,6 +5905,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -5784,6 +5948,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -5821,6 +5986,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -5873,6 +6039,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -5910,6 +6077,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -5947,6 +6115,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -5984,6 +6153,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6026,6 +6196,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6073,6 +6244,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6115,6 +6287,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6162,6 +6335,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6199,6 +6373,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -6236,6 +6411,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6273,6 +6449,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6310,6 +6487,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -6347,6 +6525,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -6384,6 +6563,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6421,6 +6601,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6458,6 +6639,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -6495,6 +6677,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -6532,6 +6715,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -6574,6 +6758,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -6616,6 +6801,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6623,6 +6809,11 @@
         "card_id": "A1-166",
         "version": "Genetic Apex #166",
         "rarity": "◊"
+      },
+      {
+        "card_id": "A4-223",
+        "version": "Wisdom of Sea and Sky #223",
+        "rarity": "☆"
       }
     ],
     "artist": "Miki Tanaka",
@@ -6653,6 +6844,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6660,6 +6852,11 @@
         "card_id": "A1-167",
         "version": "Genetic Apex #167",
         "rarity": "◊◊"
+      },
+      {
+        "card_id": "A4-224",
+        "version": "Wisdom of Sea and Sky #224",
+        "rarity": "☆"
       }
     ],
     "artist": "Kagemaru Himeno",
@@ -6690,6 +6887,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6701,6 +6899,11 @@
       {
         "card_id": "A1-240",
         "version": "Genetic Apex #240",
+        "rarity": "☆"
+      },
+      {
+        "card_id": "A4-225",
+        "version": "Wisdom of Sea and Sky #225",
         "rarity": "☆"
       }
     ],
@@ -6732,6 +6935,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6739,6 +6943,11 @@
         "card_id": "A1-169",
         "version": "Genetic Apex #169",
         "rarity": "◊"
+      },
+      {
+        "card_id": "A4-226",
+        "version": "Wisdom of Sea and Sky #226",
+        "rarity": "☆"
       }
     ],
     "artist": "Naoyo Kimura",
@@ -6769,6 +6978,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6776,6 +6986,11 @@
         "card_id": "A1-170",
         "version": "Genetic Apex #170",
         "rarity": "◊◊"
+      },
+      {
+        "card_id": "A4-227",
+        "version": "Wisdom of Sea and Sky #227",
+        "rarity": "☆"
       }
     ],
     "artist": "Kouki Saitou",
@@ -6806,6 +7021,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -6817,6 +7033,11 @@
       {
         "card_id": "A1-241",
         "version": "Genetic Apex #241",
+        "rarity": "☆"
+      },
+      {
+        "card_id": "A4-228",
+        "version": "Wisdom of Sea and Sky #228",
         "rarity": "☆"
       }
     ],
@@ -6848,6 +7069,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6885,6 +7107,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6927,6 +7150,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -6964,6 +7188,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7001,6 +7226,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7038,6 +7264,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7080,6 +7307,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -7117,6 +7345,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -7154,6 +7383,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -7191,6 +7421,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -7228,6 +7459,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -7265,6 +7497,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7302,6 +7535,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7339,6 +7573,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7381,6 +7616,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7423,6 +7659,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7465,6 +7702,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -7512,6 +7750,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -7549,6 +7788,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -7586,6 +7826,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -7623,6 +7864,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -7660,6 +7902,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -7697,6 +7940,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -7734,6 +7978,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -7786,6 +8031,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -7833,6 +8079,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -7870,6 +8117,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -7917,6 +8165,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -7954,6 +8203,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -7991,6 +8241,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8028,6 +8279,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -8070,6 +8322,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -8107,6 +8360,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -8144,6 +8398,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8186,6 +8441,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -8243,6 +8499,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8300,6 +8557,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -8357,6 +8615,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8399,6 +8658,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8441,6 +8701,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -8483,6 +8744,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -8520,6 +8782,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -8562,6 +8825,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -8599,6 +8863,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -8626,6 +8891,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -8653,6 +8919,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -8680,6 +8947,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8712,6 +8980,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -8744,6 +9013,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -8776,6 +9046,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -8808,6 +9079,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8840,6 +9112,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -8872,6 +9145,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -8904,6 +9178,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -8936,6 +9211,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -8978,6 +9254,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -9030,6 +9307,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9072,6 +9350,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9114,6 +9393,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9161,6 +9441,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9203,6 +9484,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -9255,6 +9537,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -9297,6 +9580,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9344,6 +9628,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -9386,6 +9671,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9428,6 +9714,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9470,6 +9757,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -9512,6 +9800,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -9559,6 +9848,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -9570,6 +9860,11 @@
       {
         "card_id": "A1-240",
         "version": "Genetic Apex #240",
+        "rarity": "☆"
+      },
+      {
+        "card_id": "A4-225",
+        "version": "Wisdom of Sea and Sky #225",
         "rarity": "☆"
       }
     ],
@@ -9601,6 +9896,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -9612,6 +9908,11 @@
       {
         "card_id": "A1-241",
         "version": "Genetic Apex #241",
+        "rarity": "☆"
+      },
+      {
+        "card_id": "A4-228",
+        "version": "Wisdom of Sea and Sky #228",
         "rarity": "☆"
       }
     ],
@@ -9643,6 +9944,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -9685,6 +9987,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -9727,6 +10030,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -9769,6 +10073,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -9816,6 +10121,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -9863,6 +10169,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -9905,6 +10212,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -9962,6 +10270,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10004,6 +10313,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -10052,6 +10362,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10099,6 +10410,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -10152,6 +10464,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -10204,6 +10517,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -10257,6 +10571,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -10320,6 +10635,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -10367,6 +10683,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -10420,6 +10737,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10472,6 +10790,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -10530,6 +10849,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -10582,6 +10902,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10640,6 +10961,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10697,6 +11019,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -10749,6 +11072,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10796,6 +11120,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -10838,6 +11163,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -10870,6 +11196,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -10902,6 +11229,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -10934,6 +11262,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10966,6 +11295,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -10998,6 +11328,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -11030,6 +11361,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -11062,6 +11394,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -11110,6 +11443,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -11173,6 +11507,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -11231,6 +11566,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -11283,6 +11619,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -11335,6 +11672,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -11387,6 +11725,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -11445,6 +11784,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "charizardpack",
     "alternate_versions": [
@@ -11497,6 +11837,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "pikachupack",
     "alternate_versions": [
@@ -11555,6 +11896,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "mewtwopack",
     "alternate_versions": [
@@ -11612,6 +11954,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -11660,6 +12003,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -11712,6 +12056,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [
@@ -11770,6 +12115,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "geneticapex(a1)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/A1a.json
+++ b/frontend/assets/cards/A1a.json
@@ -24,6 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -66,6 +67,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -113,6 +115,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -165,6 +168,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -202,6 +206,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -239,6 +244,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -281,6 +287,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -318,6 +325,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -355,6 +363,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -392,6 +401,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -429,6 +439,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -466,6 +477,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -503,6 +515,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -540,6 +553,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -582,6 +596,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -624,6 +639,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -661,6 +677,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -668,6 +685,11 @@
         "card_id": "A1a-17",
         "version": "Mythical Island #17",
         "rarity": "◊"
+      },
+      {
+        "card_id": "A4-214",
+        "version": "Wisdom of Sea and Sky #214",
+        "rarity": "☆"
       }
     ],
     "artist": "Mitsuhiro Arita",
@@ -698,6 +720,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -709,6 +732,11 @@
       {
         "card_id": "A1a-76",
         "version": "Mythical Island #76",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-234",
+        "version": "Wisdom of Sea and Sky #234",
         "rarity": "☆☆"
       }
     ],
@@ -740,6 +768,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -782,6 +811,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -819,6 +849,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -856,6 +887,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -893,6 +925,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -930,6 +963,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -967,6 +1001,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1004,6 +1039,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1041,6 +1077,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1078,6 +1115,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1115,6 +1153,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1152,6 +1191,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1194,6 +1234,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1242,6 +1283,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1294,6 +1336,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1331,6 +1374,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1368,6 +1412,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1405,6 +1450,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1442,6 +1488,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1479,6 +1526,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1516,6 +1564,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1553,6 +1602,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1590,6 +1640,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1597,6 +1648,11 @@
         "card_id": "A1a-41",
         "version": "Mythical Island #41",
         "rarity": "◊"
+      },
+      {
+        "card_id": "A4-221",
+        "version": "Wisdom of Sea and Sky #221",
+        "rarity": "☆"
       }
     ],
     "artist": "Akira Komayama",
@@ -1627,6 +1683,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1664,6 +1721,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1701,6 +1759,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1738,6 +1797,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1775,6 +1835,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1827,6 +1888,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1869,6 +1931,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1906,6 +1969,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1943,6 +2007,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -1980,6 +2045,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2017,6 +2083,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2054,6 +2121,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2091,6 +2159,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2128,6 +2197,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2165,6 +2235,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2202,6 +2273,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2239,6 +2311,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2276,6 +2349,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2323,6 +2397,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2360,6 +2435,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2397,6 +2473,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2425,6 +2502,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2457,6 +2535,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2484,6 +2563,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2511,6 +2591,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2543,6 +2624,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2575,6 +2657,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2617,6 +2700,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2664,6 +2748,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2706,6 +2791,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2748,6 +2834,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2790,6 +2877,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2832,6 +2920,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2874,6 +2963,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2926,6 +3016,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -2937,6 +3028,11 @@
       {
         "card_id": "A1a-76",
         "version": "Mythical Island #76",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-234",
+        "version": "Wisdom of Sea and Sky #234",
         "rarity": "☆☆"
       }
     ],
@@ -2974,6 +3070,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3026,6 +3123,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3078,6 +3176,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3115,6 +3214,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3147,6 +3247,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3179,6 +3280,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3227,6 +3329,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3279,6 +3382,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3331,6 +3435,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [
@@ -3389,6 +3494,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "mythicalisland(a1a)",
     "pack": "mewpack",
     "alternate_versions": [

--- a/frontend/assets/cards/A2.json
+++ b/frontend/assets/cards/A2.json
@@ -24,6 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -61,6 +62,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -98,6 +100,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -135,6 +138,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -172,6 +176,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -214,6 +219,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -251,6 +257,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -267,6 +274,11 @@
       {
         "card_id": "A2-196",
         "version": "Space-Time Smackdown #196",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-232",
+        "version": "Wisdom of Sea and Sky #232",
         "rarity": "☆☆"
       }
     ],
@@ -298,6 +310,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -335,6 +348,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -372,6 +386,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -414,6 +429,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -451,6 +467,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -488,6 +505,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -525,6 +543,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -562,6 +581,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -599,6 +619,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -636,6 +657,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -678,6 +700,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -715,6 +738,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -757,6 +781,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -794,6 +819,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -831,6 +857,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -873,6 +900,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -910,6 +938,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -947,6 +976,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -984,6 +1014,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1021,6 +1052,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1063,6 +1095,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1100,6 +1133,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1147,6 +1181,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1184,6 +1219,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -1221,6 +1257,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -1258,6 +1295,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -1300,6 +1338,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1337,6 +1376,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1379,6 +1419,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1416,6 +1457,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1453,6 +1495,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1490,6 +1533,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1527,6 +1571,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1564,6 +1609,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1606,6 +1652,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1643,6 +1690,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1680,6 +1728,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1717,6 +1766,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1754,6 +1804,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1791,6 +1842,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1828,6 +1880,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1871,6 +1924,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1923,6 +1977,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -1970,6 +2025,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2007,6 +2063,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2044,6 +2101,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2081,6 +2139,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2123,6 +2182,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2165,6 +2225,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2202,6 +2263,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2244,6 +2306,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2286,6 +2349,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2323,6 +2387,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2360,6 +2425,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2376,6 +2442,11 @@
       {
         "card_id": "A2-198",
         "version": "Space-Time Smackdown #198",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-236",
+        "version": "Wisdom of Sea and Sky #236",
         "rarity": "☆☆"
       }
     ],
@@ -2407,6 +2478,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -2449,6 +2521,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2491,6 +2564,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2528,6 +2602,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2565,6 +2640,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -2572,6 +2648,11 @@
         "card_id": "A2-66",
         "version": "Space-Time Smackdown #66",
         "rarity": "◊"
+      },
+      {
+        "card_id": "A4-220",
+        "version": "Wisdom of Sea and Sky #220",
+        "rarity": "☆"
       }
     ],
     "artist": "Sumiyoshi Kizuki",
@@ -2602,6 +2683,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -2618,6 +2700,11 @@
       {
         "card_id": "A2-199",
         "version": "Space-Time Smackdown #199",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-237",
+        "version": "Wisdom of Sea and Sky #237",
         "rarity": "☆☆"
       }
     ],
@@ -2649,6 +2736,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2691,6 +2779,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2733,6 +2822,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2770,6 +2860,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2807,6 +2898,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2844,6 +2936,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2886,6 +2979,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -2923,6 +3017,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2960,6 +3055,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3002,6 +3098,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3039,6 +3136,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3081,6 +3179,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3123,6 +3222,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3160,6 +3260,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3197,6 +3298,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3239,6 +3341,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3276,6 +3379,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3313,6 +3417,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3350,6 +3455,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3387,6 +3493,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3424,6 +3531,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3461,6 +3569,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3498,6 +3607,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3535,6 +3645,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3572,6 +3683,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3614,6 +3726,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3656,6 +3769,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3693,6 +3807,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3745,6 +3860,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3782,6 +3898,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -3819,6 +3936,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3856,6 +3974,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -3872,6 +3991,11 @@
       {
         "card_id": "A2-201",
         "version": "Space-Time Smackdown #201",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-238",
+        "version": "Wisdom of Sea and Sky #238",
         "rarity": "☆☆"
       }
     ],
@@ -3903,6 +4027,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3940,6 +4065,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3977,6 +4103,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4014,6 +4141,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4051,6 +4179,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4093,6 +4222,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4130,6 +4260,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4167,6 +4298,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4209,6 +4341,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4246,6 +4379,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4283,6 +4417,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4335,6 +4470,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4377,6 +4513,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4414,6 +4551,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4451,6 +4589,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4488,6 +4627,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4525,6 +4665,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4562,6 +4703,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4599,6 +4741,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4642,6 +4785,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4694,6 +4838,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -4736,6 +4881,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4773,6 +4919,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4810,6 +4957,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4852,6 +5000,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4859,6 +5008,11 @@
         "card_id": "A2-124",
         "version": "Space-Time Smackdown #124",
         "rarity": "◊"
+      },
+      {
+        "card_id": "A4-230",
+        "version": "Wisdom of Sea and Sky #230",
+        "rarity": "☆"
       }
     ],
     "artist": "Yukiko Baba",
@@ -4889,6 +5043,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -4905,6 +5060,11 @@
       {
         "card_id": "A2-203",
         "version": "Space-Time Smackdown #203",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-239",
+        "version": "Wisdom of Sea and Sky #239",
         "rarity": "☆☆"
       }
     ],
@@ -4936,6 +5096,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4973,6 +5134,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5010,6 +5172,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5047,6 +5210,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5084,6 +5248,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5121,6 +5286,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5158,6 +5324,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5195,6 +5362,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5232,6 +5400,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5274,6 +5443,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5316,6 +5486,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5353,6 +5524,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5390,6 +5562,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5427,6 +5600,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5469,6 +5643,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5506,6 +5681,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5543,6 +5719,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5580,6 +5757,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5612,6 +5790,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5639,6 +5818,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5666,6 +5846,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5693,6 +5874,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5720,6 +5902,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5747,6 +5930,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5774,6 +5958,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5806,6 +5991,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5838,6 +6024,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5870,6 +6057,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5902,6 +6090,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -5934,6 +6123,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -5976,6 +6166,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6018,6 +6209,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6060,6 +6252,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6102,6 +6295,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6144,6 +6338,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6186,6 +6381,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6228,6 +6424,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6275,6 +6472,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6317,6 +6515,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6359,6 +6558,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6401,6 +6601,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6443,6 +6644,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6485,6 +6687,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6527,6 +6730,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6569,6 +6773,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6611,6 +6816,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6653,6 +6859,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6695,6 +6902,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6737,6 +6945,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6779,6 +6988,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6821,6 +7031,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6863,6 +7074,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6905,6 +7117,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -6947,6 +7160,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -6989,6 +7203,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7005,6 +7220,11 @@
       {
         "card_id": "A2-196",
         "version": "Space-Time Smackdown #196",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-232",
+        "version": "Wisdom of Sea and Sky #232",
         "rarity": "☆☆"
       }
     ],
@@ -7036,6 +7256,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7089,6 +7310,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7141,6 +7363,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7157,6 +7380,11 @@
       {
         "card_id": "A2-198",
         "version": "Space-Time Smackdown #198",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-236",
+        "version": "Wisdom of Sea and Sky #236",
         "rarity": "☆☆"
       }
     ],
@@ -7188,6 +7416,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7204,6 +7433,11 @@
       {
         "card_id": "A2-199",
         "version": "Space-Time Smackdown #199",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-237",
+        "version": "Wisdom of Sea and Sky #237",
         "rarity": "☆☆"
       }
     ],
@@ -7235,6 +7469,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7287,6 +7522,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7303,6 +7539,11 @@
       {
         "card_id": "A2-201",
         "version": "Space-Time Smackdown #201",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-238",
+        "version": "Wisdom of Sea and Sky #238",
         "rarity": "☆☆"
       }
     ],
@@ -7334,6 +7575,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7392,6 +7634,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7444,6 +7687,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7460,6 +7704,11 @@
       {
         "card_id": "A2-203",
         "version": "Space-Time Smackdown #203",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-239",
+        "version": "Wisdom of Sea and Sky #239",
         "rarity": "☆☆"
       }
     ],
@@ -7481,6 +7730,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7513,6 +7763,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7545,6 +7796,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7577,6 +7829,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7609,6 +7862,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7641,6 +7895,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7683,6 +7938,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7699,6 +7955,11 @@
       {
         "card_id": "A2-196",
         "version": "Space-Time Smackdown #196",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-232",
+        "version": "Wisdom of Sea and Sky #232",
         "rarity": "☆☆"
       }
     ],
@@ -7730,6 +7991,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7777,6 +8039,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7793,6 +8056,11 @@
       {
         "card_id": "A2-198",
         "version": "Space-Time Smackdown #198",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-236",
+        "version": "Wisdom of Sea and Sky #236",
         "rarity": "☆☆"
       }
     ],
@@ -7824,6 +8092,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7840,6 +8109,11 @@
       {
         "card_id": "A2-199",
         "version": "Space-Time Smackdown #199",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-237",
+        "version": "Wisdom of Sea and Sky #237",
         "rarity": "☆☆"
       }
     ],
@@ -7871,6 +8145,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -7923,6 +8198,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -7939,6 +8215,11 @@
       {
         "card_id": "A2-201",
         "version": "Space-Time Smackdown #201",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-238",
+        "version": "Wisdom of Sea and Sky #238",
         "rarity": "☆☆"
       }
     ],
@@ -7970,6 +8251,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -8022,6 +8304,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -8038,6 +8321,11 @@
       {
         "card_id": "A2-203",
         "version": "Space-Time Smackdown #203",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-239",
+        "version": "Wisdom of Sea and Sky #239",
         "rarity": "☆☆"
       }
     ],
@@ -8075,6 +8363,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "palkiapack",
     "alternate_versions": [
@@ -8133,6 +8422,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "dialgapack",
     "alternate_versions": [
@@ -8191,6 +8481,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [
@@ -8249,6 +8540,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "space-timesmackdown(a2)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/A2a.json
+++ b/frontend/assets/cards/A2a.json
@@ -24,6 +24,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -61,6 +62,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -98,6 +100,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -135,6 +138,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -172,6 +176,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -209,6 +214,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -246,6 +252,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -283,6 +290,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -325,6 +333,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -362,6 +371,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -378,6 +388,11 @@
       {
         "card_id": "A2a-91",
         "version": "Triumphant Light #91",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-233",
+        "version": "Wisdom of Sea and Sky #233",
         "rarity": "☆☆"
       }
     ],
@@ -409,6 +424,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -446,6 +462,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -488,6 +505,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -525,6 +543,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -567,6 +586,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -604,6 +624,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -641,6 +662,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -678,6 +700,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -715,6 +738,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -752,6 +776,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -789,6 +814,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -826,6 +852,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -842,6 +869,11 @@
       {
         "card_id": "A2a-92",
         "version": "Triumphant Light #92",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-235",
+        "version": "Wisdom of Sea and Sky #235",
         "rarity": "☆☆"
       }
     ],
@@ -873,6 +905,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -910,6 +943,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -947,6 +981,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -984,6 +1019,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1026,6 +1062,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1063,6 +1100,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1100,6 +1138,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1137,6 +1176,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1174,6 +1214,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1216,6 +1257,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1253,6 +1295,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1290,6 +1333,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1332,6 +1376,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1369,6 +1414,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1411,6 +1457,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1448,6 +1495,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1485,6 +1533,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1522,6 +1571,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1559,6 +1609,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1596,6 +1647,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1633,6 +1685,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1670,6 +1723,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1707,6 +1761,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1749,6 +1804,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1792,6 +1848,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1839,6 +1896,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1876,6 +1934,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1913,6 +1972,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1950,6 +2010,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -1987,6 +2048,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2024,6 +2086,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2066,6 +2129,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2103,6 +2167,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2140,6 +2205,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2177,6 +2243,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2224,6 +2291,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2261,6 +2329,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2298,6 +2367,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2335,6 +2405,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2372,6 +2443,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2409,6 +2481,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2451,6 +2524,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2488,6 +2562,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2525,6 +2600,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2562,6 +2638,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2599,6 +2676,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2636,6 +2714,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2678,6 +2757,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2715,6 +2795,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2757,6 +2838,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2789,6 +2871,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2821,6 +2904,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2853,6 +2937,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2895,6 +2980,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2937,6 +3023,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -2979,6 +3066,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3021,6 +3109,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3063,6 +3152,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3105,6 +3195,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3147,6 +3238,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3163,6 +3255,11 @@
       {
         "card_id": "A2a-91",
         "version": "Triumphant Light #91",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-233",
+        "version": "Wisdom of Sea and Sky #233",
         "rarity": "☆☆"
       }
     ],
@@ -3194,6 +3291,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3210,6 +3308,11 @@
       {
         "card_id": "A2a-92",
         "version": "Triumphant Light #92",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-235",
+        "version": "Wisdom of Sea and Sky #235",
         "rarity": "☆☆"
       }
     ],
@@ -3247,6 +3350,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3294,6 +3398,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3341,6 +3446,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3383,6 +3489,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3415,6 +3522,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3447,6 +3555,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3479,6 +3588,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3521,6 +3631,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3537,6 +3648,11 @@
       {
         "card_id": "A2a-91",
         "version": "Triumphant Light #91",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-233",
+        "version": "Wisdom of Sea and Sky #233",
         "rarity": "☆☆"
       }
     ],
@@ -3568,6 +3684,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3584,6 +3701,11 @@
       {
         "card_id": "A2a-92",
         "version": "Triumphant Light #92",
+        "rarity": "☆☆"
+      },
+      {
+        "card_id": "A4-235",
+        "version": "Wisdom of Sea and Sky #235",
         "rarity": "☆☆"
       }
     ],
@@ -3621,6 +3743,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3668,6 +3791,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3715,6 +3839,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [
@@ -3767,6 +3892,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "triumphantlight(a2a)",
     "pack": "arceuspack",
     "alternate_versions": [

--- a/frontend/assets/cards/A2b.json
+++ b/frontend/assets/cards/A2b.json
@@ -24,6 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -66,6 +67,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -108,6 +110,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -155,6 +158,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -197,6 +201,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -239,6 +244,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -276,6 +282,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -318,6 +325,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -360,6 +368,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -408,6 +417,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -455,6 +465,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -492,6 +503,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -529,6 +541,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -566,6 +579,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -603,6 +617,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -640,6 +655,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -682,6 +698,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -719,6 +736,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -761,6 +779,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -808,6 +827,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -850,6 +870,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -892,6 +913,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -939,6 +961,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -976,6 +999,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1013,6 +1037,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1060,6 +1085,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1097,6 +1123,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1134,6 +1161,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1176,6 +1204,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1213,6 +1242,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1250,6 +1280,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1287,6 +1318,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1324,6 +1356,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1361,6 +1394,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1398,6 +1432,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1445,6 +1480,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1482,6 +1518,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1519,6 +1556,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1556,6 +1594,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1603,6 +1642,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1640,6 +1680,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1677,6 +1718,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1724,6 +1766,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1771,6 +1814,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1808,6 +1852,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1845,6 +1890,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1882,6 +1928,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1919,6 +1966,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1966,6 +2014,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2003,6 +2052,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2040,6 +2090,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2082,6 +2133,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2119,6 +2171,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2156,6 +2209,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2203,6 +2257,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2245,6 +2300,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2287,6 +2343,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2329,6 +2386,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2366,6 +2424,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2403,6 +2462,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2445,6 +2505,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2492,6 +2553,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2529,6 +2591,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2566,6 +2629,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2608,6 +2672,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2655,6 +2720,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2692,6 +2758,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2729,6 +2796,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2761,6 +2829,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2793,6 +2862,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2825,6 +2895,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2857,6 +2928,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2899,6 +2971,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2941,6 +3014,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2983,6 +3057,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3025,6 +3100,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3067,6 +3143,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3109,6 +3186,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3156,6 +3234,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3209,6 +3288,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3256,6 +3336,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3303,6 +3384,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3350,6 +3432,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3397,6 +3480,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3444,6 +3528,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3491,6 +3576,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3538,6 +3624,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3575,6 +3662,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3607,6 +3695,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3639,6 +3728,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3671,6 +3761,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3713,6 +3804,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3760,6 +3852,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3807,6 +3900,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3854,6 +3948,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3901,6 +3996,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3948,6 +4044,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3990,6 +4087,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4032,6 +4130,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4074,6 +4173,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4116,6 +4216,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4158,6 +4259,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4200,6 +4302,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4247,6 +4350,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4294,6 +4398,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4336,6 +4441,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4378,6 +4484,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4431,6 +4538,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4478,6 +4586,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4525,6 +4634,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4562,6 +4672,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "shiningrevelry(a2b)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/A3.json
+++ b/frontend/assets/cards/A3.json
@@ -24,6 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -66,6 +67,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -113,6 +115,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -150,6 +153,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -187,6 +191,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -224,6 +229,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -261,6 +267,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -298,6 +305,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -335,6 +343,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -372,6 +381,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -409,6 +419,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -452,6 +463,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -499,6 +511,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -536,6 +549,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -573,6 +587,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -610,6 +625,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -652,6 +668,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -689,6 +706,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -726,6 +744,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -763,6 +782,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -805,6 +825,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -842,6 +863,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -879,6 +901,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -926,6 +949,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -968,6 +992,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1005,6 +1030,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1042,6 +1068,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1084,6 +1111,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1121,6 +1149,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1158,6 +1187,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1195,6 +1225,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1232,6 +1263,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1275,6 +1307,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1322,6 +1355,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1359,6 +1393,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1396,6 +1431,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1433,6 +1469,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1475,6 +1512,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1512,6 +1550,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1549,6 +1588,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1591,6 +1631,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1633,6 +1674,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1670,6 +1712,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1707,6 +1750,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1744,6 +1788,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1781,6 +1826,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1818,6 +1864,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1855,6 +1902,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1892,6 +1940,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -1939,6 +1988,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -1976,6 +2026,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -2023,6 +2074,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2060,6 +2112,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2097,6 +2150,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -2139,6 +2193,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2176,6 +2231,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -2218,6 +2274,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2255,6 +2312,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2302,6 +2360,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2339,6 +2398,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2376,6 +2436,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2413,6 +2474,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2450,6 +2512,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2487,6 +2550,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -2524,6 +2588,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -2561,6 +2626,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2603,6 +2669,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -2640,6 +2707,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2682,6 +2750,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2719,6 +2788,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2756,6 +2826,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2793,6 +2864,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2830,6 +2902,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -2867,6 +2940,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2904,6 +2978,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2941,6 +3016,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -2978,6 +3054,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3015,6 +3092,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3057,6 +3135,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3094,6 +3173,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3136,6 +3216,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3178,6 +3259,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3215,6 +3297,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3257,6 +3340,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3299,6 +3383,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3346,6 +3431,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3383,6 +3469,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3435,6 +3522,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3472,6 +3560,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3509,6 +3598,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3546,6 +3636,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3583,6 +3674,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3620,6 +3712,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3657,6 +3750,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3694,6 +3788,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3731,6 +3826,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3768,6 +3864,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3810,6 +3907,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3852,6 +3950,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3889,6 +3988,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -3931,6 +4031,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -3968,6 +4069,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4005,6 +4107,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4047,6 +4150,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4094,6 +4198,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4136,6 +4241,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4173,6 +4279,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4210,6 +4317,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4247,6 +4355,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4284,6 +4393,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4321,6 +4431,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4368,6 +4479,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4405,6 +4517,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4442,6 +4555,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4479,6 +4593,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4516,6 +4631,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4553,6 +4669,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4590,6 +4707,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4627,6 +4745,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4664,6 +4783,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4701,6 +4821,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4738,6 +4859,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4790,6 +4912,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4832,6 +4955,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -4874,6 +4998,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4911,6 +5036,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4948,6 +5074,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -4985,6 +5112,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5022,6 +5150,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5059,6 +5188,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5096,6 +5226,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5133,6 +5264,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5170,6 +5302,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5212,6 +5345,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5249,6 +5383,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5286,6 +5421,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5323,6 +5459,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5360,6 +5497,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5397,6 +5535,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5439,6 +5578,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5476,6 +5616,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5508,6 +5649,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5535,6 +5677,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5562,6 +5705,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -5589,6 +5733,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5616,6 +5761,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5643,6 +5789,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5670,6 +5817,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5702,6 +5850,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5734,6 +5883,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5766,6 +5916,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5803,6 +5954,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5835,6 +5987,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5867,6 +6020,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5899,6 +6053,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -5946,6 +6101,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -5993,6 +6149,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6035,6 +6192,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6077,6 +6235,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6119,6 +6278,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6161,6 +6321,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6203,6 +6364,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6245,6 +6407,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6287,6 +6450,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6329,6 +6493,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6371,6 +6536,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6413,6 +6579,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6455,6 +6622,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6497,6 +6665,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6539,6 +6708,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6581,6 +6751,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6628,6 +6799,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6670,6 +6842,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6712,6 +6885,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6754,6 +6928,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6796,6 +6971,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6838,6 +7014,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6880,6 +7057,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -6922,6 +7100,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -6970,6 +7149,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7017,6 +7197,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7070,6 +7251,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7117,6 +7299,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7164,6 +7347,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7211,6 +7395,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7258,6 +7443,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7310,6 +7496,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7357,6 +7544,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7404,6 +7592,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7446,6 +7635,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7478,6 +7668,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7510,6 +7701,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7542,6 +7734,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7579,6 +7772,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7611,6 +7805,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7643,6 +7838,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7675,6 +7871,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7728,6 +7925,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7775,6 +7973,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7828,6 +8027,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7875,6 +8075,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -7922,6 +8123,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -7969,6 +8171,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8016,6 +8219,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8068,6 +8272,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8115,6 +8320,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8162,6 +8368,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8204,6 +8411,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8241,6 +8449,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8288,6 +8497,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8340,6 +8550,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8382,6 +8593,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8429,6 +8641,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8471,6 +8684,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8518,6 +8732,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8570,6 +8785,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8612,6 +8828,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8659,6 +8876,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8701,6 +8919,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8743,6 +8962,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8785,6 +9005,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8827,6 +9048,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -8869,6 +9091,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8911,6 +9134,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -8953,6 +9177,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -9000,6 +9225,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -9047,6 +9273,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -9089,6 +9316,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -9131,6 +9359,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -9184,6 +9413,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -9231,6 +9461,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -9284,6 +9515,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -9331,6 +9563,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -9378,6 +9611,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -9430,6 +9664,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -9482,6 +9717,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "lunalapack",
     "alternate_versions": [
@@ -9529,6 +9765,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "solgaleopack",
     "alternate_versions": [
@@ -9581,6 +9818,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [
@@ -9633,6 +9871,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "celestialguardians(a3)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/A3a.json
+++ b/frontend/assets/cards/A3a.json
@@ -24,6 +24,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -61,6 +62,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -98,6 +100,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -140,6 +143,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -177,6 +181,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -220,6 +225,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -267,6 +273,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -309,6 +316,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -351,6 +359,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -398,6 +407,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -435,6 +445,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -472,6 +483,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -509,6 +521,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -546,6 +559,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -583,6 +597,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -620,6 +635,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -657,6 +673,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -694,6 +711,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -737,6 +755,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -789,6 +808,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -831,6 +851,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -873,6 +894,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -910,6 +932,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -947,6 +970,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -984,6 +1008,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1021,6 +1046,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1058,6 +1084,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1095,6 +1122,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1132,6 +1160,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1169,6 +1198,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1206,6 +1236,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1243,6 +1274,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1280,6 +1312,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1327,6 +1360,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1364,6 +1398,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1401,6 +1436,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1438,6 +1474,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1480,6 +1517,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1517,6 +1555,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1554,6 +1593,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1591,6 +1631,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1628,6 +1669,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1676,6 +1718,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1723,6 +1766,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1765,6 +1809,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1802,6 +1847,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1839,6 +1885,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1886,6 +1933,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1923,6 +1971,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1960,6 +2009,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1997,6 +2047,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2034,6 +2085,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2071,6 +2123,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2113,6 +2166,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2150,6 +2204,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2187,6 +2242,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2224,6 +2280,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2266,6 +2323,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2303,6 +2361,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2340,6 +2399,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2377,6 +2437,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2419,6 +2480,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2451,6 +2513,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2478,6 +2541,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2505,6 +2569,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2532,6 +2597,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2559,6 +2625,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2591,6 +2658,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2623,6 +2691,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2665,6 +2734,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2707,6 +2777,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2749,6 +2820,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2796,6 +2868,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2838,6 +2911,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2880,6 +2954,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2928,6 +3003,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2981,6 +3057,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3033,6 +3110,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3086,6 +3164,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3133,6 +3212,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3170,6 +3250,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3202,6 +3283,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3234,6 +3316,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3282,6 +3365,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3334,6 +3418,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3387,6 +3472,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3434,6 +3520,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3487,6 +3574,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3534,6 +3622,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3576,6 +3665,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3618,6 +3708,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3665,6 +3756,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3707,6 +3799,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3754,6 +3847,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3796,6 +3890,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3838,6 +3933,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3880,6 +3976,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3927,6 +4024,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3969,6 +4067,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4021,6 +4120,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4068,6 +4168,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4120,6 +4221,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4167,6 +4269,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "extradimensionalcrisis(a3a)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/A3b.json
+++ b/frontend/assets/cards/A3b.json
@@ -24,6 +24,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -61,6 +62,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -103,6 +105,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -140,6 +143,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -177,6 +181,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -214,6 +219,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -251,6 +257,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -288,6 +295,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -299,6 +307,11 @@
       {
         "card_id": "A3b-71",
         "version": "Eevee Grove #71",
+        "rarity": "☆"
+      },
+      {
+        "card_id": "A4-213",
+        "version": "Wisdom of Sea and Sky #213",
         "rarity": "☆"
       }
     ],
@@ -330,6 +343,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -377,6 +391,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -414,6 +429,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -451,6 +467,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -488,6 +505,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -525,6 +543,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -562,6 +581,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -599,6 +619,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -641,6 +662,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -683,6 +705,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -725,6 +748,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -762,6 +786,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -799,6 +824,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -836,6 +862,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -873,6 +900,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -916,6 +944,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -963,6 +992,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -980,6 +1010,11 @@
         "card_id": "P-A-86",
         "version": "Promo-A #86",
         "rarity": ""
+      },
+      {
+        "card_id": "A4-219",
+        "version": "Wisdom of Sea and Sky #219",
+        "rarity": "☆"
       }
     ],
     "artist": "Sanosuke Sakuma",
@@ -1010,6 +1045,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1047,6 +1083,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1084,6 +1121,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1126,6 +1164,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1163,6 +1202,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1200,6 +1240,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1237,6 +1278,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1274,6 +1316,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1316,6 +1359,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1363,6 +1407,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1400,6 +1445,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1437,6 +1483,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1479,6 +1526,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1516,6 +1564,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1553,6 +1602,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1590,6 +1640,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1627,6 +1678,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1664,6 +1716,7 @@
     "rarity": "◊◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1706,6 +1759,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1743,6 +1797,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1780,6 +1835,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1817,6 +1873,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1854,6 +1911,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1896,6 +1954,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1933,6 +1992,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -1970,6 +2030,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2007,6 +2068,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2044,6 +2106,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2091,6 +2154,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2128,6 +2192,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2170,6 +2235,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2217,6 +2283,7 @@
     "rarity": "◊◊◊◊",
     "fullart": "No",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2264,6 +2331,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2301,6 +2369,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2338,6 +2407,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2375,6 +2445,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2412,6 +2483,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2449,6 +2521,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2486,6 +2559,7 @@
     "rarity": "◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2523,6 +2597,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2555,6 +2630,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2587,6 +2663,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2614,6 +2691,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2646,6 +2724,7 @@
     "rarity": "◊◊",
     "fullart": "No",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2688,6 +2767,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2730,6 +2810,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2741,6 +2822,11 @@
       {
         "card_id": "A3b-71",
         "version": "Eevee Grove #71",
+        "rarity": "☆"
+      },
+      {
+        "card_id": "A4-213",
+        "version": "Wisdom of Sea and Sky #213",
         "rarity": "☆"
       }
     ],
@@ -2772,6 +2858,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2814,6 +2901,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2856,6 +2944,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2873,6 +2962,11 @@
         "card_id": "P-A-86",
         "version": "Promo-A #86",
         "rarity": ""
+      },
+      {
+        "card_id": "A4-219",
+        "version": "Wisdom of Sea and Sky #219",
+        "rarity": "☆"
       }
     ],
     "artist": "Nisota Niso",
@@ -2903,6 +2997,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2945,6 +3040,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -2987,6 +3083,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3029,6 +3126,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3071,6 +3169,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3124,6 +3223,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3171,6 +3271,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3218,6 +3319,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3265,6 +3367,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3312,6 +3415,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3349,6 +3453,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3381,6 +3486,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3423,6 +3529,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3476,6 +3583,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3523,6 +3631,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3570,6 +3679,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3617,6 +3727,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3664,6 +3775,7 @@
     "rarity": "☆☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3711,6 +3823,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3753,6 +3866,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3800,6 +3914,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3842,6 +3957,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3884,6 +4000,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3926,6 +4043,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -3968,6 +4086,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4005,6 +4124,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4047,6 +4167,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4089,6 +4210,7 @@
     "rarity": "☆",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4142,6 +4264,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4205,6 +4328,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4263,6 +4387,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4315,6 +4440,7 @@
     "rarity": "☆☆",
     "fullart": "Yes",
     "ex": "yes",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [
@@ -4357,6 +4483,7 @@
     "rarity": "Crown Rare",
     "fullart": "Yes",
     "ex": "no",
+    "baby": false,
     "set_details": "eeveegrove(a3b)",
     "pack": "everypack",
     "alternate_versions": [

--- a/frontend/assets/cards/A4.json
+++ b/frontend/assets/cards/A4.json
@@ -1931,6 +1931,11 @@
         "card_id": "A4-49",
         "version": "Wisdom of Sea and Sky #49",
         "rarity": "◊"
+      },
+      {
+        "card_id": "P-A-99",
+        "version": "Promo-A #99",
+        "rarity": ""
       }
     ],
     "artist": "Atsuko Nishida",
@@ -3030,6 +3035,11 @@
         "card_id": "A4-77",
         "version": "Wisdom of Sea and Sky #77",
         "rarity": "◊◊◊"
+      },
+      {
+        "card_id": "P-A-93",
+        "version": "Promo-A #93",
+        "rarity": ""
       }
     ],
     "artist": "Orca",
@@ -4587,6 +4597,11 @@
         "card_id": "A4-116",
         "version": "Wisdom of Sea and Sky #116",
         "rarity": "◊◊"
+      },
+      {
+        "card_id": "P-A-100",
+        "version": "Promo-A #100",
+        "rarity": ""
       }
     ],
     "artist": "kawayoo",
@@ -4663,6 +4678,11 @@
         "card_id": "A4-118",
         "version": "Wisdom of Sea and Sky #118",
         "rarity": "◊◊"
+      },
+      {
+        "card_id": "P-A-96",
+        "version": "Promo-A #96",
+        "rarity": ""
       }
     ],
     "artist": "Shin Nagasawa",
@@ -5258,6 +5278,11 @@
         "card_id": "A4-133",
         "version": "Wisdom of Sea and Sky #133",
         "rarity": "◊◊◊"
+      },
+      {
+        "card_id": "P-A-97",
+        "version": "Promo-A #97",
+        "rarity": ""
       }
     ],
     "artist": "Toshinao Aoki",

--- a/scripts/scraper.js
+++ b/scripts/scraper.js
@@ -10,8 +10,8 @@ const targetDir = 'frontend/assets/cards/'
 const imagesDir = 'frontend/public/images/en-US/'
 const imagesPath = '/images/en-US/'
 
-// const expansions = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'A3a', 'A3b', 'A4', 'P-A']
-const expansions = ['P-A']
+const expansions = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'A3a', 'A3b', 'A4', 'P-A']
+// const expansions = ['P-A']
 const packs = [
   'Pikachu pack',
   'Charizard pack',


### PR DESCRIPTION
Fixes #556 

Simply ran the scraper script again will all expansions.

Note that it added the baby field everywhere (I guess that OK, the schema will be the same everywhere now). And it added all missing alternate version cards 😃 