### PR TITLE
Always load `CardDetails`

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
   const authSSOQuery = useAuthSSO()
   const [isLoginDialogOpen, setIsLoginDialogOpen] = useState(false)
   const [isProfileDialogOpen, setIsProfileDialogOpen] = useState(false)
-  const [selectedCardId, setSelectedCardId] = useState('')
+  const [selectedCardId, setSelectedCardId] = useState<string | undefined>(undefined)
 
   // Check for SSO parameters
   useEffect(() => {
@@ -101,7 +101,7 @@ function App() {
         <RouterProvider router={router} />
         <InstallPrompt />
         <DonationPopup />
-        <CardDetail cardId={selectedCardId} onClose={() => setSelectedCardId('')} />
+        <CardDetail />
         {/* Add React Query DevTools (only in development) */}
         {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
       </ErrorBoundary>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,7 @@ function App() {
         <RouterProvider router={router} />
         <InstallPrompt />
         <DonationPopup />
-        {selectedCardId && <CardDetail cardId={selectedCardId} onClose={() => setSelectedCardId('')} />}
+        <CardDetail cardId={selectedCardId} onClose={() => setSelectedCardId('')} />
         {/* Add React Query DevTools (only in development) */}
         {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
       </ErrorBoundary>

--- a/frontend/src/context/DialogContext.ts
+++ b/frontend/src/context/DialogContext.ts
@@ -5,8 +5,8 @@ export interface IDialogContext {
   setIsProfileDialogOpen: (isOpen: boolean) => void
   isLoginDialogOpen: boolean
   setIsLoginDialogOpen: (isOpen: boolean) => void
-  selectedCardId: string
-  setSelectedCardId: (id: string) => void
+  selectedCardId: string | undefined
+  setSelectedCardId: (id: string | undefined) => void
 }
 
 export const DialogContext = createContext<IDialogContext>({
@@ -14,6 +14,6 @@ export const DialogContext = createContext<IDialogContext>({
   setIsProfileDialogOpen: () => {},
   isLoginDialogOpen: false,
   setIsLoginDialogOpen: () => {},
-  selectedCardId: '',
+  selectedCardId: undefined,
   setSelectedCardId: () => {},
 })

--- a/frontend/src/pages/collection/CardDetail.tsx
+++ b/frontend/src/pages/collection/CardDetail.tsx
@@ -1,5 +1,5 @@
 import i18n from 'i18next'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card as CardComponent } from '@/components/Card'
 import { CardLine } from '@/components/CardLine'
@@ -11,17 +11,13 @@ import { getCardNameByLang } from '@/lib/utils'
 import { useCollection, useSelectedCard } from '@/services/collection/useCollection'
 import type { CollectionRow } from '@/types'
 
-interface CardDetailProps {
-  cardId: string
-  onClose: () => void // Function to close the sidebar
-}
-
-function CardDetail({ onClose }: Readonly<CardDetailProps>) {
+function CardDetail() {
   const { t } = useTranslation(['pages/card-detail', 'common/types', 'common/packs', 'common/sets'])
   const { selectedCardId: cardId, setSelectedCardId: setCardId } = useSelectedCard()
 
   const { data: ownedCards = [] } = useCollection()
 
+  const [isOpen, setIsOpen] = useState(false)
   const [isImageDialogOpen, setIsImageDialogOpen] = useState(false)
 
   const card = useMemo(() => (cardId === undefined ? undefined : getCardById(cardId)), [cardId])
@@ -31,6 +27,12 @@ function CardDetail({ onClose }: Readonly<CardDetailProps>) {
     [card, ownedCards],
   )
   const expansion = useMemo(() => (card === undefined ? undefined : getExpansionById(card?.expansion)), [card])
+
+  useEffect(() => {
+    if (cardId) {
+      setIsOpen(true)
+    }
+  }, [cardId])
 
   if (cardId && !card) {
     console.log(`Unrecognized card_id: ${cardId}`)
@@ -54,10 +56,11 @@ function CardDetail({ onClose }: Readonly<CardDetailProps>) {
 
   return (
     <Sheet
-      open={Boolean(card)}
+      open={Boolean(cardId) && isOpen}
       onOpenChange={(open) => {
         if (!open) {
-          onClose()
+          setIsOpen(open)
+          setTimeout(() => setCardId(undefined), 300) // keep content when sliding out
         }
       }}
     >

--- a/frontend/src/pages/collection/CardDetail.tsx
+++ b/frontend/src/pages/collection/CardDetail.tsx
@@ -8,42 +8,42 @@ import { Radio, RadioIndicator, RadioItem } from '@/components/ui/radio'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { getCardById, getExpansionById, pullRateForSpecificCard } from '@/lib/CardsDB.ts'
 import { getCardNameByLang } from '@/lib/utils'
-import { useCollection } from '@/services/collection/useCollection'
-import type { Card, CollectionRow } from '@/types'
+import { useCollection, useSelectedCard } from '@/services/collection/useCollection'
+import type { CollectionRow } from '@/types'
 
 interface CardDetailProps {
   cardId: string
   onClose: () => void // Function to close the sidebar
 }
 
-function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps>) {
+function CardDetail({ onClose }: Readonly<CardDetailProps>) {
   const { t } = useTranslation(['pages/card-detail', 'common/types', 'common/packs', 'common/sets'])
-  const [cardId, setCardId] = useState(initialCardId)
+  const { selectedCardId: cardId, setSelectedCardId: setCardId } = useSelectedCard()
 
   const { data: ownedCards = [] } = useCollection()
 
   const [isImageDialogOpen, setIsImageDialogOpen] = useState(false)
 
-  const card: Card = useMemo(() => getCardById(cardId) || ({} as Card), [cardId])
+  const card = useMemo(() => (cardId === undefined ? undefined : getCardById(cardId)), [cardId])
   const row = useMemo(() => ownedCards.find((oc: CollectionRow) => oc.card_id === cardId), [cardId])
   const alternatives = useMemo(
-    () => card.alternate_versions.map((card) => ({ ...card, amount_owned: ownedCards.find((c) => c.card_id === card.card_id)?.amount_owned ?? 0 })),
+    () => card?.alternate_versions.map((card) => ({ ...card, amount_owned: ownedCards.find((c) => c.card_id === card.card_id)?.amount_owned ?? 0 })),
     [card, ownedCards],
   )
-  const expansion = useMemo(() => getExpansionById(card.expansion), [card])
+  const expansion = useMemo(() => (card === undefined ? undefined : getExpansionById(card?.expansion)), [card])
 
-  if (!card) {
+  if (cardId && !card) {
     console.log(`Unrecognized card_id: ${cardId}`)
     return null
   }
 
-  if (!expansion) {
+  if (card && !expansion) {
     console.log(`Unrecognized expansion: ${card.expansion}`)
     return null
   }
 
   // if we draw from 'everypack' we need to take one of the packs to base calculations on
-  const packName = card.pack === 'everypack' ? expansion?.packs[0].name : card.pack
+  const packName = card?.pack === 'everypack' ? expansion?.packs[0].name : card?.pack
 
   const formatTimestamp = (timestamp: string) => {
     return new Intl.DateTimeFormat(undefined, {
@@ -54,7 +54,7 @@ function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps
 
   return (
     <Sheet
-      open={true}
+      open={Boolean(card)}
       onOpenChange={(open) => {
         if (!open) {
           onClose()
@@ -64,18 +64,20 @@ function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps
       <SheetContent className="transition-all duration-300 ease-in-out border-slate-600 overflow-y-auto w-full md:w-[725px]">
         <SheetHeader>
           <SheetTitle>
-            {getCardNameByLang(card, i18n.language)} {card.rarity}
+            {card && getCardNameByLang(card, i18n.language)} {card?.rarity}
           </SheetTitle>
         </SheetHeader>
         <div className="flex flex-col items-center">
           <div className="px-10 py-4 w-full">
             <div className="cursor-pointer">
-              <CardComponent
-                key={cardId}
-                className="w-full"
-                card={{ ...card, amount_owned: row?.amount_owned || 0 }}
-                onImageClick={() => setIsImageDialogOpen(true)}
-              />
+              {card && (
+                <CardComponent
+                  key={cardId}
+                  className="w-full"
+                  card={{ ...card, amount_owned: row?.amount_owned || 0 }}
+                  onImageClick={() => setIsImageDialogOpen(true)}
+                />
+              )}
             </div>
           </div>
 
@@ -85,7 +87,7 @@ function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps
             </DialogHeader>
 
             <DialogContent className="flex items-center justify-center p-0 max-w-3xl max-h-[90vh]">
-              {card.image && (
+              {card?.image && (
                 <img
                   src={card.image}
                   alt={getCardNameByLang(card, i18n.language)}
@@ -100,7 +102,7 @@ function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps
             <div className="mb-3">
               <h2 className="text-xl font-semibold">{t('text.alternateVersions')}</h2>
               <Radio className="w-fit" value={cardId} onValueChange={setCardId}>
-                {alternatives.map((x) => (
+                {alternatives?.map((x) => (
                   <label key={x.card_id} className="flex items-center cursor-pointer" htmlFor={`radio-${x.card_id}`}>
                     <RadioItem id={`radio-${x.card_id}`} value={x.card_id}>
                       <RadioIndicator />
@@ -110,63 +112,63 @@ function CardDetail({ cardId: initialCardId, onClose }: Readonly<CardDetailProps
                 ))}
                 <p className="flex items-baseline mt-1">
                   <span className="mr-4">{t('text.totalAmount')}:</span>
-                  <span className="text-neutral-400 ml-auto mr-2">×{alternatives.reduce((acc, c) => acc + c.amount_owned, 0)}</span>
+                  <span className="text-neutral-400 ml-auto mr-2">×{alternatives?.reduce((acc, c) => acc + c.amount_owned, 0)}</span>
                 </p>
               </Radio>
             </div>
 
             <p className="mt-8 flex">
-              <strong className="block min-w-[175px]">{t('text.expansion')}</strong> {card.expansion}
+              <strong className="block min-w-[175px]">{t('text.expansion')}</strong> {card?.expansion}
             </p>
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.pack')}</strong> {t(`${card.pack}`, { ns: 'common/packs' })}
+              <strong className="block min-w-[175px]">{t('text.pack')}</strong> {card && t(`${card.pack}`, { ns: 'common/packs' })}
             </p>
 
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">Energy</strong> {card.energy}
+              <strong className="block min-w-[175px]">Energy</strong> {card?.energy}
             </p>
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.weakness')}</strong> {t(`${card.weakness}`, { ns: 'common/types' }) || 'N/A'}
+              <strong className="block min-w-[175px]">{t('text.weakness')}</strong> {(card && t(`${card.weakness}`, { ns: 'common/types' })) || 'N/A'}
             </p>
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.hp')}</strong> {card.hp}
+              <strong className="block min-w-[175px]">{t('text.hp')}</strong> {card?.hp}
             </p>
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.retreat')}</strong> {card.retreat || 'N/A'}
+              <strong className="block min-w-[175px]">{t('text.retreat')}</strong> {card?.retreat || 'N/A'}
             </p>
 
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.ability')}</strong> {card.ability?.name ?? <i>None</i>}
+              <strong className="block min-w-[175px]">{t('text.ability')}</strong> {card?.ability?.name ?? <i>None</i>}
             </p>
-            {card.ability && (
+            {card?.ability && (
               <p className="mt-1 flex">
-                <strong className="block min-w-[175px]">{t('text.abilityEffect')}</strong> {card.ability.effect}
+                <strong className="block min-w-[175px]">{t('text.abilityEffect')}</strong> {card?.ability.effect}
               </p>
             )}
 
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.cardType')}</strong> {t(`cardType.${card.card_type}`)}
+              <strong className="block min-w-[175px]">{t('text.cardType')}</strong> {card && t(`cardType.${card.card_type}`)}
             </p>
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.evolutionType')}</strong> {t(`evolutionType.${card.evolution_type}`)}
+              <strong className="block min-w-[175px]">{t('text.evolutionType')}</strong> {card && t(`evolutionType.${card.evolution_type}`)}
             </p>
 
             {expansion && packName && (
               <p className="mt-1 flex">
                 <strong className="block min-w-[175px]">{t('text.chanceToPull', { ns: 'pages/card-detail' })}</strong>
-                {pullRateForSpecificCard(expansion, packName, card).toFixed(2)}%
+                {card && pullRateForSpecificCard(expansion, packName, card).toFixed(2)}%
               </p>
             )}
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.craftingCost')}</strong> {card.crafting_cost}
+              <strong className="block min-w-[175px]">{t('text.craftingCost')}</strong> {card?.crafting_cost}
             </p>
 
             <p className="mt-1 flex">
-              <strong className="block min-w-[175px]">{t('text.artist')}</strong> {card.artist}
+              <strong className="block min-w-[175px]">{t('text.artist')}</strong> {card?.artist}
             </p>
 
             <p className="mt-4 text-neutral-400 text-sm flex">
-              <strong className="font-semibold">{t('text.updated')}</strong> {row?.updated_at ? formatTimestamp(row.updated_at) : 'N/A'}
+              <strong className="font-semibold mr-1">{t('text.updated')}</strong> {row?.updated_at ? formatTimestamp(row.updated_at) : 'N/A'}
             </p>
           </div>
         </div>


### PR DESCRIPTION
Currently, when you first open the `CardDetail`, the page goes blank for a second and scrolls you back to the top of the page. This makes the `Sheet` always present in the DOM (just closed) preventing that. It also correctly slides out because of that.

I checked that it opens and closes on the collection, trade and decks pages. I checked that you can open it multiple times, including with the same card_id. Switching between alternate cards also works.