### PR TITLE
feat: add hyphen formatting to friend ID display

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -9,6 +9,14 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function formatFriendId(friendId: string): string {
+  if (!friendId || friendId.length !== 16) {
+    return friendId
+  }
+
+  return friendId.match(/.{4}/g)?.join('-') || friendId
+}
+
 export function getCardNameByLang(card: Card, lang: string): string {
   if (card.name === undefined || card.name === null) return ''
 

--- a/frontend/src/pages/collection/TradeMatches.tsx
+++ b/frontend/src/pages/collection/TradeMatches.tsx
@@ -17,6 +17,7 @@ import { toast } from '@/hooks/use-toast.ts'
 import { supabase } from '@/lib/Auth.ts'
 import { expansions, getCardById } from '@/lib/CardsDB'
 import { UserContext } from '@/lib/context/UserContext.ts'
+import { formatFriendId } from '@/lib/utils.ts'
 import type { AccountRow, Card, CollectionRow, Rarity } from '@/types'
 
 interface Props {
@@ -337,7 +338,7 @@ const TradeMatches: FC<Props> = ({ ownedCards, friendCards, ownAccount, friendAc
         </DialogHeader>
         <div className="flex flex-col gap-4 grow">
           <p className="pb-2">{t('featureDescription')}</p>
-          <p className="pb-2">{t('friendAccountDetails', { ...friendAccount })}</p>
+          <p className="pb-2">{t('friendAccountDetails', { ...friendAccount, friend_id: formatFriendId(friendAccount?.friend_id || '') })}</p>
 
           {!ownCollection && (
             <div className="flex flex-row gap-4 mb-4 justify-between">

--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -10,6 +10,7 @@ import { toast } from '@/hooks/use-toast.ts'
 import { allCards, expansions, sellableForTokensDictionary, tradeableRaritiesDictionary } from '@/lib/CardsDB.ts'
 import { CollectionContext } from '@/lib/context/CollectionContext.ts'
 import { UserContext } from '@/lib/context/UserContext'
+import { formatFriendId } from '@/lib/utils.ts'
 import CardDetail from '@/pages/collection/CardDetail.tsx'
 import { NoCardsNeeded } from '@/pages/trade/components/NoCardsNeeded.tsx'
 import { NoSellableCards } from '@/pages/trade/components/NoSellableCards.tsx'
@@ -90,7 +91,7 @@ function Trade() {
       cardValues += `${t('publicTradePage')} https://tcgpocketcollectiontracker.com/#/collection/${account?.friend_id}/trade\n`
     }
     if (account?.username) {
-      cardValues += `${t('friendID')} ${account.friend_id} (${account.username})\n\n`
+      cardValues += `${t('friendID')} ${formatFriendId(account.friend_id)} (${account.username})\n\n`
     }
 
     cardValues += `${t('lookingForCards')}\n`


### PR DESCRIPTION
<img width="1752" height="315" alt="image" src="https://github.com/user-attachments/assets/8320a803-05e3-43af-8877-614517e6fe67" />

(And even in the text copied to the clipboard!)

Note: I can also go with a thin space or a no-break space. In-game, the Friend ID is displayed with hyphens.