### PR TITLE
CardLine stop propagation

### DIFF
--- a/frontend/src/components/CardLine.tsx
+++ b/frontend/src/components/CardLine.tsx
@@ -43,7 +43,14 @@ export const CardLine: FC<Props> = ({ card_id, className, increment, rarity, id,
           </>
         )}
       </span>
-      <button type="button" className={cn('rounded bg-zinc-600 px-1 cursor-pointer', details)} onClick={() => setSelectedCardId(card_id)}>
+      <button
+        type="button"
+        className={cn('rounded bg-zinc-600 px-1 cursor-pointer', details)}
+        onClick={(e) => {
+          e.stopPropagation()
+          setSelectedCardId(card_id)
+        }}
+      >
         <svg className="fill-neutral-100 w-4 h-4 my-auto" viewBox="0 0 122.88 112.5">
           <title>Card details</title>
           <g>


### PR DESCRIPTION
Currently when you click the "card details" button in the `CardLine` component, it opens the sheet and also triggers the `onClick` (for example adding the card to trade offer). This prevents that.
