### PR TITLE
Update local collection state atomically

### DIFF
--- a/frontend/src/lib/fetchCollection.ts
+++ b/frontend/src/lib/fetchCollection.ts
@@ -30,7 +30,6 @@ export async function fetchOwnCollection(email: string, collectionLastUpdated: D
 
   const cacheLastUpdatedRaw = localStorage.getItem(`${COLLECTION_TIMESTAMP_KEY}_${email}`)
   const cacheLastUpdated = cacheLastUpdatedRaw && new Date(cacheLastUpdatedRaw)
-  console.log(collectionLastUpdated, cacheLastUpdated)
 
   if (cacheLastUpdated && !Number.isNaN(cacheLastUpdated.getTime()) && cacheLastUpdated >= collectionLastUpdated) {
     const cachedCollection = getCollectionFromCache(email)


### PR DESCRIPTION
Might fix #601, but needs confirmation.

I believe the bug is related to creating a copy of whole `ownedCards` and holding on it for quite amount of time (basically two db detours). Other running updates (that were started earlier, but not yet commited their changes to `ownedCards`) might modify it in the meantime, and the later update reverts the state because it made the copy before the commit. Turns out concurrency is hard.