### PR TITLE
Total amount

### DIFF
--- a/frontend/public/locales/en-US/pages/card-detail.json
+++ b/frontend/public/locales/en-US/pages/card-detail.json
@@ -1,5 +1,6 @@
 {
   "text": {
+    "totalAmount": "Total amount",
     "chanceToPull": "Chance to pull: {{percent}}%",
     "hp": "HP",
     "cardType": "Card Type",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,8 @@ function App() {
   const [selectedCardId, setSelectedCardId] = useState('')
   const [selectedMissionCardOptions, setSelectedMissionCardOptions] = useState<string[]>([])
 
+  const ownedCardsMap = useMemo(() => new Map(ownedCards.map((c) => [c.card_id, c])), [ownedCards])
+
   const updateCards = async (rowsToUpdate: CollectionRowUpdate[]) => {
     if (!user || !user.user.email) {
       throw new Error('App.tsx:updateCards: User not logged in')
@@ -150,13 +152,14 @@ function App() {
   const collectionContextValue = useMemo(
     () => ({
       ownedCards,
+      ownedCardsMap,
       updateCards,
       selectedCardId,
       setSelectedCardId,
       selectedMissionCardOptions,
       setSelectedMissionCardOptions,
     }),
-    [ownedCards, selectedCardId, selectedMissionCardOptions],
+    [ownedCards, ownedCardsMap, selectedCardId, selectedMissionCardOptions],
   )
 
   const errorDiv = <div className="m-4">A new version was deployed, please refresh the page to see the latest changes.</div>

--- a/frontend/src/components/PokemonCardDetectorComponent.tsx
+++ b/frontend/src/components/PokemonCardDetectorComponent.tsx
@@ -50,7 +50,7 @@ enum State {
 
 const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete, modelPath = '/model/model.json' }) => {
   const { t } = useTranslation('scan')
-  const { ownedCards, updateCards } = use(CollectionContext)
+  const { ownedCardsMap, updateCards } = use(CollectionContext)
   const { user } = use(UserContext)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -342,8 +342,7 @@ const PokemonCardDetector: FC<PokemonCardDetectorProps> = ({ onDetectionComplete
     const cardArray: CollectionRowUpdate[] = []
 
     for (const [card_id, increment] of counts) {
-      const ownedCard = ownedCards.find((row) => row.card_id === card_id)
-      cardArray.push({ card_id, amount_owned: (ownedCard?.amount_owned ?? 0) + increment })
+      cardArray.push({ card_id, amount_owned: (ownedCardsMap.get(card_id)?.amount_owned ?? 0) + increment })
     }
 
     updateCards(cardArray)

--- a/frontend/src/lib/context/CollectionContext.ts
+++ b/frontend/src/lib/context/CollectionContext.ts
@@ -3,6 +3,7 @@ import type { CollectionRow, CollectionRowUpdate } from '@/types'
 
 interface ICollectionContext {
   ownedCards: CollectionRow[]
+  ownedCardsMap: Map<string, CollectionRow>
   updateCards: (rows: CollectionRowUpdate[]) => Promise<void>
   selectedCardId: string
   setSelectedCardId: (cardId: string) => void
@@ -12,6 +13,7 @@ interface ICollectionContext {
 
 export const CollectionContext = createContext<ICollectionContext>({
   ownedCards: [],
+  ownedCardsMap: new Map(),
   updateCards: async (_) => {},
   selectedCardId: '',
   setSelectedCardId: () => {},

--- a/frontend/src/pages/export/components/ExportWriter.tsx
+++ b/frontend/src/pages/export/components/ExportWriter.tsx
@@ -10,7 +10,7 @@ import type { ImportExportRow } from '@/types'
 
 export const ExportWriter = () => {
   const { t } = useTranslation('pages/export')
-  const { ownedCards } = use(CollectionContext)
+  const { ownedCardsMap } = use(CollectionContext)
 
   const createFile = () => {
     const json: ImportExportRow[] = allCards
@@ -19,7 +19,7 @@ export const ExportWriter = () => {
         return {
           Id: ac.card_id,
           CardName: getCardNameByLang(ac, i18n.language),
-          NumberOwned: ownedCards.find((oc) => oc.card_id === ac.card_id)?.amount_owned ?? 0,
+          NumberOwned: ownedCardsMap.get(ac.card_id)?.amount_owned ?? 0,
           Expansion: ac.expansion,
           Pack: ac.pack,
           Rarity: ac.rarity,

--- a/frontend/src/pages/import/components/ImportReader.tsx
+++ b/frontend/src/pages/import/components/ImportReader.tsx
@@ -7,7 +7,7 @@ import type { CollectionRowUpdate, ImportExportRow } from '@/types'
 
 export const ImportReader = () => {
   const { t } = useTranslation('pages/import')
-  const { ownedCards, updateCards } = use(CollectionContext)
+  const { ownedCardsMap, updateCards } = use(CollectionContext)
 
   const [processedData, setProcessedData] = useState<(ImportExportRow & { added?: boolean; updated?: boolean; removed?: boolean })[] | null>(null)
   const [numberProcessed, setNumberProcessed] = useState<number>(0)
@@ -23,7 +23,7 @@ export const ImportReader = () => {
       console.log('Row', r)
       const newAmount = Math.max(0, Number(r.NumberOwned))
       const cardId = r.Id
-      const ownedCard = ownedCards.find((row) => row.card_id === r.Id)
+      const ownedCard = ownedCardsMap.get(r.Id)
       console.log('Owned Card', ownedCard)
 
       cardArray.push({ card_id: cardId, amount_owned: newAmount })

--- a/frontend/src/pages/trade/TradeList.tsx
+++ b/frontend/src/pages/trade/TradeList.tsx
@@ -21,7 +21,7 @@ function TradeList({ trades: allTrades, update, viewHistory }: Props) {
     return (row.offering_friend_id === account?.friend_id && !row.offerer_ended) || (row.receiving_friend_id === account?.friend_id && !row.receiver_ended)
   }
 
-  const { ownedCards, updateCards } = useContext(CollectionContext)
+  const { ownedCardsMap, updateCards } = useContext(CollectionContext)
   const { account, user } = useContext(UserContext)
   const trades = viewHistory ? allTrades.filter((x) => !interesting(x)) : allTrades.filter(interesting)
   const [selectedTradeId, setSelectedTradeId] = useState<number | undefined>(undefined)
@@ -31,7 +31,7 @@ function TradeList({ trades: allTrades, update, viewHistory }: Props) {
   }
 
   const getAndIncrement = (card_id: string, increment: number): CollectionRowUpdate => {
-    return { card_id, amount_owned: (ownedCards.find((r) => r.card_id === card_id)?.amount_owned ?? 0) + increment }
+    return { card_id, amount_owned: (ownedCardsMap.get(card_id)?.amount_owned ?? 0) + increment }
   }
 
   const increment = async (row: TradeRow) => {

--- a/frontend/src/pages/trade/components/TradeListRow.tsx
+++ b/frontend/src/pages/trade/components/TradeListRow.tsx
@@ -16,7 +16,7 @@ interface Props {
 export const TradeListRow: FC<Props> = ({ row, selectedTradeId, setSelectedTradeId }) => {
   const { t, i18n } = useTranslation('trade-matches')
   const { account } = useContext(UserContext)
-  const { ownedCards } = useContext(CollectionContext)
+  const { ownedCardsMap } = useContext(CollectionContext)
 
   if (!account) {
     return null
@@ -35,7 +35,7 @@ export const TradeListRow: FC<Props> = ({ row, selectedTradeId, setSelectedTrade
         <span className="mr-2 sm:min-w-10">{card.rarity} </span>
         <span className="mr-2 sm:min-w-14 me-4">{card.card_id} </span>
         <span>{getCardNameByLang(card, i18n.language)}</span>
-        <span className="text-neutral-400 ml-auto">×{ownedCards.find((c) => c.card_id === card.card_id)?.amount_owned || 0}</span>
+        <span className="text-neutral-400 ml-auto">×{ownedCardsMap.get(card.card_id)?.amount_owned ?? 0}</span>
       </span>
     )
   }


### PR DESCRIPTION
<img width="323" height="347" alt="image" src="https://github.com/user-attachments/assets/b2066b86-5016-443f-931f-547eaf2814dd" />

Added a "Total amount" to card side panel. Also included `ownedCardsMap` in the context to speed up all the `find` operations.

Tested:
- [x] Total amount works
- [ ] `OwnedCardsMap` doesn't break `PokemonCardDetector`
- [ ] `OwnedCardsMap` doesn't break import/export
- [x] `OwnedCardsMap` doesn't break `TradeListRow`