### PR TITLE
Decouple collection and missions

### DIFF
--- a/frontend/public/locales/en-US/common.json
+++ b/frontend/public/locales/en-US/common.json
@@ -1,0 +1,4 @@
+{
+  "noAccount": "Account not found",
+  "loading": "Loading"
+}

--- a/frontend/public/locales/en-US/pages/collection.json
+++ b/frontend/public/locales/en-US/pages/collection.json
@@ -1,4 +1,6 @@
 {
+  "goToCollection": "Go to collection",
+  "goToMissions": "Go to missions",
   "publicCollectionTitle": "You are viewing the public collection of \"{{username}}\".",
   "publicCollectionDescription": "You are currently viewing a public collection. Click any of the navigation items to return to your own collection.",
   "showPossibleTrades": "Show possible trades",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { DialogContext } from './context/DialogContext.ts'
 // Lazy import for chunking
 const Overview = loadable(() => import('./pages/overview/Overview.tsx'))
 const Collection = loadable(() => import('./pages/collection/Collection.tsx'))
+const Missions = loadable(() => import('./pages/collection/Missions.tsx'))
 const Decks = loadable(() => import('./pages/decks/Decks.tsx'))
 const Trade = loadable(() => import('./pages/trade/Trade.tsx'))
 const TradeWith = loadable(() => import('./pages/trade/TradeWith.tsx'))
@@ -71,6 +72,7 @@ function App() {
       errorElement: errorDiv,
       children: [
         { path: '/', element: <Overview /> },
+        { path: '/collection/missions', element: <Missions /> },
         { path: '/collection/:friendId?', element: <Collection /> },
         { path: '/decks', element: <Decks /> },
         { path: '/trade', element: <Trade /> },

--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -27,9 +27,7 @@ export function CardsTable({ cards, resetScrollTrigger, showStats, extraOffset, 
     if (scrollRef.current) {
       const headerHeight = (document.querySelector('#header') as HTMLElement | null)?.offsetHeight || 0
       const filterbarHeight = (document.querySelector('#filterbar') as HTMLElement | null)?.offsetHeight || 0
-      const isMobileDevice = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent)
-      const offset = isMobileDevice ? 0 : extraOffset
-      const maxHeight = window.innerHeight - headerHeight - filterbarHeight - offset
+      const maxHeight = window.innerHeight - headerHeight - filterbarHeight - extraOffset
       setScrollContainerHeight(`${maxHeight}px`)
     }
   }

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -1,6 +1,7 @@
 import i18n from 'i18next'
-import { type Dispatch, type FC, type JSX, type SetStateAction, useEffect, useMemo } from 'react'
+import { type Dispatch, type FC, type SetStateAction, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router'
 import { BatchUpdateDialog } from '@/components/BatchUpdateDialog.tsx'
 import ExpansionsFilter from '@/components/filters/ExpansionsFilter.tsx'
 import NumberFilter from '@/components/filters/NumberFilter.tsx'
@@ -12,7 +13,7 @@ import { Button } from '@/components/ui/button.tsx'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog.tsx'
 import { allCards, basicRarities, expansions } from '@/lib/CardsDB.ts'
 import { levenshtein } from '@/lib/levenshtein'
-import { cn, getCardNameByLang } from '@/lib/utils'
+import { getCardNameByLang } from '@/lib/utils'
 import { useProfileDialog } from '@/services/account/useAccount'
 import type { Card, CardType, CollectionRow, Rarity } from '@/types'
 import AllTextSearchFilter from './filters/AllTextSearchFilter'
@@ -35,9 +36,6 @@ export interface Filters {
 }
 
 interface Props {
-  children?: JSX.Element
-  className?: string
-
   cards: CollectionRow[] | null
 
   filters: Filters
@@ -68,21 +66,12 @@ interface Props {
 
   batchUpdate?: boolean
   share?: boolean
+  missionsButton?: boolean
 }
 
-const FilterPanel: FC<Props> = ({
-  children,
-  cards,
-  filters,
-  setFilters,
-  onFiltersChanged,
-  visibleFilters,
-  filtersDialog,
-  batchUpdate,
-  share,
-  className,
-}: Props) => {
+const FilterPanel: FC<Props> = ({ cards, filters, setFilters, onFiltersChanged, visibleFilters, filtersDialog, batchUpdate, share, missionsButton }: Props) => {
   const { t } = useTranslation(['pages/collection'])
+  const navigate = useNavigate()
   const { setIsProfileDialogOpen } = useProfileDialog()
 
   const setFilterChange = (filters: Partial<Filters>) => {
@@ -234,9 +223,7 @@ const FilterPanel: FC<Props> = ({
   }
 
   return (
-    <div id="filterbar" className={cn('flex flex-col gap-x-2 flex-wrap', className)}>
-      {children}
-
+    <div id="filterbar" className="flex flex-col gap-x-2 flex-wrap">
       {visibleFilters?.expansions && (
         <div className="flex gap-x-2 px-4 mb-2">
           <ExpansionsFilter value={filters.expansion} onChange={onExpansionChange} />
@@ -304,6 +291,11 @@ const FilterPanel: FC<Props> = ({
                 >
                   {t('filters.clear')}
                 </Button>
+                {missionsButton && (
+                  <Button className="mt-2" variant="outline" onClick={() => navigate('/collection/missions')}>
+                    Go to missions
+                  </Button>
+                )}
               </div>
             </DialogContent>
           </Dialog>

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -293,7 +293,7 @@ const FilterPanel: FC<Props> = ({ cards, filters, setFilters, onFiltersChanged, 
                 </Button>
                 {missionsButton && (
                   <Button className="mt-2" variant="outline" onClick={() => navigate('/collection/missions')}>
-                    Go to missions
+                    {t('goToMissions')}
                   </Button>
                 )}
               </div>

--- a/frontend/src/components/filters/ExpansionsFilter.tsx
+++ b/frontend/src/components/filters/ExpansionsFilter.tsx
@@ -5,15 +5,16 @@ import { expansions } from '@/lib/CardsDB.ts'
 interface Props {
   value: string
   onChange: (expansion: string) => void
+  allowAll?: boolean
 }
-const ExpansionsFilter: FC<Props> = ({ value, onChange }) => {
+const ExpansionsFilter: FC<Props> = ({ value, onChange, allowAll = true }) => {
   const { t } = useTranslation('common/sets')
 
   return (
     <label className="flex items-baseline justify-between gap-5 px-3 my-auto border-1 border-neutral-700 rounded-md p-1 bg-neutral-800 text-neutral-400">
       <div className="text-sm">{t('expansion')}</div>
       <select value={value} onChange={(e) => onChange(e.target.value)} className="min-h-[27px] text-sm">
-        <option value="all">{t('all')}</option>
+        {allowAll && <option value="all">{t('all')}</option>}
         {expansions.map((expansion) => (
           <option key={expansion.id} value={expansion.id}>
             {t(expansion.name)}

--- a/frontend/src/components/filters/PackFilter.tsx
+++ b/frontend/src/components/filters/PackFilter.tsx
@@ -14,7 +14,6 @@ const PackFilter: FC<Props> = ({ value, onChange, expansion, className }) => {
   const { t } = useTranslation('common/packs')
 
   let packsToShow = getExpansionById(expansion)?.packs
-  const showMissions = !(packsToShow === undefined || expansion === 'P-A')
   if (packsToShow === undefined || packsToShow.length <= 1) {
     packsToShow = []
   }
@@ -34,7 +33,6 @@ const PackFilter: FC<Props> = ({ value, onChange, expansion, className }) => {
               {t(pack.name)}
             </TabsTrigger>
           ))}
-        {showMissions && <TabsTrigger value="missions">{t('missions')}</TabsTrigger>}
       </TabsList>
     </Tabs>
   )

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -1,120 +1,65 @@
 import { Siren } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useMediaQuery } from 'react-responsive'
 import { useNavigate, useParams } from 'react-router'
-import { CardsTable } from '@/components/CardsTable.tsx'
-import FilterPanel, { type Filters } from '@/components/FiltersPanel'
-import { MissionsTable } from '@/components/MissionsTable.tsx'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx'
-import { Button } from '@/components/ui/button.tsx'
-import MissionDetail from '@/pages/collection/MissionDetail.tsx'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 import { usePublicAccount } from '@/services/account/useAccount.ts'
 import { useCollection, usePublicCollection } from '@/services/collection/useCollection'
-import type { Card, Mission } from '@/types'
+import CollectionCards from './CollectionCards'
+import { Missions } from './Missions'
 
 function Collection() {
-  const navigate = useNavigate()
+  const { t } = useTranslation(['pages/collection'])
+
   const { friendId } = useParams()
+  const navigate = useNavigate()
 
   const { data: friendAccount } = usePublicAccount(friendId)
   const { data: friendCards } = usePublicCollection(friendId)
 
-  const { t } = useTranslation(['pages/collection'])
-  const isMobile = useMediaQuery({ query: '(max-width: 767px)' })
+  const { data: ownedCards } = useCollection()
 
-  const { data: ownedCards = [] } = useCollection()
-  const [selectedMissionCardOptions, setSelectedMissionCardOptions] = useState<string[]>([])
+  const [missions, setMissions] = useState(false)
 
-  const [filters, setFilters] = useState<Filters>({
-    search: '',
-    expansion: 'all',
-    pack: 'all',
-    cardType: [],
-    rarity: [],
-    owned: 'all',
-    sortBy: 'expansion-newest',
-    minNumber: 0,
-    maxNumber: 100,
-    deckbuildingMode: false,
-    allTextSearch: false,
-  })
-  const [resetScrollTrigger, setResetScrollTrigger] = useState(false)
-  const [filteredCards, setFilteredCards] = useState<Card[] | null>(null)
-  const [missions, setMissions] = useState<Mission[] | null>(null)
+  if (friendId) {
+    if (friendAccount === null) {
+      return <p className="text-xl text-center py-8">Account not found</p>
+    } else if (friendCards === null) {
+      return <p className="text-xl text-center py-8">Not a public account</p>
+    } else if (friendCards === undefined || friendAccount === undefined) {
+      return <p className="text-xl text-center py-8">Loading...</p>
+    }
 
-  const cardCollection = friendCards ?? ownedCards
+    return (
+      <div className="flex flex-col gap-y-1 mx-auto max-w-[900px]">
+        <Alert className="mb-4 border-1 border-neutral-700 shadow-none">
+          <Siren className="h-4 w-4" />
+          <AlertTitle>{t('publicCollectionTitle', { username: friendAccount?.username })}</AlertTitle>
+          <AlertDescription>
+            <div className="flex items-center">
+              {t('publicCollectionDescription')}
+              <Button className="mb-4" onClick={() => navigate(`/trade/${friendAccount?.friend_id}`)}>
+                {t('showPossibleTrades')}
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+        <CollectionCards cards={friendCards} isPublic={true} extraOffset={136} />
+      </div>
+    )
+  }
 
-  useEffect(() => {
-    setResetScrollTrigger(true)
-    const timeout = setTimeout(() => setResetScrollTrigger(false), 100)
-    return () => clearTimeout(timeout)
-  }, [filters])
+  if (ownedCards === undefined) {
+    return <p className="text-xl text-center py-8">Loading...</p>
+  }
 
   return (
     <div className="flex flex-col gap-y-1 mx-auto max-w-[900px]">
-      <FilterPanel
-        cards={cardCollection}
-        filters={filters}
-        setFilters={setFilters}
-        onFiltersChanged={(cards) => setFilteredCards(cards)}
-        onChangeToMissions={(missions) => setMissions(missions)}
-        visibleFilters={{ expansions: !isMobile, allTextSearch: !isMobile, search: true, owned: !isMobile, rarity: !isMobile }}
-        filtersDialog={{
-          expansions: true,
-          pack: true,
-          search: true,
-          owned: true,
-          sortBy: true,
-          rarity: true,
-          cardType: true,
-          amount: true,
-          deckBuildingMode: true,
-          allTextSearch: true,
-        }}
-        batchUpdate={Boolean(friendAccount)}
-        share
-      >
-        <div>
-          {friendAccount && (
-            <Alert className="mb-4 border-1 border-neutral-700 shadow-none">
-              <Siren className="h-4 w-4" />
-              <AlertTitle>{t('publicCollectionTitle', { username: friendAccount?.username })}</AlertTitle>
-              <AlertDescription>
-                <div className="flex items-center">
-                  {t('publicCollectionDescription')}
-                  <Button className="mb-4" onClick={() => navigate(`/trade/${friendAccount?.friend_id}`)}>
-                    {t('showPossibleTrades')}
-                  </Button>
-                </div>
-              </AlertDescription>
-            </Alert>
-          )}
-        </div>
-      </FilterPanel>
-      <div>
-        {filteredCards && !missions && (
-          <CardsTable
-            cards={filteredCards}
-            resetScrollTrigger={resetScrollTrigger}
-            showStats={!filters.deckbuildingMode}
-            extraOffset={24}
-            editable={!filters.deckbuildingMode && !friendAccount}
-          />
-        )}
-      </div>
-      <div>
-        {missions && (
-          <MissionsTable missions={missions} resetScrollTrigger={resetScrollTrigger} setSelectedMissionCardOptions={setSelectedMissionCardOptions} />
-        )}
-      </div>
-      {missions && (
-        <MissionDetail
-          missionCardOptions={selectedMissionCardOptions}
-          onClose={() => {
-            setSelectedMissionCardOptions([])
-          }}
-        />
+      {missions ? (
+        <Missions onSwitchToCards={() => setMissions(false)} />
+      ) : (
+        <CollectionCards cards={ownedCards} isPublic={false} extraOffset={20} onSwitchToMissions={() => setMissions(true)} />
       )}
     </div>
   )

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -8,7 +8,7 @@ import { useCollection, usePublicCollection } from '@/services/collection/useCol
 import CollectionCards from './CollectionCards'
 
 function Collection() {
-  const { t } = useTranslation(['pages/collection'])
+  const { t } = useTranslation(['pages/collection', 'common'])
 
   const { friendId } = useParams()
   const navigate = useNavigate()
@@ -20,11 +20,11 @@ function Collection() {
 
   if (friendId) {
     if (friendAccount === null) {
-      return <p className="text-xl text-center py-8">Account not found</p>
+      return <p className="text-xl text-center py-8">{t('common:noAccount')}</p>
     } else if (friendCards === null) {
       return <p className="text-xl text-center py-8">Not a public account</p>
     } else if (friendCards === undefined || friendAccount === undefined) {
-      return <p className="text-xl text-center py-8">Loading...</p>
+      return <p className="text-xl text-center py-8">{t('common:loading')}...</p>
     }
 
     return (
@@ -47,7 +47,7 @@ function Collection() {
   }
 
   if (ownedCards === undefined) {
-    return <p className="text-xl text-center py-8">Loading...</p>
+    return <p className="text-xl text-center py-8">{t('common:loading')}...</p>
   }
 
   return (

--- a/frontend/src/pages/collection/Collection.tsx
+++ b/frontend/src/pages/collection/Collection.tsx
@@ -1,5 +1,4 @@
 import { Siren } from 'lucide-react'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -7,7 +6,6 @@ import { Button } from '@/components/ui/button'
 import { usePublicAccount } from '@/services/account/useAccount.ts'
 import { useCollection, usePublicCollection } from '@/services/collection/useCollection'
 import CollectionCards from './CollectionCards'
-import { Missions } from './Missions'
 
 function Collection() {
   const { t } = useTranslation(['pages/collection'])
@@ -19,8 +17,6 @@ function Collection() {
   const { data: friendCards } = usePublicCollection(friendId)
 
   const { data: ownedCards } = useCollection()
-
-  const [missions, setMissions] = useState(false)
 
   if (friendId) {
     if (friendAccount === null) {
@@ -56,11 +52,7 @@ function Collection() {
 
   return (
     <div className="flex flex-col gap-y-1 mx-auto max-w-[900px]">
-      {missions ? (
-        <Missions onSwitchToCards={() => setMissions(false)} />
-      ) : (
-        <CollectionCards cards={ownedCards} isPublic={false} extraOffset={20} onSwitchToMissions={() => setMissions(true)} />
-      )}
+      <CollectionCards cards={ownedCards} isPublic={false} extraOffset={20} />
     </div>
   )
 }

--- a/frontend/src/pages/collection/CollectionCards.tsx
+++ b/frontend/src/pages/collection/CollectionCards.tsx
@@ -2,17 +2,15 @@ import { useEffect, useState } from 'react'
 import { useMediaQuery } from 'react-responsive'
 import { CardsTable } from '@/components/CardsTable.tsx'
 import FilterPanel, { type Filters } from '@/components/FiltersPanel'
-import { Button } from '@/components/ui/button'
 import type { Card, CollectionRow } from '@/types'
 
 interface Props {
   cards: CollectionRow[]
   isPublic: boolean
   extraOffset: number
-  onSwitchToMissions?: () => void
 }
 
-export default function CollectionCards({ cards, isPublic, extraOffset, onSwitchToMissions }: Props) {
+export default function CollectionCards({ cards, isPublic, extraOffset }: Props) {
   const isMobile = useMediaQuery({ query: '(max-width: 767px)' }) // tailwind "md"
 
   const [filteredCards, setFilteredCards] = useState<Card[] | null>(null)
@@ -41,7 +39,6 @@ export default function CollectionCards({ cards, isPublic, extraOffset, onSwitch
   return (
     <>
       <FilterPanel
-        className="relative h-20 sm:h-fit"
         cards={cards}
         filters={filters}
         setFilters={setFilters}
@@ -60,14 +57,9 @@ export default function CollectionCards({ cards, isPublic, extraOffset, onSwitch
           allTextSearch: true,
         }}
         batchUpdate={!isPublic}
+        missionsButton={!isPublic}
         share
-      >
-        {onSwitchToMissions && (
-          <Button className="border absolute right-4 top-11 sm:top-0 cursor-pointer px-3" variant="ghost" onClick={onSwitchToMissions}>
-            Go to missions
-          </Button>
-        )}
-      </FilterPanel>
+      />
       {filteredCards && (
         <CardsTable
           cards={filteredCards}

--- a/frontend/src/pages/collection/CollectionCards.tsx
+++ b/frontend/src/pages/collection/CollectionCards.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { useMediaQuery } from 'react-responsive'
+import { CardsTable } from '@/components/CardsTable.tsx'
+import FilterPanel, { type Filters } from '@/components/FiltersPanel'
+import { Button } from '@/components/ui/button'
+import type { Card, CollectionRow } from '@/types'
+
+interface Props {
+  cards: CollectionRow[]
+  isPublic: boolean
+  extraOffset: number
+  onSwitchToMissions?: () => void
+}
+
+export default function CollectionCards({ cards, isPublic, extraOffset, onSwitchToMissions }: Props) {
+  const isMobile = useMediaQuery({ query: '(max-width: 767px)' }) // tailwind "md"
+
+  const [filteredCards, setFilteredCards] = useState<Card[] | null>(null)
+
+  const [filters, setFilters] = useState<Filters>({
+    search: '',
+    expansion: 'all',
+    pack: 'all',
+    cardType: [],
+    rarity: [],
+    owned: 'all',
+    sortBy: 'expansion-newest',
+    minNumber: 0,
+    maxNumber: 100,
+    deckbuildingMode: false,
+    allTextSearch: false,
+  })
+  const [resetScrollTrigger, setResetScrollTrigger] = useState(false)
+
+  useEffect(() => {
+    setResetScrollTrigger(true)
+    const timeout = setTimeout(() => setResetScrollTrigger(false), 100)
+    return () => clearTimeout(timeout)
+  }, [filters])
+
+  return (
+    <>
+      <FilterPanel
+        className="relative h-20 sm:h-fit"
+        cards={cards}
+        filters={filters}
+        setFilters={setFilters}
+        onFiltersChanged={(cards) => setFilteredCards(cards)}
+        visibleFilters={{ expansions: !isMobile, allTextSearch: !isMobile, search: true, owned: !isMobile, rarity: !isMobile }}
+        filtersDialog={{
+          expansions: true,
+          pack: true,
+          search: true,
+          owned: true,
+          sortBy: true,
+          rarity: true,
+          cardType: true,
+          amount: true,
+          deckBuildingMode: true,
+          allTextSearch: true,
+        }}
+        batchUpdate={!isPublic}
+        share
+      >
+        {onSwitchToMissions && (
+          <Button className="border absolute right-4 top-11 sm:top-0 cursor-pointer px-3" variant="ghost" onClick={onSwitchToMissions}>
+            Go to missions
+          </Button>
+        )}
+      </FilterPanel>
+      {filteredCards && (
+        <CardsTable
+          cards={filteredCards}
+          resetScrollTrigger={resetScrollTrigger}
+          showStats={!filters.deckbuildingMode}
+          extraOffset={extraOffset}
+          editable={!filters.deckbuildingMode && !isPublic}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/collection/Missions.tsx
+++ b/frontend/src/pages/collection/Missions.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
 import ExpansionsFilter from '@/components/filters/ExpansionsFilter'
 import OwnedFilter from '@/components/filters/OwnedFilter'
 import { MissionsTable } from '@/components/MissionsTable'
@@ -7,11 +8,9 @@ import { expansionsDict } from '@/lib/CardsDB'
 import type { Mission } from '@/types'
 import MissionDetail from './MissionDetail'
 
-interface Props {
-  onSwitchToCards: () => void
-}
+export default function Missions() {
+  const navigate = useNavigate()
 
-export function Missions({ onSwitchToCards }: Props) {
   const [expansion, setExpansion] = useState<string>('A1')
   const [ownedFilter, setOwnedFilter] = useState<'all' | 'owned' | 'missing'>('all')
   const [missions, setMissions] = useState<Mission[] | null>(null)
@@ -32,16 +31,16 @@ export function Missions({ onSwitchToCards }: Props) {
   }, [expansion, ownedFilter])
 
   return (
-    <>
+    <div className="flex flex-col gap-y-1 mx-auto max-w-[900px]">
       <div className="flex flex-wrap gap-2 mx-4">
         <ExpansionsFilter value={expansion} onChange={setExpansion} allowAll={false} />
         <OwnedFilter ownedFilter={ownedFilter} setOwnedFilter={setOwnedFilter} />
-        <Button className="border ml-auto cursor-pointer" variant="ghost" onClick={onSwitchToCards}>
+        <Button className="ml-auto cursor-pointer" variant="outline" onClick={() => navigate('/collection')}>
           Go to collection
         </Button>
       </div>
       {missions && <MissionsTable missions={missions} resetScrollTrigger={resetScrollTrigger} setSelectedMissionCardOptions={setSelectedMissionCardOptions} />}
       <MissionDetail missionCardOptions={selectedMissionCardOptions} onClose={() => setSelectedMissionCardOptions([])} />
-    </>
+    </div>
   )
 }

--- a/frontend/src/pages/collection/Missions.tsx
+++ b/frontend/src/pages/collection/Missions.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import ExpansionsFilter from '@/components/filters/ExpansionsFilter'
+import OwnedFilter from '@/components/filters/OwnedFilter'
+import { MissionsTable } from '@/components/MissionsTable'
+import { Button } from '@/components/ui/button'
+import { expansionsDict } from '@/lib/CardsDB'
+import type { Mission } from '@/types'
+import MissionDetail from './MissionDetail'
+
+interface Props {
+  onSwitchToCards: () => void
+}
+
+export function Missions({ onSwitchToCards }: Props) {
+  const [expansion, setExpansion] = useState<string>('A1')
+  const [ownedFilter, setOwnedFilter] = useState<'all' | 'owned' | 'missing'>('all')
+  const [missions, setMissions] = useState<Mission[] | null>(null)
+  const [selectedMissionCardOptions, setSelectedMissionCardOptions] = useState<string[]>([])
+  const [resetScrollTrigger] = useState(false)
+
+  useEffect(() => {
+    let missions = expansionsDict.get(expansion)?.missions
+    if (!missions) {
+      throw new Error(`Unrecognized expansion id: ${expansion}`)
+    }
+    if (ownedFilter === 'owned') {
+      missions = missions.filter((mission) => mission.completed)
+    } else if (ownedFilter === 'missing') {
+      missions = missions.filter((mission) => !mission.completed)
+    }
+    setMissions(missions)
+  }, [expansion, ownedFilter])
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2 mx-4">
+        <ExpansionsFilter value={expansion} onChange={setExpansion} allowAll={false} />
+        <OwnedFilter ownedFilter={ownedFilter} setOwnedFilter={setOwnedFilter} />
+        <Button className="border ml-auto cursor-pointer" variant="ghost" onClick={onSwitchToCards}>
+          Go to collection
+        </Button>
+      </div>
+      {missions && <MissionsTable missions={missions} resetScrollTrigger={resetScrollTrigger} setSelectedMissionCardOptions={setSelectedMissionCardOptions} />}
+      <MissionDetail missionCardOptions={selectedMissionCardOptions} onClose={() => setSelectedMissionCardOptions([])} />
+    </>
+  )
+}

--- a/frontend/src/pages/collection/Missions.tsx
+++ b/frontend/src/pages/collection/Missions.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import ExpansionsFilter from '@/components/filters/ExpansionsFilter'
 import OwnedFilter from '@/components/filters/OwnedFilter'
@@ -9,6 +10,7 @@ import type { Mission } from '@/types'
 import MissionDetail from './MissionDetail'
 
 export default function Missions() {
+  const { t } = useTranslation(['pages/collection'])
   const navigate = useNavigate()
 
   const [expansion, setExpansion] = useState<string>('A1')
@@ -36,7 +38,7 @@ export default function Missions() {
         <ExpansionsFilter value={expansion} onChange={setExpansion} allowAll={false} />
         <OwnedFilter ownedFilter={ownedFilter} setOwnedFilter={setOwnedFilter} />
         <Button className="ml-auto cursor-pointer" variant="outline" onClick={() => navigate('/collection')}>
-          Go to collection
+          {t('goToCollection')}
         </Button>
       </div>
       {missions && <MissionsTable missions={missions} resetScrollTrigger={resetScrollTrigger} setSelectedMissionCardOptions={setSelectedMissionCardOptions} />}

--- a/frontend/src/pages/trade/TradeWith.tsx
+++ b/frontend/src/pages/trade/TradeWith.tsx
@@ -23,7 +23,7 @@ function getTradeCards(extraCards: string[], neededCards: string[]) {
 }
 
 function TradeWith() {
-  const { t } = useTranslation('trade-matches')
+  const { t } = useTranslation(['trade-matches', 'common'])
   const { friendId } = useParams()
 
   const { data: friendAccount } = usePublicAccount(friendId)
@@ -46,7 +46,7 @@ function TradeWith() {
   }
 
   if (friendAccount === undefined || friendCards === undefined) {
-    return <p className="text-xl text-center py-8">Loading...</p>
+    return <p className="text-xl text-center py-8">{t('common:loading')}...</p>
   }
 
   if (!friendAccount.is_active_trading) {


### PR DESCRIPTION
Currently missions are considered as packs and deeply coupled with you collection in `Collection.tsx` and `FiltersPanel.tsx` (which does `filteredCards = []` when you choose the "mission pack", which is, lest say, unconventional). This has some non-obvious consequences:

- When viewing missions, you still have all the filters panel available, but it mostly doesn't work. For example, you can change the mission rarity/energy type/maximum number of cards owned, or search for a text, but these doesn't influence the missions shown in any way. This might be confusing for the user who expects to find the 5 charizard mission by typing the card name in the search box.
- You can switch to missions in friends collection. But it actually shows your missions, not friends. It shouldn't behave this way.
- More on developer side: it's hard to add new filters when the `FiltersPanel.tsx` holds so much responsibility not related to actually doing what it is designed to (filtering cards).

This PR makes Collection and Mission a separate thing. You still access the missions in `/collection`, but the component is different and you can switch back and forth. The missions show only relevant filters. And also you can no longer view your missions when on friends collection.

Positioning the button in a sensible way wasn't easy. I tried tabs (like in trading) but they took too much space, especially valuable on smaller screens. I ended up with this:

<img width="965" height="535" alt="image" src="https://github.com/user-attachments/assets/a23302de-4ea4-4c88-9479-1aa11459e704" />
<img width="952" height="839" alt="image" src="https://github.com/user-attachments/assets/38e767f6-c9bd-4c56-9675-bca7623d35e1" />

The button from collection to missions on mobile was especially hard, I ended up with this:

<img width="557" height="929" alt="image" src="https://github.com/user-attachments/assets/550ee4e6-61b7-4c7e-ae49-49404bb75220" />

Which sadly adds another row 😕 This is an alternative, doesn't add a row, but is a little bit awkward:

<img width="535" height="916" alt="image" src="https://github.com/user-attachments/assets/41bcc951-931a-4f15-93b7-b7cea56db3cb" />

I was also considering adding another navbar tab, but it's also not great. Missions aren't that important to consume this precious space in my opinion. Any ideas on how to better handle going to missions are really welcome!