### PR TITLE
Fix duplicate trade partners

### DIFF
--- a/frontend/public/locales/de-DE/trade-matches.json
+++ b/frontend/public/locales/de-DE/trade-matches.json
@@ -28,7 +28,6 @@
   "amountFriendOwns": "Dein Freund besitzt",
   "save": "Speichern",
   "collectionUpdated": "Deine Sammlung wurde aktualisiert.",
-  "noActiveTrades": "Kein Tausch aktiv",
   "tradeFiled": "Angebotener Tausch abgelehnt",
   "tradeOffered": "Tauschangebot versendet!",
   "actionAccept": "Tausch annehmen",

--- a/frontend/public/locales/en-US/trade-matches.json
+++ b/frontend/public/locales/en-US/trade-matches.json
@@ -31,7 +31,6 @@
   "amountFriendOwns": "Amount your friend owns",
   "save": "Save",
   "collectionUpdated": "Your collection has been updated to reflect the traded cards.",
-  "noActiveTrades": "No active trades",
   "tradeFiled": "Offering trade failed",
   "tradeOffered": "Trade offer sent!",
   "actionAccept": "Accept trade",

--- a/frontend/public/locales/fr-FR/trade-matches.json
+++ b/frontend/public/locales/fr-FR/trade-matches.json
@@ -31,7 +31,6 @@
   "amountFriendOwns": "Quantité que votre ami(e) possède",
   "save": "Sauvegarder",
   "collectionUpdated": "Votre collection a été mise à jour pour refléter votre échange.",
-  "noActiveTrades": "Pas d'échange actif",
   "tradeFiled": "L'offre d'échange a échoué",
   "tradeOffered": "Offre d'échange envoyée !",
   "actionAccept": "Accepter l'échange",

--- a/frontend/src/pages/trade/TradeOffers.tsx
+++ b/frontend/src/pages/trade/TradeOffers.tsx
@@ -20,47 +20,40 @@ function TradeOffers() {
 
   //split into two groups for finished and ongoing trades
   const friends = groupTrades(trades, account.friend_id)
+  const friendsHasTrades = Object.fromEntries(
+    Object.entries(friends).map(([key, value]) => [key, Number(activeTrades(value as TradeRow[], account.friend_id).length === 0)]),
+  )
   const friendsLastActivity = Object.fromEntries(
     Object.entries(friends).map(([key, value]) => [key, Math.max(...(value as TradeRow[]).map((row) => new Date(row.updated_at).getTime()))]),
   )
-  const friendIds = Object.keys(friends).toSorted((a, b) => friendsLastActivity[b] - friendsLastActivity[a])
-
-  const friendsFinished = groupTrades(trades, account.friend_id, true)
-  const friendsFinishedLastActivity = Object.fromEntries(
-    Object.entries(friendsFinished).map(([key, value]) => [key, Math.max(...(value as TradeRow[]).map((row) => new Date(row.updated_at).getTime()))]),
-  )
-  const finishedIds = Object.keys(friendsFinished).toSorted((a, b) => friendsFinishedLastActivity[b] - friendsFinishedLastActivity[a])
+  const friendIds = Object.keys(friends).toSorted((a, b) => {
+    if (friendsHasTrades[a] !== friendsHasTrades[b]) {
+      return friendsHasTrades[a] - friendsHasTrades[b]
+    }
+    return friendsLastActivity[b] - friendsLastActivity[a]
+  })
 
   return (
-    <div className="flex flex-col items-center mx-auto gap-12 sm:px-4 mb-12 w-full">
+    <div className="flex flex-col items-center mx-auto gap-6 sm:px-4 mb-12 w-full">
       {friendIds.map((friend_id) => (
-        <TradePartner key={friend_id} friendId={friend_id} />
-      ))}
-      {finishedIds.map((friend_id) => (
         <TradePartner key={friend_id} friendId={friend_id} />
       ))}
     </div>
   )
 }
 
-function groupTrades(arr: TradeRow[], id: string, finishedTradesOnly = false) {
-  const filtered = arr.filter((row) => {
-    if (finishedTradesOnly) {
-      if (row.offering_friend_id === id) {
-        return row.offerer_ended
-      } else {
-        return row.receiver_ended
-      }
+function activeTrades(arr: TradeRow[], id: string) {
+  return arr.filter((row) => {
+    if (row.offering_friend_id === id) {
+      return !row.offerer_ended
     } else {
-      if (row.offering_friend_id === id) {
-        return !row.offerer_ended
-      } else {
-        return !row.receiver_ended
-      }
+      return !row.receiver_ended
     }
   })
+}
 
-  return Object.groupBy(filtered, (row) => {
+function groupTrades(arr: TradeRow[], id: string) {
+  return Object.groupBy(arr, (row) => {
     if (row.offering_friend_id === id) {
       return row.receiving_friend_id
     } else if (row.receiving_friend_id === id) {

--- a/frontend/src/pages/trade/components/TradeList.tsx
+++ b/frontend/src/pages/trade/components/TradeList.tsx
@@ -139,7 +139,7 @@ function TradeList({ trades, viewHistory }: Props) {
   const selectedTrade = filteredTrades.find((r) => r.id === selectedTradeId)
 
   if (filteredTrades.length === 0) {
-    return <div className="rounded-lg border-1 border-neutral-700 border-solid p-2 text-center">{t('noActiveTrades')}</div>
+    return null
   }
 
   return (

--- a/frontend/src/pages/trade/components/TradePartner.tsx
+++ b/frontend/src/pages/trade/components/TradePartner.tsx
@@ -21,9 +21,15 @@ function TradePartner({ friendId }: TradePartnerProps) {
 
   const [viewHistory, setViewHistory] = useState<boolean>(false)
 
+  if (!trades) {
+    return null
+  }
+
+  const partnerTrades = trades.filter((t) => t.offering_friend_id === friendId || t.receiving_friend_id === friendId)
+
   return (
     <div className="w-full">
-      <div className="flex justify-between items-center mb-2 mx-1">
+      <div className="flex justify-between items-center mb-1 mx-1">
         <p>
           <span className="text-md">{t('tradingWith')}</span>
           <span className="text-md font-bold"> {friendAccount?.username || 'loading'} </span>
@@ -39,9 +45,7 @@ function TradePartner({ friendId }: TradePartnerProps) {
           </Button>
         </span>
       </div>
-      {friendAccount !== null && trades && (
-        <TradeList trades={trades.filter((t) => t.offering_friend_id === friendId || t.receiving_friend_id === friendId)} viewHistory={viewHistory} />
-      )}
+      {friendAccount !== null && <TradeList trades={partnerTrades} viewHistory={viewHistory} />}
     </div>
   )
 }


### PR DESCRIPTION
Closes #658. I removed the "no active trade" message to save some space. The page now looks much shorter:

Before:
<img width="912" height="1705" alt="image" src="https://github.com/user-attachments/assets/9b920068-4ada-4333-b9b4-50263f7deb75" />

After:
<img width="922" height="901" alt="image" src="https://github.com/user-attachments/assets/563713da-394e-4e34-a487-e1b5506c035e" />
