### PR TITLE
refactor(i18n): languages in native form

### DIFF
--- a/frontend/public/locales/en-US/header.json
+++ b/frontend/public/locales/en-US/header.json
@@ -5,13 +5,6 @@
   "offers": "Offers",
   "decks": "Decks",
   "selectLanguage": "Select language",
-  "languages": {
-    "es-ES": "Spanish",
-    "en-US": "English",
-    "pt-BR": "Portuguese",
-    "fr-FR": "French",
-    "it-IT": "Italian"
-  },
   "community": "Community ↗",
   "blog": "Blog ↗",
   "login": "Login",

--- a/frontend/public/locales/es-ES/header.json
+++ b/frontend/public/locales/es-ES/header.json
@@ -3,13 +3,6 @@
   "collection": "Colección",
   "trade": "Intercambios",
   "selectLanguage": "Seleccionar idioma",
-  "languages": {
-    "es-ES": "Español",
-    "en-US": "Inglés",
-    "pt-BR": "Portugués",
-    "fr-FR": "Francés",
-    "it-IT": "Italiano"
-  },
   "community": "Comunidad ↗",
   "login": "Iniciar sesión",
   "signup": "Iniciar sesión / Crear cuenta",

--- a/frontend/public/locales/fr-FR/header.json
+++ b/frontend/public/locales/fr-FR/header.json
@@ -3,13 +3,6 @@
   "collection": "Collection",
   "trade": "Échanges",
   "selectLanguage": "Sélectionner une langue",
-  "languages": {
-    "es-ES": "Espagnol",
-    "en-US": "Anglais",
-    "pt-BR": "Portugais",
-    "fr-FR": "Français",
-    "it-IT": "Italien"
-  },
   "community": "Communauté ↗",
   "login": "Se connecter",
   "signUp": "Se connecter / Créer un compte",

--- a/frontend/public/locales/it-IT/header.json
+++ b/frontend/public/locales/it-IT/header.json
@@ -3,13 +3,6 @@
   "collection": "Collezione",
   "trade": "Scambio",
   "selectLanguage": "Seleziona lingua",
-  "languages": {
-    "es-ES": "Spagnolo",
-    "en-US": "Inglese",
-    "pt-BR": "Portoghese",
-    "fr-FR": "Francese",
-    "it-IT": "Italiano"
-  },
   "community": "Community ↗",
   "login": "Login",
   "signUp": "Login / Registrazione",

--- a/frontend/public/locales/pt-BR/header.json
+++ b/frontend/public/locales/pt-BR/header.json
@@ -3,13 +3,6 @@
   "collection": "Coleção",
   "trade": "Troca",
   "selectLanguage": "Selecionar idioma",
-  "languages": {
-    "es-ES": "Espanhol",
-    "en-US": "Inglês",
-    "pt-BR": "Português",
-    "fr-FR": "Francês",
-    "it-IT": "Italiano"
-  },
   "community": "Comunidade ↗",
   "login": "Entrar",
   "signUp": "Entrar / Cadastrar-se",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -35,12 +35,12 @@ export function Header() {
   const changeLanguage = (lng: string) => i18n.changeLanguage(lng)
 
   const languages = [
-    { code: 'en-US', name: t('languages.en-US') },
-    { code: 'es-ES', name: t('languages.es-ES') },
-    { code: 'pt-BR', name: t('languages.pt-BR') },
-    { code: 'fr-FR', name: t('languages.fr-FR') },
-    { code: 'it-IT', name: t('languages.it-IT') },
-  ].sort((a, b) => a.name.localeCompare(b.name))
+    { code: 'en-US', name: 'English' },
+    { code: 'es-ES', name: 'Español' },
+    { code: 'fr-FR', name: 'Français' },
+    { code: 'it-IT', name: 'Italiano' },
+    { code: 'pt-BR', name: 'Português' },
+  ] // alphabetical language order in their native form for UX accessibility
 
   const isOverviewPage = location.pathname === '/'
 


### PR DESCRIPTION
Refactored language dropdown to use hardcoded alphabetical list in native form, removed the now unused translations. 
Implements the changes discussed in #519 to support a more user-friendly and accessible language selector.