### PR TITLE
Reserve ids for rarities and expansions

### DIFF
--- a/frontend/assets/cards/A1.json
+++ b/frontend/assets/cards/A1.json
@@ -26,7 +26,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-1", "A1-227", "P-A-23", "A3-210", "A4b-1", "A4b-2"],
     "artist": "Narumi Sato",
-    "internal_id": 262273,
+    "internal_id": 65600,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-2", "A3-211", "A4b-3", "A4b-4"],
     "artist": "Kurata So",
-    "internal_id": 262402,
+    "internal_id": 65665,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-3", "P-A-18", "A3-212"],
     "artist": "Ryota Murayama",
-    "internal_id": 262531,
+    "internal_id": 65730,
     "linked": false
   },
   {
@@ -122,7 +122,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-4", "A1-251", "A3-230", "A4b-5"],
     "artist": "PLANETA CG Works",
-    "internal_id": 262660,
+    "internal_id": 65795,
     "linked": false
   },
   {
@@ -152,7 +152,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-5"],
     "artist": "Miki Tanaka",
-    "internal_id": 262785,
+    "internal_id": 65856,
     "linked": false
   },
   {
@@ -182,7 +182,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-6"],
     "artist": "Yuka Morii",
-    "internal_id": 262913,
+    "internal_id": 65920,
     "linked": false
   },
   {
@@ -216,7 +216,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-7", "P-A-13"],
     "artist": "Shin Nagasawa",
-    "internal_id": 263043,
+    "internal_id": 65986,
     "linked": false
   },
   {
@@ -246,7 +246,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-8"],
     "artist": "Hajime Kusajima",
-    "internal_id": 263169,
+    "internal_id": 66048,
     "linked": false
   },
   {
@@ -276,7 +276,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-9"],
     "artist": "miki kudo",
-    "internal_id": 263297,
+    "internal_id": 66112,
     "linked": false
   },
   {
@@ -306,7 +306,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-10"],
     "artist": "You Iribi",
-    "internal_id": 263427,
+    "internal_id": 66178,
     "linked": false
   },
   {
@@ -336,7 +336,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-11"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 263553,
+    "internal_id": 66240,
     "linked": false
   },
   {
@@ -366,7 +366,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-12", "A1-228"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 263682,
+    "internal_id": 66305,
     "linked": false
   },
   {
@@ -396,7 +396,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-13"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 263811,
+    "internal_id": 66370,
     "linked": false
   },
   {
@@ -426,7 +426,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-14"],
     "artist": "Naoyo Kimura",
-    "internal_id": 263937,
+    "internal_id": 66432,
     "linked": false
   },
   {
@@ -456,7 +456,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-15"],
     "artist": "Eri Yamaki",
-    "internal_id": 264066,
+    "internal_id": 66497,
     "linked": false
   },
   {
@@ -486,7 +486,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-16"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 264193,
+    "internal_id": 66560,
     "linked": false
   },
   {
@@ -516,7 +516,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-17"],
     "artist": "Mina Nakai",
-    "internal_id": 264322,
+    "internal_id": 66625,
     "linked": false
   },
   {
@@ -546,7 +546,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-18"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 264449,
+    "internal_id": 66688,
     "linked": false
   },
   {
@@ -576,7 +576,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-19"],
     "artist": "Miki Tanaka",
-    "internal_id": 264578,
+    "internal_id": 66753,
     "linked": false
   },
   {
@@ -610,7 +610,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-20"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 264707,
+    "internal_id": 66818,
     "linked": false
   },
   {
@@ -640,7 +640,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-21", "A4b-11", "A4b-12"],
     "artist": "kawayoo",
-    "internal_id": 264833,
+    "internal_id": 66880,
     "linked": false
   },
   {
@@ -670,7 +670,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-22"],
     "artist": "Yukiko Baba",
-    "internal_id": 264963,
+    "internal_id": 66946,
     "linked": false
   },
   {
@@ -700,7 +700,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-23", "A1-252", "A3-231", "A4b-13"],
     "artist": "PLANETA CG Works",
-    "internal_id": 265092,
+    "internal_id": 67011,
     "linked": false
   },
   {
@@ -730,7 +730,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-24"],
     "artist": "Midori Harada",
-    "internal_id": 265217,
+    "internal_id": 67072,
     "linked": false
   },
   {
@@ -760,7 +760,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-25"],
     "artist": "Hasuno",
-    "internal_id": 265345,
+    "internal_id": 67136,
     "linked": false
   },
   {
@@ -790,7 +790,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-26", "A1-229"],
     "artist": "Eri Yamaki",
-    "internal_id": 265474,
+    "internal_id": 67201,
     "linked": false
   },
   {
@@ -820,7 +820,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-27"],
     "artist": "Kanako Eo",
-    "internal_id": 265601,
+    "internal_id": 67264,
     "linked": false
   },
   {
@@ -850,7 +850,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-28"],
     "artist": "Atsuko Nishida",
-    "internal_id": 265730,
+    "internal_id": 67329,
     "linked": false
   },
   {
@@ -880,7 +880,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-29"],
     "artist": "Naoyo Kimura",
-    "internal_id": 265857,
+    "internal_id": 67392,
     "linked": false
   },
   {
@@ -910,7 +910,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-30"],
     "artist": "You Iribi",
-    "internal_id": 265986,
+    "internal_id": 67457,
     "linked": false
   },
   {
@@ -940,7 +940,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-31"],
     "artist": "Naoki Saito",
-    "internal_id": 266113,
+    "internal_id": 67520,
     "linked": false
   },
   {
@@ -970,7 +970,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-32"],
     "artist": "You Iribi",
-    "internal_id": 266241,
+    "internal_id": 67584,
     "linked": false
   },
   {
@@ -1000,7 +1000,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-33", "A1-230", "P-A-32", "A4b-55", "A4b-56"],
     "artist": "Teeziro",
-    "internal_id": 266369,
+    "internal_id": 67648,
     "linked": false
   },
   {
@@ -1030,7 +1030,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-34", "A4b-57", "A4b-58"],
     "artist": "kantaro",
-    "internal_id": 266498,
+    "internal_id": 67713,
     "linked": false
   },
   {
@@ -1060,7 +1060,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-35"],
     "artist": "takuyoa",
-    "internal_id": 266627,
+    "internal_id": 67778,
     "linked": false
   },
   {
@@ -1096,7 +1096,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-36", "A1-253", "A1-280", "A1-284", "A4b-59", "A4b-361"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 266756,
+    "internal_id": 67843,
     "linked": false
   },
   {
@@ -1126,7 +1126,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-37"],
     "artist": "Toshinao Aoki",
-    "internal_id": 266881,
+    "internal_id": 67904,
     "linked": false
   },
   {
@@ -1156,7 +1156,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-38"],
     "artist": "You Iribi",
-    "internal_id": 267010,
+    "internal_id": 67969,
     "linked": false
   },
   {
@@ -1186,7 +1186,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-39", "A3a-89", "A4b-61", "A4b-62"],
     "artist": "Mizue",
-    "internal_id": 267137,
+    "internal_id": 68032,
     "linked": false
   },
   {
@@ -1216,7 +1216,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-40", "A3a-90"],
     "artist": "kodama",
-    "internal_id": 267267,
+    "internal_id": 68098,
     "linked": false
   },
   {
@@ -1246,7 +1246,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-41", "A1-254", "A3a-100", "A4b-63"],
     "artist": "PLANETA Saito",
-    "internal_id": 267396,
+    "internal_id": 68163,
     "linked": false
   },
   {
@@ -1276,7 +1276,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-42"],
     "artist": "Uta",
-    "internal_id": 267521,
+    "internal_id": 68224,
     "linked": false
   },
   {
@@ -1306,7 +1306,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-43", "A1-231"],
     "artist": "Misa Tsutsui",
-    "internal_id": 267650,
+    "internal_id": 68289,
     "linked": false
   },
   {
@@ -1336,7 +1336,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-44"],
     "artist": "Ryuta Fuse",
-    "internal_id": 267777,
+    "internal_id": 68352,
     "linked": false
   },
   {
@@ -1366,7 +1366,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-45"],
     "artist": "sui",
-    "internal_id": 267907,
+    "internal_id": 68418,
     "linked": false
   },
   {
@@ -1396,7 +1396,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-46"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 268035,
+    "internal_id": 68482,
     "linked": false
   },
   {
@@ -1432,7 +1432,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-47", "A1-255", "A1-274", "P-A-25", "A3b-103", "A4b-67"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 268164,
+    "internal_id": 68547,
     "linked": false
   },
   {
@@ -1462,7 +1462,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-48"],
     "artist": "Suwama Chiaki",
-    "internal_id": 268289,
+    "internal_id": 68608,
     "linked": false
   },
   {
@@ -1492,7 +1492,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-49"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 268417,
+    "internal_id": 68672,
     "linked": false
   },
   {
@@ -1522,7 +1522,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-50"],
     "artist": "hatachu",
-    "internal_id": 268545,
+    "internal_id": 68736,
     "linked": false
   },
   {
@@ -1552,7 +1552,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-51"],
     "artist": "Teeziro",
-    "internal_id": 268673,
+    "internal_id": 68800,
     "linked": false
   },
   {
@@ -1582,7 +1582,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-52"],
     "artist": "GOSSAN",
-    "internal_id": 268802,
+    "internal_id": 68865,
     "linked": false
   },
   {
@@ -1612,7 +1612,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-53", "A1-232", "P-A-33", "A3-215", "A4b-83", "A4b-84"],
     "artist": "Mizue",
-    "internal_id": 268929,
+    "internal_id": 68928,
     "linked": false
   },
   {
@@ -1642,7 +1642,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-54", "A3-216", "A4b-85", "A4b-86"],
     "artist": "Nelnal",
-    "internal_id": 269058,
+    "internal_id": 68993,
     "linked": false
   },
   {
@@ -1672,7 +1672,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-55", "P-A-29", "A3-217"],
     "artist": "Nurikabe",
-    "internal_id": 269187,
+    "internal_id": 69058,
     "linked": false
   },
   {
@@ -1708,7 +1708,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-56", "A1-256", "A3-232", "A4b-87"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 269316,
+    "internal_id": 69123,
     "linked": false
   },
   {
@@ -1738,7 +1738,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-57", "A4a-93"],
     "artist": "Shibuzoh.",
-    "internal_id": 269441,
+    "internal_id": 69184,
     "linked": false
   },
   {
@@ -1768,7 +1768,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-58", "A4a-94"],
     "artist": "Naoki Saito",
-    "internal_id": 269570,
+    "internal_id": 69249,
     "linked": false
   },
   {
@@ -1798,7 +1798,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-59"],
     "artist": "Shibuzoh.",
-    "internal_id": 269697,
+    "internal_id": 69312,
     "linked": false
   },
   {
@@ -1828,7 +1828,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-60"],
     "artist": "Yuka Morii",
-    "internal_id": 269826,
+    "internal_id": 69377,
     "linked": false
   },
   {
@@ -1862,7 +1862,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-61"],
     "artist": "Akira Komayama",
-    "internal_id": 269955,
+    "internal_id": 69442,
     "linked": false
   },
   {
@@ -1892,7 +1892,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-62"],
     "artist": "Shinya Komatsu",
-    "internal_id": 270081,
+    "internal_id": 69504,
     "linked": false
   },
   {
@@ -1922,7 +1922,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-63"],
     "artist": "kodama",
-    "internal_id": 270210,
+    "internal_id": 69569,
     "linked": false
   },
   {
@@ -1952,7 +1952,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-64"],
     "artist": "Masako Yamashita",
-    "internal_id": 270337,
+    "internal_id": 69632,
     "linked": false
   },
   {
@@ -1982,7 +1982,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-65"],
     "artist": "Kanako Eo",
-    "internal_id": 270466,
+    "internal_id": 69697,
     "linked": false
   },
   {
@@ -2012,7 +2012,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-66"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 270593,
+    "internal_id": 69760,
     "linked": false
   },
   {
@@ -2046,7 +2046,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-67"],
     "artist": "Saya Tsuruta",
-    "internal_id": 270722,
+    "internal_id": 69825,
     "linked": false
   },
   {
@@ -2076,7 +2076,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-68", "A4a-95"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 270849,
+    "internal_id": 69888,
     "linked": false
   },
   {
@@ -2106,7 +2106,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-69", "A4a-96"],
     "artist": "Shigenori Negishi",
-    "internal_id": 270978,
+    "internal_id": 69953,
     "linked": false
   },
   {
@@ -2136,7 +2136,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-70"],
     "artist": "Saya Tsuruta",
-    "internal_id": 271105,
+    "internal_id": 70016,
     "linked": false
   },
   {
@@ -2166,7 +2166,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-71"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 271234,
+    "internal_id": 70081,
     "linked": false
   },
   {
@@ -2196,7 +2196,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-72"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 271361,
+    "internal_id": 70144,
     "linked": false
   },
   {
@@ -2226,7 +2226,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-73"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 271489,
+    "internal_id": 70208,
     "linked": false
   },
   {
@@ -2256,7 +2256,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-74", "A3-218", "A4b-93", "A4b-94"],
     "artist": "Hiroki Asanuma",
-    "internal_id": 271617,
+    "internal_id": 70272,
     "linked": false
   },
   {
@@ -2286,7 +2286,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-75", "A3-219"],
     "artist": "Yukiko Baba",
-    "internal_id": 271746,
+    "internal_id": 70337,
     "linked": false
   },
   {
@@ -2316,7 +2316,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-76", "A1-257", "A3-233", "A4b-95"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 271876,
+    "internal_id": 70403,
     "linked": false
   },
   {
@@ -2346,7 +2346,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-77"],
     "artist": "Sekio",
-    "internal_id": 272001,
+    "internal_id": 70464,
     "linked": false
   },
   {
@@ -2376,7 +2376,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-78", "A1-233"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 272131,
+    "internal_id": 70530,
     "linked": false
   },
   {
@@ -2406,7 +2406,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-79", "A1-234", "A3b-94"],
     "artist": "Sekio",
-    "internal_id": 272259,
+    "internal_id": 70594,
     "linked": false
   },
   {
@@ -2436,7 +2436,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-80", "A4-216"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 272387,
+    "internal_id": 70658,
     "linked": false
   },
   {
@@ -2466,7 +2466,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-81"],
     "artist": "Suwama Chiaki",
-    "internal_id": 272514,
+    "internal_id": 70721,
     "linked": false
   },
   {
@@ -2496,7 +2496,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-82"],
     "artist": "kirisAki",
-    "internal_id": 272643,
+    "internal_id": 70786,
     "linked": false
   },
   {
@@ -2526,7 +2526,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-83"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 272771,
+    "internal_id": 70850,
     "linked": false
   },
   {
@@ -2562,7 +2562,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-84", "A1-258", "A1-275", "A3b-104", "A4b-101"],
     "artist": "PLANETA Saito",
-    "internal_id": 272900,
+    "internal_id": 70915,
     "linked": false
   },
   {
@@ -2592,7 +2592,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-85"],
     "artist": "Yumi",
-    "internal_id": 273025,
+    "internal_id": 70976,
     "linked": false
   },
   {
@@ -2622,7 +2622,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-86"],
     "artist": "sui",
-    "internal_id": 273154,
+    "internal_id": 71041,
     "linked": false
   },
   {
@@ -2652,7 +2652,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-87", "P-A-61", "A3a-91", "A4b-110", "A4b-111"],
     "artist": "Aya Kusube",
-    "internal_id": 273281,
+    "internal_id": 71104,
     "linked": false
   },
   {
@@ -2682,7 +2682,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-88", "A3a-92", "A4b-112", "A4b-113"],
     "artist": "Akira Komayama",
-    "internal_id": 273410,
+    "internal_id": 71169,
     "linked": false
   },
   {
@@ -2716,7 +2716,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-89", "P-A-19", "A3a-93", "A4b-114", "A4b-115", "A4b-356"],
     "artist": "5ban Graphics",
-    "internal_id": 273539,
+    "internal_id": 71234,
     "linked": false
   },
   {
@@ -2746,7 +2746,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-90"],
     "artist": "OOYAMA",
-    "internal_id": 273665,
+    "internal_id": 71296,
     "linked": false
   },
   {
@@ -2776,7 +2776,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-91"],
     "artist": "Mizue",
-    "internal_id": 273794,
+    "internal_id": 71361,
     "linked": false
   },
   {
@@ -2806,7 +2806,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-92"],
     "artist": "ryoma uratsuka",
-    "internal_id": 273921,
+    "internal_id": 71424,
     "linked": false
   },
   {
@@ -2836,7 +2836,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-93"],
     "artist": "aoki",
-    "internal_id": 274050,
+    "internal_id": 71489,
     "linked": false
   },
   {
@@ -2866,7 +2866,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-94", "P-A-9", "P-A-15", "P-A-26", "A4b-128", "A4b-129"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 274177,
+    "internal_id": 71552,
     "linked": false
   },
   {
@@ -2896,7 +2896,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-95"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 274307,
+    "internal_id": 71618,
     "linked": false
   },
   {
@@ -2926,7 +2926,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-96", "A1-259", "A1-281", "A1-285", "A4b-131", "A4b-364", "A4b-376"],
     "artist": "PLANETA CG Works",
-    "internal_id": 274436,
+    "internal_id": 71683,
     "linked": false
   },
   {
@@ -2956,7 +2956,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-97", "P-A-24", "A4-217", "A4b-133", "A4b-134"],
     "artist": "sowsow",
-    "internal_id": 274561,
+    "internal_id": 71744,
     "linked": false
   },
   {
@@ -2990,7 +2990,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-98", "A4-218", "A4b-135", "A4b-136"],
     "artist": "kirisAki",
-    "internal_id": 274691,
+    "internal_id": 71810,
     "linked": false
   },
   {
@@ -3020,7 +3020,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-99"],
     "artist": "SATOSHI NAKAI",
-    "internal_id": 274817,
+    "internal_id": 71872,
     "linked": false
   },
   {
@@ -3050,7 +3050,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-100", "A1-235"],
     "artist": "Asako Ito",
-    "internal_id": 274946,
+    "internal_id": 71937,
     "linked": false
   },
   {
@@ -3080,7 +3080,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-101"],
     "artist": "Ryuta Fuse",
-    "internal_id": 275073,
+    "internal_id": 72000,
     "linked": false
   },
   {
@@ -3110,7 +3110,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-102"],
     "artist": "Kouki Saitou",
-    "internal_id": 275203,
+    "internal_id": 72066,
     "linked": false
   },
   {
@@ -3140,7 +3140,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-103"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 275331,
+    "internal_id": 72130,
     "linked": false
   },
   {
@@ -3176,7 +3176,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-104", "A1-260", "A1-276", "A3b-105", "A4b-139"],
     "artist": "PLANETA CG Works",
-    "internal_id": 275460,
+    "internal_id": 72195,
     "linked": false
   },
   {
@@ -3206,7 +3206,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-105"],
     "artist": "Shin Nagasawa",
-    "internal_id": 275585,
+    "internal_id": 72256,
     "linked": false
   },
   {
@@ -3236,7 +3236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-106"],
     "artist": "Misa Tsutsui",
-    "internal_id": 275714,
+    "internal_id": 72321,
     "linked": false
   },
   {
@@ -3266,7 +3266,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-107"],
     "artist": "Asako Ito",
-    "internal_id": 275841,
+    "internal_id": 72384,
     "linked": false
   },
   {
@@ -3296,7 +3296,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-108"],
     "artist": "Midori Harada",
-    "internal_id": 275970,
+    "internal_id": 72449,
     "linked": false
   },
   {
@@ -3326,7 +3326,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-109"],
     "artist": "hatachu",
-    "internal_id": 276099,
+    "internal_id": 72514,
     "linked": false
   },
   {
@@ -3356,7 +3356,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-110"],
     "artist": "5ban Graphics",
-    "internal_id": 276225,
+    "internal_id": 72576,
     "linked": false
   },
   {
@@ -3386,7 +3386,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-111"],
     "artist": "otumami",
-    "internal_id": 276353,
+    "internal_id": 72640,
     "linked": false
   },
   {
@@ -3416,7 +3416,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-112"],
     "artist": "Tika Matsuno",
-    "internal_id": 276482,
+    "internal_id": 72705,
     "linked": false
   },
   {
@@ -3446,7 +3446,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-113", "P-A-16"],
     "artist": "kirisAki",
-    "internal_id": 276609,
+    "internal_id": 72768,
     "linked": false
   },
   {
@@ -3476,7 +3476,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-114"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 276738,
+    "internal_id": 72833,
     "linked": false
   },
   {
@@ -3506,7 +3506,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-115"],
     "artist": "Aya Kusube",
-    "internal_id": 276865,
+    "internal_id": 72896,
     "linked": false
   },
   {
@@ -3536,7 +3536,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-116"],
     "artist": "Ken Sugimori",
-    "internal_id": 276994,
+    "internal_id": 72961,
     "linked": false
   },
   {
@@ -3566,7 +3566,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-117", "A1-236"],
     "artist": "Kouki Saitou",
-    "internal_id": 277123,
+    "internal_id": 73026,
     "linked": false
   },
   {
@@ -3596,7 +3596,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-118", "A1-237"],
     "artist": "Miki Tanaka",
-    "internal_id": 277249,
+    "internal_id": 73088,
     "linked": false
   },
   {
@@ -3626,7 +3626,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-119"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 277378,
+    "internal_id": 73153,
     "linked": false
   },
   {
@@ -3656,7 +3656,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-120", "A4b-151", "A4b-152"],
     "artist": "Masako Yamashita",
-    "internal_id": 277505,
+    "internal_id": 73216,
     "linked": false
   },
   {
@@ -3686,7 +3686,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-121", "A3-221", "A4b-153", "A4b-154"],
     "artist": "Nisata Niso",
-    "internal_id": 277634,
+    "internal_id": 73281,
     "linked": false
   },
   {
@@ -3716,7 +3716,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-122", "A3-222"],
     "artist": "Naoyo Kimura",
-    "internal_id": 277763,
+    "internal_id": 73346,
     "linked": false
   },
   {
@@ -3750,7 +3750,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-123", "A1-261", "A1-277", "A3-234", "A4b-155"],
     "artist": "PLANETA CG Works",
-    "internal_id": 277892,
+    "internal_id": 73411,
     "linked": false
   },
   {
@@ -3780,7 +3780,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-124"],
     "artist": "Yukiko Baba",
-    "internal_id": 278017,
+    "internal_id": 73472,
     "linked": false
   },
   {
@@ -3814,7 +3814,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-125"],
     "artist": "Shigenori Negishi",
-    "internal_id": 278147,
+    "internal_id": 73538,
     "linked": false
   },
   {
@@ -3844,7 +3844,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-126"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 278274,
+    "internal_id": 73601,
     "linked": false
   },
   {
@@ -3874,7 +3874,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-127", "A3a-94", "A4b-156", "A4b-157"],
     "artist": "Oswaldo KATO",
-    "internal_id": 278401,
+    "internal_id": 73664,
     "linked": false
   },
   {
@@ -3904,7 +3904,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-128", "P-A-10"],
     "artist": "kawayoo",
-    "internal_id": 278531,
+    "internal_id": 73730,
     "linked": false
   },
   {
@@ -3940,7 +3940,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-129", "A1-262", "A1-282", "A1-286", "P-A-50", "A4b-158", "A4b-365"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 278660,
+    "internal_id": 73795,
     "linked": false
   },
   {
@@ -3970,7 +3970,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-130"],
     "artist": "Yuka Morii",
-    "internal_id": 278785,
+    "internal_id": 73856,
     "linked": false
   },
   {
@@ -4000,7 +4000,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-131"],
     "artist": "sowsow",
-    "internal_id": 278914,
+    "internal_id": 73921,
     "linked": false
   },
   {
@@ -4034,7 +4034,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-132", "A3b-99", "A4b-168", "A4b-169", "A4b-357"],
     "artist": "Yuu Nishida",
-    "internal_id": 279043,
+    "internal_id": 73986,
     "linked": false
   },
   {
@@ -4064,7 +4064,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-133"],
     "artist": "MAHOU",
-    "internal_id": 279169,
+    "internal_id": 74048,
     "linked": false
   },
   {
@@ -4094,7 +4094,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-134"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 279297,
+    "internal_id": 74112,
     "linked": false
   },
   {
@@ -4124,7 +4124,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-135"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 279425,
+    "internal_id": 74176,
     "linked": false
   },
   {
@@ -4154,7 +4154,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-136"],
     "artist": "match",
-    "internal_id": 279554,
+    "internal_id": 74241,
     "linked": false
   },
   {
@@ -4184,7 +4184,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-137"],
     "artist": "Miki Tanaka",
-    "internal_id": 279681,
+    "internal_id": 74304,
     "linked": false
   },
   {
@@ -4214,7 +4214,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-138"],
     "artist": "Miki Tanaka",
-    "internal_id": 279810,
+    "internal_id": 74369,
     "linked": false
   },
   {
@@ -4244,7 +4244,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-139", "A1-238"],
     "artist": "Masako Yamashita",
-    "internal_id": 279937,
+    "internal_id": 74432,
     "linked": false
   },
   {
@@ -4274,7 +4274,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-140"],
     "artist": "Akira Komayama",
-    "internal_id": 280066,
+    "internal_id": 74497,
     "linked": false
   },
   {
@@ -4304,7 +4304,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-141"],
     "artist": "Kanako Eo",
-    "internal_id": 280193,
+    "internal_id": 74560,
     "linked": false
   },
   {
@@ -4334,7 +4334,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-142", "A4-222"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 280322,
+    "internal_id": 74625,
     "linked": false
   },
   {
@@ -4364,7 +4364,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-143", "A3-223", "A4b-189", "A4b-190"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 280449,
+    "internal_id": 74688,
     "linked": false
   },
   {
@@ -4394,7 +4394,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-144", "A3-224", "A4b-191", "A4b-192"],
     "artist": "match",
-    "internal_id": 280578,
+    "internal_id": 74753,
     "linked": false
   },
   {
@@ -4424,7 +4424,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-145"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 280707,
+    "internal_id": 74818,
     "linked": false
   },
   {
@@ -4454,7 +4454,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-146", "A1-263", "A1-278", "A3-235", "A4b-193"],
     "artist": "PLANETA CG Works",
-    "internal_id": 280836,
+    "internal_id": 74883,
     "linked": false
   },
   {
@@ -4484,7 +4484,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-147"],
     "artist": "Kouki Saitou",
-    "internal_id": 280961,
+    "internal_id": 74944,
     "linked": false
   },
   {
@@ -4514,7 +4514,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-148"],
     "artist": "Naoyo Kimura",
-    "internal_id": 281090,
+    "internal_id": 75009,
     "linked": false
   },
   {
@@ -4544,7 +4544,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-149"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 281219,
+    "internal_id": 75074,
     "linked": false
   },
   {
@@ -4574,7 +4574,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-150", "P-A-21"],
     "artist": "otumami",
-    "internal_id": 281346,
+    "internal_id": 75137,
     "linked": false
   },
   {
@@ -4604,7 +4604,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-151", "A1-239", "A3-226", "A4b-194", "A4b-195"],
     "artist": "sowsow",
-    "internal_id": 281473,
+    "internal_id": 75200,
     "linked": false
   },
   {
@@ -4634,7 +4634,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-152", "A3-227"],
     "artist": "Shin Nagasawa",
-    "internal_id": 281602,
+    "internal_id": 75265,
     "linked": false
   },
   {
@@ -4664,7 +4664,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-153", "A1-264", "A3-236", "A4b-196"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 281732,
+    "internal_id": 75331,
     "linked": false
   },
   {
@@ -4694,7 +4694,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-154"],
     "artist": "Yukiko Baba",
-    "internal_id": 281857,
+    "internal_id": 75392,
     "linked": false
   },
   {
@@ -4724,7 +4724,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-155"],
     "artist": "Ken Sugimori",
-    "internal_id": 281985,
+    "internal_id": 75456,
     "linked": false
   },
   {
@@ -4754,7 +4754,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-156"],
     "artist": "Midori Harada",
-    "internal_id": 282113,
+    "internal_id": 75520,
     "linked": false
   },
   {
@@ -4784,7 +4784,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-157"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 282242,
+    "internal_id": 75585,
     "linked": false
   },
   {
@@ -4814,7 +4814,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-158"],
     "artist": "sui",
-    "internal_id": 282370,
+    "internal_id": 75649,
     "linked": false
   },
   {
@@ -4844,7 +4844,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-159"],
     "artist": "Shin Nagasawa",
-    "internal_id": 282499,
+    "internal_id": 75714,
     "linked": false
   },
   {
@@ -4874,7 +4874,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-160"],
     "artist": "match",
-    "internal_id": 282625,
+    "internal_id": 75776,
     "linked": false
   },
   {
@@ -4904,7 +4904,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-161"],
     "artist": "Atsuko Nishida",
-    "internal_id": 282754,
+    "internal_id": 75841,
     "linked": false
   },
   {
@@ -4934,7 +4934,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-162"],
     "artist": "Yuu Nishida",
-    "internal_id": 282881,
+    "internal_id": 75904,
     "linked": false
   },
   {
@@ -4964,7 +4964,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-163"],
     "artist": "kurumitsu",
-    "internal_id": 283010,
+    "internal_id": 75969,
     "linked": false
   },
   {
@@ -4994,7 +4994,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-164", "A3b-100"],
     "artist": "MAHOU",
-    "internal_id": 283137,
+    "internal_id": 76032,
     "linked": false
   },
   {
@@ -5024,7 +5024,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-165", "A3b-101"],
     "artist": "Naoki Saito",
-    "internal_id": 283266,
+    "internal_id": 76097,
     "linked": false
   },
   {
@@ -5054,7 +5054,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-166", "A4-223"],
     "artist": "Miki Tanaka",
-    "internal_id": 283393,
+    "internal_id": 76160,
     "linked": false
   },
   {
@@ -5084,7 +5084,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-167", "A4-224"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 283522,
+    "internal_id": 76225,
     "linked": false
   },
   {
@@ -5114,7 +5114,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-168", "A1-240", "A4-225"],
     "artist": "nagimiso",
-    "internal_id": 283651,
+    "internal_id": 76290,
     "linked": false
   },
   {
@@ -5144,7 +5144,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-169", "A4-226"],
     "artist": "Naoyo Kimura",
-    "internal_id": 283777,
+    "internal_id": 76352,
     "linked": false
   },
   {
@@ -5174,7 +5174,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-170", "A4-227"],
     "artist": "Kouki Saitou",
-    "internal_id": 283906,
+    "internal_id": 76417,
     "linked": false
   },
   {
@@ -5204,7 +5204,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-171", "A1-241", "A4-228"],
     "artist": "kawayoo",
-    "internal_id": 284035,
+    "internal_id": 76482,
     "linked": false
   },
   {
@@ -5234,7 +5234,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-172"],
     "artist": "match",
-    "internal_id": 284161,
+    "internal_id": 76544,
     "linked": false
   },
   {
@@ -5264,7 +5264,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-173", "A1-242"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 284290,
+    "internal_id": 76609,
     "linked": false
   },
   {
@@ -5294,7 +5294,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-174"],
     "artist": "Pani Kobayashi",
-    "internal_id": 284417,
+    "internal_id": 76672,
     "linked": false
   },
   {
@@ -5324,7 +5324,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-175"],
     "artist": "Hajime Kusajima",
-    "internal_id": 284547,
+    "internal_id": 76738,
     "linked": false
   },
   {
@@ -5354,7 +5354,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-176"],
     "artist": "Saya Tsuruta",
-    "internal_id": 284673,
+    "internal_id": 76800,
     "linked": false
   },
   {
@@ -5388,7 +5388,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-177", "A1-243"],
     "artist": "OOYAMA",
-    "internal_id": 284803,
+    "internal_id": 76866,
     "linked": false
   },
   {
@@ -5418,7 +5418,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-178"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 284929,
+    "internal_id": 76928,
     "linked": false
   },
   {
@@ -5448,7 +5448,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-179"],
     "artist": "Kouki Saitou",
-    "internal_id": 285057,
+    "internal_id": 76992,
     "linked": false
   },
   {
@@ -5478,7 +5478,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-180"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 285186,
+    "internal_id": 77057,
     "linked": false
   },
   {
@@ -5508,7 +5508,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-181"],
     "artist": "Shin Nagasawa",
-    "internal_id": 285313,
+    "internal_id": 77120,
     "linked": false
   },
   {
@@ -5542,7 +5542,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-182"],
     "artist": "Kouki Saitou",
-    "internal_id": 285443,
+    "internal_id": 77186,
     "linked": false
   },
   {
@@ -5572,7 +5572,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-183"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 285569,
+    "internal_id": 77248,
     "linked": false
   },
   {
@@ -5602,7 +5602,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-184"],
     "artist": "kirisAki",
-    "internal_id": 285698,
+    "internal_id": 77313,
     "linked": false
   },
   {
@@ -5632,7 +5632,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-185", "A1-244"],
     "artist": "Hiroyuki Yamamoto",
-    "internal_id": 285827,
+    "internal_id": 77378,
     "linked": false
   },
   {
@@ -5662,7 +5662,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-186", "A3a-95"],
     "artist": "Scav",
-    "internal_id": 285953,
+    "internal_id": 77440,
     "linked": false
   },
   {
@@ -5692,7 +5692,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-187", "A3a-96"],
     "artist": "Scav",
-    "internal_id": 286081,
+    "internal_id": 77504,
     "linked": false
   },
   {
@@ -5726,7 +5726,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-188", "A1-245", "A3a-97"],
     "artist": "Scav",
-    "internal_id": 286211,
+    "internal_id": 77570,
     "linked": false
   },
   {
@@ -5756,7 +5756,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-189"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 286337,
+    "internal_id": 77632,
     "linked": false
   },
   {
@@ -5786,7 +5786,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-190"],
     "artist": "Shigenori Negishi",
-    "internal_id": 286465,
+    "internal_id": 77696,
     "linked": false
   },
   {
@@ -5816,7 +5816,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-191"],
     "artist": "Shiburingaru",
-    "internal_id": 286593,
+    "internal_id": 77760,
     "linked": false
   },
   {
@@ -5846,7 +5846,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-192"],
     "artist": "Satoshi Shirai",
-    "internal_id": 286721,
+    "internal_id": 77824,
     "linked": false
   },
   {
@@ -5876,7 +5876,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-193", "A4b-277", "A4b-278"],
     "artist": "Mizue",
-    "internal_id": 286849,
+    "internal_id": 77888,
     "linked": false
   },
   {
@@ -5906,7 +5906,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-194"],
     "artist": "Atsuko Nishida",
-    "internal_id": 286977,
+    "internal_id": 77952,
     "linked": false
   },
   {
@@ -5936,7 +5936,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-195", "A1-265", "A1-279", "A3-237", "A4b-279"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 287108,
+    "internal_id": 78019,
     "linked": false
   },
   {
@@ -5966,7 +5966,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-196", "A1-246", "P-A-12"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 287233,
+    "internal_id": 78080,
     "linked": false
   },
   {
@@ -5996,7 +5996,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-197"],
     "artist": "nagimiso",
-    "internal_id": 287362,
+    "internal_id": 78145,
     "linked": false
   },
   {
@@ -6026,7 +6026,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-198", "P-A-62", "A3b-102", "A4b-280", "A4b-281", "A4b-359"],
     "artist": "Miki Tanaka",
-    "internal_id": 287489,
+    "internal_id": 78208,
     "linked": false
   },
   {
@@ -6056,7 +6056,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-199"],
     "artist": "Yuya Oka",
-    "internal_id": 287617,
+    "internal_id": 78272,
     "linked": false
   },
   {
@@ -6086,7 +6086,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-200"],
     "artist": "Miki Tanaka",
-    "internal_id": 287746,
+    "internal_id": 78337,
     "linked": false
   },
   {
@@ -6116,7 +6116,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-201"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 287874,
+    "internal_id": 78401,
     "linked": false
   },
   {
@@ -6146,7 +6146,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-202", "P-A-11"],
     "artist": "MAHOU",
-    "internal_id": 288002,
+    "internal_id": 78465,
     "linked": false
   },
   {
@@ -6176,7 +6176,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-203"],
     "artist": "Ken Sugimori",
-    "internal_id": 288131,
+    "internal_id": 78530,
     "linked": false
   },
   {
@@ -6206,7 +6206,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-204"],
     "artist": "kodama",
-    "internal_id": 288258,
+    "internal_id": 78593,
     "linked": false
   },
   {
@@ -6236,7 +6236,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-205", "A1-247"],
     "artist": "Miki Tanaka",
-    "internal_id": 288387,
+    "internal_id": 78658,
     "linked": false
   },
   {
@@ -6266,7 +6266,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-206", "A1-207", "A1-208", "A1-248", "P-A-92"],
     "artist": "Atsuko Nishida",
-    "internal_id": 288513,
+    "internal_id": 78720,
     "linked": false
   },
   {
@@ -6296,7 +6296,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-206", "A1-207", "A1-208", "A1-248", "P-A-92"],
     "artist": "Hasuno",
-    "internal_id": 288641,
+    "internal_id": 78784,
     "linked": false
   },
   {
@@ -6326,7 +6326,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-206", "A1-207", "A1-208", "A1-248", "P-A-92"],
     "artist": "Sekio",
-    "internal_id": 288769,
+    "internal_id": 78848,
     "linked": false
   },
   {
@@ -6360,7 +6360,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-209", "A1-249"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 288898,
+    "internal_id": 78913,
     "linked": false
   },
   {
@@ -6390,7 +6390,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-210", "A3a-98"],
     "artist": "Naoyo Kimura",
-    "internal_id": 289027,
+    "internal_id": 78978,
     "linked": false
   },
   {
@@ -6420,7 +6420,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-211", "A1-250"],
     "artist": "Naoki Saito",
-    "internal_id": 289155,
+    "internal_id": 79042,
     "linked": false
   },
   {
@@ -6450,7 +6450,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-212"],
     "artist": "sui",
-    "internal_id": 289281,
+    "internal_id": 79104,
     "linked": false
   },
   {
@@ -6480,7 +6480,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-213", "P-A-31"],
     "artist": "0313",
-    "internal_id": 289410,
+    "internal_id": 79169,
     "linked": false
   },
   {
@@ -6510,7 +6510,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-214"],
     "artist": "Yoriyuki Ikegami",
-    "internal_id": 289537,
+    "internal_id": 79232,
     "linked": false
   },
   {
@@ -6540,7 +6540,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-215"],
     "artist": "saino misaki",
-    "internal_id": 289665,
+    "internal_id": 79296,
     "linked": false
   },
   {
@@ -6567,7 +6567,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-216"],
     "artist": "Toyste Beach",
-    "internal_id": 289793,
+    "internal_id": 79360,
     "linked": false
   },
   {
@@ -6594,7 +6594,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-217"],
     "artist": "Toyste Beach",
-    "internal_id": 289921,
+    "internal_id": 79424,
     "linked": false
   },
   {
@@ -6621,7 +6621,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-218", "A1a-63", "A4b-312", "A4b-313"],
     "artist": "Toyste Beach",
-    "internal_id": 290049,
+    "internal_id": 79488,
     "linked": false
   },
   {
@@ -6648,7 +6648,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-219", "A1-266", "A4b-328", "A4b-329"],
     "artist": "kirisAki",
-    "internal_id": 290178,
+    "internal_id": 79553,
     "linked": false
   },
   {
@@ -6675,7 +6675,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-220", "A1-267"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 290306,
+    "internal_id": 79617,
     "linked": false
   },
   {
@@ -6702,7 +6702,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-221", "A1-268"],
     "artist": "GOSSAN",
-    "internal_id": 290434,
+    "internal_id": 79681,
     "linked": false
   },
   {
@@ -6729,7 +6729,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-222", "A1-269"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 290562,
+    "internal_id": 79745,
     "linked": false
   },
   {
@@ -6756,7 +6756,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-223", "A1-270", "A4b-334", "A4b-335"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 290690,
+    "internal_id": 79809,
     "linked": false
   },
   {
@@ -6783,7 +6783,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-224", "A1-271"],
     "artist": "Taira Akitsu",
-    "internal_id": 290818,
+    "internal_id": 79873,
     "linked": false
   },
   {
@@ -6810,7 +6810,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-225", "A1-272", "A4b-338", "A4b-339"],
     "artist": "Yuu Nishida",
-    "internal_id": 290946,
+    "internal_id": 79937,
     "linked": false
   },
   {
@@ -6837,7 +6837,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-226", "A1-273"],
     "artist": "nagimiso",
-    "internal_id": 291074,
+    "internal_id": 80001,
     "linked": false
   },
   {
@@ -6867,7 +6867,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-1", "A1-227", "P-A-23", "A3-210", "A4b-1", "A4b-2"],
     "artist": "Ryota Murayama",
-    "internal_id": 291205,
+    "internal_id": 80068,
     "linked": false
   },
   {
@@ -6897,7 +6897,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-12", "A1-228"],
     "artist": "OKACHEKE",
-    "internal_id": 291333,
+    "internal_id": 80132,
     "linked": false
   },
   {
@@ -6927,7 +6927,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-26", "A1-229"],
     "artist": "Scav",
-    "internal_id": 291461,
+    "internal_id": 80196,
     "linked": false
   },
   {
@@ -6957,7 +6957,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-33", "A1-230", "P-A-32", "A4b-55", "A4b-56"],
     "artist": "GIDORA",
-    "internal_id": 291589,
+    "internal_id": 80260,
     "linked": false
   },
   {
@@ -6987,7 +6987,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-43", "A1-231"],
     "artist": "Taira Akitsu",
-    "internal_id": 291717,
+    "internal_id": 80324,
     "linked": false
   },
   {
@@ -7017,7 +7017,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-53", "A1-232", "P-A-33", "A3-215", "A4b-83", "A4b-84"],
     "artist": "Taira Akitsu",
-    "internal_id": 291845,
+    "internal_id": 80388,
     "linked": false
   },
   {
@@ -7047,7 +7047,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-78", "A1-233"],
     "artist": "Nurikabe",
-    "internal_id": 291973,
+    "internal_id": 80452,
     "linked": false
   },
   {
@@ -7077,7 +7077,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-79", "A1-234", "A3b-94"],
     "artist": "Haru Akasaka",
-    "internal_id": 292101,
+    "internal_id": 80516,
     "linked": false
   },
   {
@@ -7107,7 +7107,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-100", "A1-235"],
     "artist": "DOM",
-    "internal_id": 292229,
+    "internal_id": 80580,
     "linked": false
   },
   {
@@ -7137,7 +7137,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-117", "A1-236"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 292357,
+    "internal_id": 80644,
     "linked": false
   },
   {
@@ -7167,7 +7167,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-118", "A1-237"],
     "artist": "Miki Tanaka",
-    "internal_id": 292485,
+    "internal_id": 80708,
     "linked": false
   },
   {
@@ -7197,7 +7197,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-139", "A1-238"],
     "artist": "Shinya Komatsu",
-    "internal_id": 292613,
+    "internal_id": 80772,
     "linked": false
   },
   {
@@ -7227,7 +7227,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-151", "A1-239", "A3-226", "A4b-194", "A4b-195"],
     "artist": "Teeziro",
-    "internal_id": 292741,
+    "internal_id": 80836,
     "linked": false
   },
   {
@@ -7257,7 +7257,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-168", "A1-240", "A4-225"],
     "artist": "aoki",
-    "internal_id": 292869,
+    "internal_id": 80900,
     "linked": false
   },
   {
@@ -7287,7 +7287,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-171", "A1-241", "A4-228"],
     "artist": "nagimiso",
-    "internal_id": 292997,
+    "internal_id": 80964,
     "linked": false
   },
   {
@@ -7317,7 +7317,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-173", "A1-242"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 293125,
+    "internal_id": 81028,
     "linked": false
   },
   {
@@ -7351,7 +7351,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-177", "A1-243"],
     "artist": "KEIICHIRO ITO",
-    "internal_id": 293253,
+    "internal_id": 81092,
     "linked": false
   },
   {
@@ -7381,7 +7381,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-185", "A1-244"],
     "artist": "Gemi",
-    "internal_id": 293381,
+    "internal_id": 81156,
     "linked": false
   },
   {
@@ -7415,7 +7415,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-188", "A1-245", "A3a-97"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 293509,
+    "internal_id": 81220,
     "linked": false
   },
   {
@@ -7445,7 +7445,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-196", "A1-246", "P-A-12"],
     "artist": "Mina Nakai",
-    "internal_id": 293637,
+    "internal_id": 81284,
     "linked": false
   },
   {
@@ -7475,7 +7475,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-205", "A1-247"],
     "artist": "Jerky",
-    "internal_id": 293765,
+    "internal_id": 81348,
     "linked": false
   },
   {
@@ -7505,7 +7505,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-206", "A1-207", "A1-208", "A1-248", "P-A-92"],
     "artist": "sowsow",
-    "internal_id": 293893,
+    "internal_id": 81412,
     "linked": false
   },
   {
@@ -7539,7 +7539,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-209", "A1-249"],
     "artist": "Akira Komayama",
-    "internal_id": 294021,
+    "internal_id": 81476,
     "linked": false
   },
   {
@@ -7569,7 +7569,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-211", "A1-250"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 294149,
+    "internal_id": 81540,
     "linked": false
   },
   {
@@ -7605,7 +7605,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-4", "A1-251", "A3-230", "A4b-5"],
     "artist": "PLANETA CG Works",
-    "internal_id": 294278,
+    "internal_id": 81605,
     "linked": false
   },
   {
@@ -7635,7 +7635,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-23", "A1-252", "A3-231", "A4b-13"],
     "artist": "PLANETA CG Works",
-    "internal_id": 294406,
+    "internal_id": 81669,
     "linked": false
   },
   {
@@ -7671,7 +7671,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-36", "A1-253", "A1-280", "A1-284", "A4b-59", "A4b-361"],
     "artist": "PLANETA CG Works",
-    "internal_id": 294534,
+    "internal_id": 81733,
     "linked": false
   },
   {
@@ -7701,7 +7701,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-41", "A1-254", "A3a-100", "A4b-63"],
     "artist": "PLANETA Saito",
-    "internal_id": 294662,
+    "internal_id": 81797,
     "linked": false
   },
   {
@@ -7737,7 +7737,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-47", "A1-255", "A1-274", "P-A-25", "A3b-103", "A4b-67"],
     "artist": "PLANETA Saito",
-    "internal_id": 294790,
+    "internal_id": 81861,
     "linked": false
   },
   {
@@ -7773,7 +7773,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-56", "A1-256", "A3-232", "A4b-87"],
     "artist": "PLANETA CG Works",
-    "internal_id": 294918,
+    "internal_id": 81925,
     "linked": false
   },
   {
@@ -7803,7 +7803,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-76", "A1-257", "A3-233", "A4b-95"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 295046,
+    "internal_id": 81989,
     "linked": false
   },
   {
@@ -7839,7 +7839,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-84", "A1-258", "A1-275", "A3b-104", "A4b-101"],
     "artist": "PLANETA Saito",
-    "internal_id": 295174,
+    "internal_id": 82053,
     "linked": false
   },
   {
@@ -7869,7 +7869,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-96", "A1-259", "A1-281", "A1-285", "A4b-131", "A4b-364", "A4b-376"],
     "artist": "PLANETA CG Works",
-    "internal_id": 295302,
+    "internal_id": 82117,
     "linked": false
   },
   {
@@ -7905,7 +7905,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-104", "A1-260", "A1-276", "A3b-105", "A4b-139"],
     "artist": "PLANETA Saito",
-    "internal_id": 295430,
+    "internal_id": 82181,
     "linked": false
   },
   {
@@ -7939,7 +7939,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-123", "A1-261", "A1-277", "A3-234", "A4b-155"],
     "artist": "PLANETA CG Works",
-    "internal_id": 295558,
+    "internal_id": 82245,
     "linked": false
   },
   {
@@ -7975,7 +7975,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-129", "A1-262", "A1-282", "A1-286", "P-A-50", "A4b-158", "A4b-365"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 295686,
+    "internal_id": 82309,
     "linked": false
   },
   {
@@ -8005,7 +8005,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-146", "A1-263", "A1-278", "A3-235", "A4b-193"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 295814,
+    "internal_id": 82373,
     "linked": false
   },
   {
@@ -8035,7 +8035,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-153", "A1-264", "A3-236", "A4b-196"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 295942,
+    "internal_id": 82437,
     "linked": false
   },
   {
@@ -8065,7 +8065,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-195", "A1-265", "A1-279", "A3-237", "A4b-279"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 296070,
+    "internal_id": 82501,
     "linked": false
   },
   {
@@ -8092,7 +8092,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-219", "A1-266", "A4b-328", "A4b-329"],
     "artist": "saino misaki",
-    "internal_id": 296198,
+    "internal_id": 82565,
     "linked": false
   },
   {
@@ -8119,7 +8119,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-220", "A1-267"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 296326,
+    "internal_id": 82629,
     "linked": false
   },
   {
@@ -8146,7 +8146,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-221", "A1-268"],
     "artist": "GOSSAN",
-    "internal_id": 296454,
+    "internal_id": 82693,
     "linked": false
   },
   {
@@ -8173,7 +8173,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-222", "A1-269"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 296582,
+    "internal_id": 82757,
     "linked": false
   },
   {
@@ -8200,7 +8200,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-223", "A1-270", "A4b-334", "A4b-335"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 296710,
+    "internal_id": 82821,
     "linked": false
   },
   {
@@ -8227,7 +8227,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-224", "A1-271"],
     "artist": "Ryuta Fuse",
-    "internal_id": 296838,
+    "internal_id": 82885,
     "linked": false
   },
   {
@@ -8254,7 +8254,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-225", "A1-272", "A4b-338", "A4b-339"],
     "artist": "GIDORA",
-    "internal_id": 296966,
+    "internal_id": 82949,
     "linked": false
   },
   {
@@ -8281,7 +8281,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-226", "A1-273"],
     "artist": "nagimiso",
-    "internal_id": 297094,
+    "internal_id": 83013,
     "linked": false
   },
   {
@@ -8317,7 +8317,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-47", "A1-255", "A1-274", "P-A-25", "A3b-103", "A4b-67"],
     "artist": "hncl",
-    "internal_id": 297222,
+    "internal_id": 83077,
     "linked": false
   },
   {
@@ -8353,7 +8353,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-84", "A1-258", "A1-275", "A3b-104", "A4b-101"],
     "artist": "kodama",
-    "internal_id": 297350,
+    "internal_id": 83141,
     "linked": false
   },
   {
@@ -8389,7 +8389,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-104", "A1-260", "A1-276", "A3b-105", "A4b-139"],
     "artist": "GOSSAN",
-    "internal_id": 297478,
+    "internal_id": 83205,
     "linked": false
   },
   {
@@ -8423,7 +8423,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-123", "A1-261", "A1-277", "A3-234", "A4b-155"],
     "artist": "NC Empire",
-    "internal_id": 297606,
+    "internal_id": 83269,
     "linked": false
   },
   {
@@ -8453,7 +8453,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-146", "A1-263", "A1-278", "A3-235", "A4b-193"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 297734,
+    "internal_id": 83333,
     "linked": false
   },
   {
@@ -8483,7 +8483,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-195", "A1-265", "A1-279", "A3-237", "A4b-279"],
     "artist": "Shibuzoh.",
-    "internal_id": 297862,
+    "internal_id": 83397,
     "linked": false
   },
   {
@@ -8519,7 +8519,7 @@
     "pack": "charizardpack",
     "alternate_versions": ["A1-36", "A1-253", "A1-280", "A1-284", "A4b-59", "A4b-361"],
     "artist": "kantaro",
-    "internal_id": 297991,
+    "internal_id": 83462,
     "linked": false
   },
   {
@@ -8549,7 +8549,7 @@
     "pack": "pikachupack",
     "alternate_versions": ["A1-96", "A1-259", "A1-281", "A1-285", "A4b-131", "A4b-364", "A4b-376"],
     "artist": "Ryota Murayama",
-    "internal_id": 298119,
+    "internal_id": 83526,
     "linked": false
   },
   {
@@ -8585,7 +8585,7 @@
     "pack": "mewtwopack",
     "alternate_versions": ["A1-129", "A1-262", "A1-282", "A1-286", "P-A-50", "A4b-158", "A4b-365"],
     "artist": "Nurikabe",
-    "internal_id": 298247,
+    "internal_id": 83590,
     "linked": false
   },
   {
@@ -8615,7 +8615,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-283", "A1a-31"],
     "artist": "Amelicart",
-    "internal_id": 298375,
+    "internal_id": 83654,
     "linked": false
   },
   {
@@ -8651,7 +8651,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-36", "A1-253", "A1-280", "A1-284", "A4b-59", "A4b-361"],
     "artist": "PLANETA CG Works",
-    "internal_id": 298506,
+    "internal_id": 83724,
     "linked": false
   },
   {
@@ -8681,7 +8681,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-96", "A1-259", "A1-281", "A1-285", "A4b-131", "A4b-364", "A4b-376"],
     "artist": "PLANETA CG Works",
-    "internal_id": 298634,
+    "internal_id": 83788,
     "linked": false
   },
   {
@@ -8717,7 +8717,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-129", "A1-262", "A1-282", "A1-286", "P-A-50", "A4b-158", "A4b-365"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 298762,
+    "internal_id": 83852,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A1a.json
+++ b/frontend/assets/cards/A1a.json
@@ -26,7 +26,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-1", "P-A-60"],
     "artist": "Yuka Morii",
-    "internal_id": 393345,
+    "internal_id": 131136,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-2", "A1a-69", "A3-214"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 393474,
+    "internal_id": 131201,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-3", "A1a-75", "A1a-85", "A3a-99", "A4b-24"],
     "artist": "PLANETA CG Works",
-    "internal_id": 393604,
+    "internal_id": 131267,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-4", "A4b-32", "A4b-33"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 393729,
+    "internal_id": 131328,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-5", "A4b-34", "A4b-35"],
     "artist": "Shigenori Negishi",
-    "internal_id": 393858,
+    "internal_id": 131393,
     "linked": false
   },
   {
@@ -180,7 +180,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-6", "A1a-70", "A4b-36", "A4b-37"],
     "artist": "Yoshioka",
-    "internal_id": 393987,
+    "internal_id": 131458,
     "linked": false
   },
   {
@@ -210,7 +210,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-7"],
     "artist": "Saya Tsuruta",
-    "internal_id": 394113,
+    "internal_id": 131520,
     "linked": false
   },
   {
@@ -240,7 +240,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-8"],
     "artist": "Mizue",
-    "internal_id": 394242,
+    "internal_id": 131585,
     "linked": false
   },
   {
@@ -270,7 +270,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-9"],
     "artist": "Hasuno",
-    "internal_id": 394370,
+    "internal_id": 131649,
     "linked": false
   },
   {
@@ -300,7 +300,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-10"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 394497,
+    "internal_id": 131712,
     "linked": false
   },
   {
@@ -330,7 +330,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-11"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 394626,
+    "internal_id": 131777,
     "linked": false
   },
   {
@@ -360,7 +360,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-12"],
     "artist": "sui",
-    "internal_id": 394754,
+    "internal_id": 131841,
     "linked": false
   },
   {
@@ -390,7 +390,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-13"],
     "artist": "kawayoo",
-    "internal_id": 394881,
+    "internal_id": 131904,
     "linked": false
   },
   {
@@ -420,7 +420,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-14", "P-A-28"],
     "artist": "DOM",
-    "internal_id": 395011,
+    "internal_id": 131970,
     "linked": false
   },
   {
@@ -450,7 +450,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-15", "A1a-71"],
     "artist": "Naoki Saito",
-    "internal_id": 395137,
+    "internal_id": 132032,
     "linked": false
   },
   {
@@ -480,7 +480,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-16"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 395265,
+    "internal_id": 132096,
     "linked": false
   },
   {
@@ -510,7 +510,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-17", "A4-214", "A4b-96", "A4b-97"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 395393,
+    "internal_id": 132160,
     "linked": false
   },
   {
@@ -540,7 +540,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-18", "A1a-76", "A4-234", "A4b-98"],
     "artist": "PLANETA CG Works",
-    "internal_id": 395524,
+    "internal_id": 132227,
     "linked": false
   },
   {
@@ -574,7 +574,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-19", "A1a-72", "A4b-99", "A4b-100"],
     "artist": "LINNE",
-    "internal_id": 395651,
+    "internal_id": 132290,
     "linked": false
   },
   {
@@ -604,7 +604,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-20"],
     "artist": "sui",
-    "internal_id": 395777,
+    "internal_id": 132352,
     "linked": false
   },
   {
@@ -634,7 +634,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-21"],
     "artist": "Sekio",
-    "internal_id": 395906,
+    "internal_id": 132417,
     "linked": false
   },
   {
@@ -664,7 +664,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-22"],
     "artist": "Taiga Kayama",
-    "internal_id": 396033,
+    "internal_id": 132480,
     "linked": false
   },
   {
@@ -694,7 +694,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-23"],
     "artist": "nisimono",
-    "internal_id": 396162,
+    "internal_id": 132545,
     "linked": false
   },
   {
@@ -724,7 +724,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-24"],
     "artist": "Jerky",
-    "internal_id": 396289,
+    "internal_id": 132608,
     "linked": false
   },
   {
@@ -754,7 +754,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-25"],
     "artist": "Naoyo Kimura",
-    "internal_id": 396417,
+    "internal_id": 132672,
     "linked": false
   },
   {
@@ -784,7 +784,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-26"],
     "artist": "hncl",
-    "internal_id": 396547,
+    "internal_id": 132738,
     "linked": false
   },
   {
@@ -814,7 +814,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-27"],
     "artist": "Naoyo Kimura",
-    "internal_id": 396674,
+    "internal_id": 132801,
     "linked": false
   },
   {
@@ -844,7 +844,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-28"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 396801,
+    "internal_id": 132864,
     "linked": false
   },
   {
@@ -874,7 +874,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-29"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 396930,
+    "internal_id": 132929,
     "linked": false
   },
   {
@@ -904,7 +904,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-30", "A1a-73"],
     "artist": "Taiga Kayama",
-    "internal_id": 397057,
+    "internal_id": 132992,
     "linked": false
   },
   {
@@ -934,7 +934,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1-283", "A1a-31"],
     "artist": "Saya Tsuruta",
-    "internal_id": 397187,
+    "internal_id": 133058,
     "linked": false
   },
   {
@@ -970,7 +970,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-32", "A1a-77", "A1a-83", "A1a-86", "A4a-102", "A4b-159", "A4b-366"],
     "artist": "PLANETA CG Works",
-    "internal_id": 397316,
+    "internal_id": 133123,
     "linked": false
   },
   {
@@ -1000,7 +1000,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-33"],
     "artist": "Shigenori Negishi",
-    "internal_id": 397442,
+    "internal_id": 133185,
     "linked": false
   },
   {
@@ -1030,7 +1030,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-34"],
     "artist": "Kouki Saitou",
-    "internal_id": 397569,
+    "internal_id": 133248,
     "linked": false
   },
   {
@@ -1060,7 +1060,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-35"],
     "artist": "sowsow",
-    "internal_id": 397698,
+    "internal_id": 133313,
     "linked": false
   },
   {
@@ -1090,7 +1090,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-36"],
     "artist": "Cona Nitanda",
-    "internal_id": 397825,
+    "internal_id": 133376,
     "linked": false
   },
   {
@@ -1120,7 +1120,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-37"],
     "artist": "Cona Nitanda",
-    "internal_id": 397953,
+    "internal_id": 133440,
     "linked": false
   },
   {
@@ -1150,7 +1150,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-38"],
     "artist": "Cona Nitanda",
-    "internal_id": 398082,
+    "internal_id": 133505,
     "linked": false
   },
   {
@@ -1180,7 +1180,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-39"],
     "artist": "5ban Graphics",
-    "internal_id": 398209,
+    "internal_id": 133568,
     "linked": false
   },
   {
@@ -1210,7 +1210,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-40"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 398337,
+    "internal_id": 133632,
     "linked": false
   },
   {
@@ -1240,7 +1240,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-41", "A4-221"],
     "artist": "Akira Komayama",
-    "internal_id": 398465,
+    "internal_id": 133696,
     "linked": false
   },
   {
@@ -1270,7 +1270,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-42"],
     "artist": "Taiga Kayama",
-    "internal_id": 398593,
+    "internal_id": 133760,
     "linked": false
   },
   {
@@ -1300,7 +1300,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-43"],
     "artist": "GOSSAN",
-    "internal_id": 398721,
+    "internal_id": 133824,
     "linked": false
   },
   {
@@ -1330,7 +1330,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-44"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 398850,
+    "internal_id": 133889,
     "linked": false
   },
   {
@@ -1360,7 +1360,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-45"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 398979,
+    "internal_id": 133954,
     "linked": false
   },
   {
@@ -1394,7 +1394,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-46", "A1a-78", "A1a-84", "A3a-101", "A4b-197"],
     "artist": "PLANETA CG Works",
-    "internal_id": 399108,
+    "internal_id": 134019,
     "linked": false
   },
   {
@@ -1424,7 +1424,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-47", "A1a-74", "A4b-224", "A4b-225"],
     "artist": "kantaro",
-    "internal_id": 399235,
+    "internal_id": 134082,
     "linked": false
   },
   {
@@ -1454,7 +1454,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-48"],
     "artist": "Teeziro",
-    "internal_id": 399362,
+    "internal_id": 134145,
     "linked": false
   },
   {
@@ -1484,7 +1484,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-49"],
     "artist": "Naoyo Kimura",
-    "internal_id": 399489,
+    "internal_id": 134208,
     "linked": false
   },
   {
@@ -1514,7 +1514,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-50"],
     "artist": "Mousho",
-    "internal_id": 399618,
+    "internal_id": 134273,
     "linked": false
   },
   {
@@ -1544,7 +1544,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-51"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 399745,
+    "internal_id": 134336,
     "linked": false
   },
   {
@@ -1574,7 +1574,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-52"],
     "artist": "GIDORA",
-    "internal_id": 399873,
+    "internal_id": 134400,
     "linked": false
   },
   {
@@ -1604,7 +1604,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-53"],
     "artist": "Yukiko Baba",
-    "internal_id": 400001,
+    "internal_id": 134464,
     "linked": false
   },
   {
@@ -1634,7 +1634,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-54"],
     "artist": "Shin Nagasawa",
-    "internal_id": 400129,
+    "internal_id": 134528,
     "linked": false
   },
   {
@@ -1664,7 +1664,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-55"],
     "artist": "5ban Graphics",
-    "internal_id": 400258,
+    "internal_id": 134593,
     "linked": false
   },
   {
@@ -1698,7 +1698,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-56"],
     "artist": "Ryota Murayama",
-    "internal_id": 400386,
+    "internal_id": 134657,
     "linked": false
   },
   {
@@ -1728,7 +1728,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-57", "A4b-272", "A4b-273"],
     "artist": "Shigenori Negishi",
-    "internal_id": 400513,
+    "internal_id": 134720,
     "linked": false
   },
   {
@@ -1758,7 +1758,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-58", "A4b-274", "A4b-275"],
     "artist": "Taiga Kayama",
-    "internal_id": 400641,
+    "internal_id": 134784,
     "linked": false
   },
   {
@@ -1788,7 +1788,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-59", "A1a-79", "A3a-102", "A4b-276"],
     "artist": "PLANETA CG Works",
-    "internal_id": 400772,
+    "internal_id": 134851,
     "linked": false
   },
   {
@@ -1818,7 +1818,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-60"],
     "artist": "KEIICHIRO ITO",
-    "internal_id": 400899,
+    "internal_id": 134914,
     "linked": false
   },
   {
@@ -1848,7 +1848,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-61"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 401025,
+    "internal_id": 134976,
     "linked": false
   },
   {
@@ -1878,7 +1878,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-62"],
     "artist": "Masako Tomii",
-    "internal_id": 401153,
+    "internal_id": 135040,
     "linked": false
   },
   {
@@ -1905,7 +1905,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1-218", "A1a-63", "A4b-312", "A4b-313"],
     "artist": "Toyste Beach",
-    "internal_id": 290049,
+    "internal_id": 79488,
     "linked": true
   },
   {
@@ -1932,7 +1932,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-64"],
     "artist": "Toyste Beach",
-    "internal_id": 401410,
+    "internal_id": 135169,
     "linked": false
   },
   {
@@ -1959,7 +1959,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-65"],
     "artist": "AYUMI ODASHIMA",
-    "internal_id": 401538,
+    "internal_id": 135233,
     "linked": false
   },
   {
@@ -1986,7 +1986,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-66", "A1a-80"],
     "artist": "Yuu Nishida",
-    "internal_id": 401666,
+    "internal_id": 135297,
     "linked": false
   },
   {
@@ -2013,7 +2013,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-67", "A1a-81"],
     "artist": "Ryuta Fuse",
-    "internal_id": 401794,
+    "internal_id": 135361,
     "linked": false
   },
   {
@@ -2040,7 +2040,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-68", "A1a-82", "A4b-346", "A4b-347"],
     "artist": "En Morikura",
-    "internal_id": 401922,
+    "internal_id": 135425,
     "linked": false
   },
   {
@@ -2070,7 +2070,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-2", "A1a-69", "A3-214"],
     "artist": "Gapao",
-    "internal_id": 402053,
+    "internal_id": 135492,
     "linked": false
   },
   {
@@ -2104,7 +2104,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-6", "A1a-70", "A4b-36", "A4b-37"],
     "artist": "rika",
-    "internal_id": 402181,
+    "internal_id": 135556,
     "linked": false
   },
   {
@@ -2134,7 +2134,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-15", "A1a-71"],
     "artist": "Nurikabe",
-    "internal_id": 402309,
+    "internal_id": 135620,
     "linked": false
   },
   {
@@ -2168,7 +2168,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-19", "A1a-72", "A4b-99", "A4b-100"],
     "artist": "aspara",
-    "internal_id": 402437,
+    "internal_id": 135684,
     "linked": false
   },
   {
@@ -2198,7 +2198,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-30", "A1a-73"],
     "artist": "Yuu Nishida",
-    "internal_id": 402565,
+    "internal_id": 135748,
     "linked": false
   },
   {
@@ -2228,7 +2228,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-47", "A1a-74", "A4b-224", "A4b-225"],
     "artist": "OKACHEKE",
-    "internal_id": 402693,
+    "internal_id": 135812,
     "linked": false
   },
   {
@@ -2258,7 +2258,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-3", "A1a-75", "A1a-85", "A3a-99", "A4b-24"],
     "artist": "PLANETA CG Works",
-    "internal_id": 402822,
+    "internal_id": 135877,
     "linked": false
   },
   {
@@ -2288,7 +2288,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-18", "A1a-76", "A4-234", "A4b-98"],
     "artist": "PLANETA CG Works",
-    "internal_id": 402950,
+    "internal_id": 135941,
     "linked": false
   },
   {
@@ -2324,7 +2324,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-32", "A1a-77", "A1a-83", "A1a-86", "A4a-102", "A4b-159", "A4b-366"],
     "artist": "PLANETA CG Works",
-    "internal_id": 403078,
+    "internal_id": 136005,
     "linked": false
   },
   {
@@ -2358,7 +2358,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-46", "A1a-78", "A1a-84", "A3a-101", "A4b-197"],
     "artist": "PLANETA CG Works",
-    "internal_id": 403206,
+    "internal_id": 136069,
     "linked": false
   },
   {
@@ -2388,7 +2388,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-59", "A1a-79", "A3a-102", "A4b-276"],
     "artist": "PLANETA CG Works",
-    "internal_id": 403334,
+    "internal_id": 136133,
     "linked": false
   },
   {
@@ -2415,7 +2415,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-66", "A1a-80"],
     "artist": "Yuu Nishida",
-    "internal_id": 403462,
+    "internal_id": 136197,
     "linked": false
   },
   {
@@ -2442,7 +2442,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-67", "A1a-81"],
     "artist": "Ryuta Fuse",
-    "internal_id": 403590,
+    "internal_id": 136261,
     "linked": false
   },
   {
@@ -2469,7 +2469,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-68", "A1a-82", "A4b-346", "A4b-347"],
     "artist": "En Morikura",
-    "internal_id": 403718,
+    "internal_id": 136325,
     "linked": false
   },
   {
@@ -2505,7 +2505,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-32", "A1a-77", "A1a-83", "A1a-86", "A4a-102", "A4b-159", "A4b-366"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 403846,
+    "internal_id": 136389,
     "linked": false
   },
   {
@@ -2539,7 +2539,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-46", "A1a-78", "A1a-84", "A3a-101", "A4b-197"],
     "artist": "danciao",
-    "internal_id": 403974,
+    "internal_id": 136453,
     "linked": false
   },
   {
@@ -2569,7 +2569,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-3", "A1a-75", "A1a-85", "A3a-99", "A4b-24"],
     "artist": "kantaro",
-    "internal_id": 404103,
+    "internal_id": 136518,
     "linked": false
   },
   {
@@ -2605,7 +2605,7 @@
     "pack": "mewpack",
     "alternate_versions": ["A1a-32", "A1a-77", "A1a-83", "A1a-86", "A4a-102", "A4b-159", "A4b-366"],
     "artist": "PLANETA CG Works",
-    "internal_id": 404234,
+    "internal_id": 136588,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A2.json
+++ b/frontend/assets/cards/A2.json
@@ -26,7 +26,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-1"],
     "artist": "Asako Ito",
-    "internal_id": 524417,
+    "internal_id": 196672,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-2"],
     "artist": "Shibuzoh.",
-    "internal_id": 524545,
+    "internal_id": 196736,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-3"],
     "artist": "Naoyo Kimura",
-    "internal_id": 524674,
+    "internal_id": 196801,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-4"],
     "artist": "Narumi Sato",
-    "internal_id": 524801,
+    "internal_id": 196864,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-5", "A2-156"],
     "artist": "kodama",
-    "internal_id": 524930,
+    "internal_id": 196929,
     "linked": false
   },
   {
@@ -176,7 +176,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-6", "A4b-20", "A4b-21"],
     "artist": "Eri Yamaki",
-    "internal_id": 525057,
+    "internal_id": 196992,
     "linked": false
   },
   {
@@ -206,7 +206,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-7", "A2-180", "A2-196", "A4-232", "A4b-22"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 525188,
+    "internal_id": 197059,
     "linked": false
   },
   {
@@ -236,7 +236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-8"],
     "artist": "kirisAki",
-    "internal_id": 525313,
+    "internal_id": 197120,
     "linked": false
   },
   {
@@ -266,7 +266,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-9"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 525442,
+    "internal_id": 197185,
     "linked": false
   },
   {
@@ -296,7 +296,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-10", "P-A-35"],
     "artist": "OOYAMA",
-    "internal_id": 525569,
+    "internal_id": 197248,
     "linked": false
   },
   {
@@ -326,7 +326,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-11"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 525698,
+    "internal_id": 197313,
     "linked": false
   },
   {
@@ -356,7 +356,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-12"],
     "artist": "kawayoo",
-    "internal_id": 525827,
+    "internal_id": 197378,
     "linked": false
   },
   {
@@ -386,7 +386,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-13"],
     "artist": "Shigenori Negishi",
-    "internal_id": 525953,
+    "internal_id": 197440,
     "linked": false
   },
   {
@@ -416,7 +416,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-14"],
     "artist": "Naoyo Kimura",
-    "internal_id": 526081,
+    "internal_id": 197504,
     "linked": false
   },
   {
@@ -446,7 +446,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-15"],
     "artist": "Mugi Hamada",
-    "internal_id": 526209,
+    "internal_id": 197568,
     "linked": false
   },
   {
@@ -476,7 +476,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-16"],
     "artist": "Kouki Saitou",
-    "internal_id": 526337,
+    "internal_id": 197632,
     "linked": false
   },
   {
@@ -506,7 +506,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-17", "A2-157"],
     "artist": "Yukiko Baba",
-    "internal_id": 526465,
+    "internal_id": 197696,
     "linked": false
   },
   {
@@ -536,7 +536,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-18"],
     "artist": "chibi",
-    "internal_id": 526594,
+    "internal_id": 197761,
     "linked": false
   },
   {
@@ -566,7 +566,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-19", "A2-158"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 526722,
+    "internal_id": 197825,
     "linked": false
   },
   {
@@ -596,7 +596,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-20"],
     "artist": "Kouki Saitou",
-    "internal_id": 526851,
+    "internal_id": 197890,
     "linked": false
   },
   {
@@ -626,7 +626,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-21"],
     "artist": "kawayoo",
-    "internal_id": 526977,
+    "internal_id": 197952,
     "linked": false
   },
   {
@@ -660,7 +660,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-22", "A2-159", "A4b-30", "A4b-31", "P-A-116"],
     "artist": "Narumi Sato",
-    "internal_id": 527107,
+    "internal_id": 198018,
     "linked": false
   },
   {
@@ -690,7 +690,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-23"],
     "artist": "Hiroki Asanuma",
-    "internal_id": 527233,
+    "internal_id": 198080,
     "linked": false
   },
   {
@@ -720,7 +720,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-24"],
     "artist": "KEIICHIRO ITO",
-    "internal_id": 527363,
+    "internal_id": 198146,
     "linked": false
   },
   {
@@ -750,7 +750,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-25"],
     "artist": "Naoyo Kimura",
-    "internal_id": 527489,
+    "internal_id": 198208,
     "linked": false
   },
   {
@@ -780,7 +780,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-26"],
     "artist": "Oswaldo KATO",
-    "internal_id": 527618,
+    "internal_id": 198273,
     "linked": false
   },
   {
@@ -810,7 +810,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-27", "P-A-40", "A4a-91", "A4b-71", "A4b-72"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 527745,
+    "internal_id": 198336,
     "linked": false
   },
   {
@@ -840,7 +840,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-28", "A4a-92", "A4b-73", "A4b-74"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 527874,
+    "internal_id": 198401,
     "linked": false
   },
   {
@@ -870,7 +870,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-29", "A2-181", "A2-197", "A4a-101", "A4b-75"],
     "artist": "PLANETA CG Works",
-    "internal_id": 528004,
+    "internal_id": 198467,
     "linked": false
   },
   {
@@ -900,7 +900,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-30"],
     "artist": "Kedamahadaitai Yawarakai",
-    "internal_id": 528129,
+    "internal_id": 198528,
     "linked": false
   },
   {
@@ -930,7 +930,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-31"],
     "artist": "Eri Yamaki",
-    "internal_id": 528257,
+    "internal_id": 198592,
     "linked": false
   },
   {
@@ -964,7 +964,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-32"],
     "artist": "Suwama Chiaki",
-    "internal_id": 528386,
+    "internal_id": 198657,
     "linked": false
   },
   {
@@ -998,7 +998,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-33", "A2-160"],
     "artist": "match",
-    "internal_id": 528515,
+    "internal_id": 198722,
     "linked": false
   },
   {
@@ -1032,7 +1032,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-34"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 528642,
+    "internal_id": 198785,
     "linked": false
   },
   {
@@ -1062,7 +1062,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-35", "P-A-34"],
     "artist": "Hajime Kusajima",
-    "internal_id": 528769,
+    "internal_id": 198848,
     "linked": false
   },
   {
@@ -1092,7 +1092,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-36"],
     "artist": "Mizue",
-    "internal_id": 528898,
+    "internal_id": 198913,
     "linked": false
   },
   {
@@ -1122,7 +1122,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-37"],
     "artist": "Satoshi Shirai",
-    "internal_id": 529027,
+    "internal_id": 198978,
     "linked": false
   },
   {
@@ -1152,7 +1152,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-38"],
     "artist": "OKUBO",
-    "internal_id": 529153,
+    "internal_id": 199040,
     "linked": false
   },
   {
@@ -1182,7 +1182,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-39"],
     "artist": "Kanako Eo",
-    "internal_id": 529282,
+    "internal_id": 199105,
     "linked": false
   },
   {
@@ -1212,7 +1212,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-40"],
     "artist": "Teeziro",
-    "internal_id": 529409,
+    "internal_id": 199168,
     "linked": false
   },
   {
@@ -1242,7 +1242,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-41", "A2-161"],
     "artist": "Aya Kusube",
-    "internal_id": 529538,
+    "internal_id": 199233,
     "linked": false
   },
   {
@@ -1272,7 +1272,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-42"],
     "artist": "Shigenori Negishi",
-    "internal_id": 529665,
+    "internal_id": 199296,
     "linked": false
   },
   {
@@ -1302,7 +1302,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-43"],
     "artist": "rika",
-    "internal_id": 529794,
+    "internal_id": 199361,
     "linked": false
   },
   {
@@ -1332,7 +1332,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-44"],
     "artist": "match",
-    "internal_id": 529921,
+    "internal_id": 199424,
     "linked": false
   },
   {
@@ -1362,7 +1362,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-45"],
     "artist": "Shin Nagasawa",
-    "internal_id": 530050,
+    "internal_id": 199489,
     "linked": false
   },
   {
@@ -1392,7 +1392,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-46"],
     "artist": "Naoyo Kimura",
-    "internal_id": 530179,
+    "internal_id": 199554,
     "linked": false
   },
   {
@@ -1422,7 +1422,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-47"],
     "artist": "Saboteri",
-    "internal_id": 530305,
+    "internal_id": 199616,
     "linked": false
   },
   {
@@ -1452,7 +1452,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-48"],
     "artist": "MAHOU",
-    "internal_id": 530433,
+    "internal_id": 199680,
     "linked": false
   },
   {
@@ -1488,7 +1488,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-49", "A2-182", "A2-204", "A2-206", "A4b-107", "A4b-363"],
     "artist": "PLANETA CG Works",
-    "internal_id": 530564,
+    "internal_id": 199747,
     "linked": false
   },
   {
@@ -1518,7 +1518,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-50", "A2-162", "P-A-48", "A4b-108", "A4b-109"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 530690,
+    "internal_id": 199809,
     "linked": false
   },
   {
@@ -1548,7 +1548,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-51"],
     "artist": "MAHOU",
-    "internal_id": 530817,
+    "internal_id": 199872,
     "linked": false
   },
   {
@@ -1578,7 +1578,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-52"],
     "artist": "Yumi",
-    "internal_id": 530946,
+    "internal_id": 199937,
     "linked": false
   },
   {
@@ -1608,7 +1608,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-53", "A4b-137", "A4b-138"],
     "artist": "Yoshinobu Saito",
-    "internal_id": 531075,
+    "internal_id": 200002,
     "linked": false
   },
   {
@@ -1638,7 +1638,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-54", "A3b-95"],
     "artist": "Midori Harada",
-    "internal_id": 531201,
+    "internal_id": 200064,
     "linked": false
   },
   {
@@ -1668,7 +1668,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-55", "A3b-96"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 531330,
+    "internal_id": 200129,
     "linked": false
   },
   {
@@ -1698,7 +1698,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-56"],
     "artist": "Shin Nagasawa",
-    "internal_id": 531457,
+    "internal_id": 200192,
     "linked": false
   },
   {
@@ -1728,7 +1728,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-57", "P-A-36"],
     "artist": "kawayoo",
-    "internal_id": 531587,
+    "internal_id": 200258,
     "linked": false
   },
   {
@@ -1758,7 +1758,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-58", "A2-163"],
     "artist": "Shibuzoh.",
-    "internal_id": 531713,
+    "internal_id": 200320,
     "linked": false
   },
   {
@@ -1788,7 +1788,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-59"],
     "artist": "Naoki Saito",
-    "internal_id": 531842,
+    "internal_id": 200385,
     "linked": false
   },
   {
@@ -1818,7 +1818,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-60"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 531971,
+    "internal_id": 200450,
     "linked": false
   },
   {
@@ -1848,7 +1848,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-61", "A2-183", "A2-198", "A4-236", "A4b-145"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 532100,
+    "internal_id": 200515,
     "linked": false
   },
   {
@@ -1878,7 +1878,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-62", "A2-164"],
     "artist": "Krgc",
-    "internal_id": 532225,
+    "internal_id": 200576,
     "linked": false
   },
   {
@@ -1908,7 +1908,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-63", "P-A-41"],
     "artist": "Narumi Sato",
-    "internal_id": 532353,
+    "internal_id": 200640,
     "linked": false
   },
   {
@@ -1938,7 +1938,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-64"],
     "artist": "Kanako Eo",
-    "internal_id": 532482,
+    "internal_id": 200705,
     "linked": false
   },
   {
@@ -1968,7 +1968,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-65"],
     "artist": "kawayoo",
-    "internal_id": 532611,
+    "internal_id": 200770,
     "linked": false
   },
   {
@@ -1998,7 +1998,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-66", "A4-220", "A4b-161", "A4b-162"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 532737,
+    "internal_id": 200832,
     "linked": false
   },
   {
@@ -2028,7 +2028,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-67", "A2-184", "A2-199", "A4-237", "A4b-163"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 532868,
+    "internal_id": 200899,
     "linked": false
   },
   {
@@ -2058,7 +2058,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-68", "A3b-97", "A4b-164", "A4b-165"],
     "artist": "Miki Tanaka",
-    "internal_id": 532993,
+    "internal_id": 200960,
     "linked": false
   },
   {
@@ -2088,7 +2088,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-69", "A3b-98", "A4b-166", "A4b-167"],
     "artist": "Yukiko Baba",
-    "internal_id": 533121,
+    "internal_id": 201024,
     "linked": false
   },
   {
@@ -2118,7 +2118,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-70"],
     "artist": "ryoma uratsuka",
-    "internal_id": 533249,
+    "internal_id": 201088,
     "linked": false
   },
   {
@@ -2148,7 +2148,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-71"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 533378,
+    "internal_id": 201153,
     "linked": false
   },
   {
@@ -2182,7 +2182,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-72"],
     "artist": "Suwama Chiaki",
-    "internal_id": 533507,
+    "internal_id": 201218,
     "linked": false
   },
   {
@@ -2212,7 +2212,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-73", "A2-165"],
     "artist": "Atsuko Nishida",
-    "internal_id": 533633,
+    "internal_id": 201280,
     "linked": false
   },
   {
@@ -2242,7 +2242,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-74"],
     "artist": "Miki Tanaka",
-    "internal_id": 533762,
+    "internal_id": 201345,
     "linked": false
   },
   {
@@ -2272,7 +2272,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-75"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 533890,
+    "internal_id": 201409,
     "linked": false
   },
   {
@@ -2302,7 +2302,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-76", "A2-166"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 534019,
+    "internal_id": 201474,
     "linked": false
   },
   {
@@ -2332,7 +2332,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-77"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 534146,
+    "internal_id": 201537,
     "linked": false
   },
   {
@@ -2366,7 +2366,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-78", "A2-167", "A4b-170", "A4b-171"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 534275,
+    "internal_id": 201602,
     "linked": false
   },
   {
@@ -2396,7 +2396,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-79", "A2-168"],
     "artist": "Masako Tomii",
-    "internal_id": 534403,
+    "internal_id": 201666,
     "linked": false
   },
   {
@@ -2426,7 +2426,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-80"],
     "artist": "otumami",
-    "internal_id": 534529,
+    "internal_id": 201728,
     "linked": false
   },
   {
@@ -2456,7 +2456,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-81"],
     "artist": "Oswaldo KATO",
-    "internal_id": 534658,
+    "internal_id": 201793,
     "linked": false
   },
   {
@@ -2486,7 +2486,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-82", "A2-169"],
     "artist": "Naoki Saito",
-    "internal_id": 534787,
+    "internal_id": 201858,
     "linked": false
   },
   {
@@ -2516,7 +2516,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-83"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 534913,
+    "internal_id": 201920,
     "linked": false
   },
   {
@@ -2546,7 +2546,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-84"],
     "artist": "Mizue",
-    "internal_id": 535042,
+    "internal_id": 201985,
     "linked": false
   },
   {
@@ -2576,7 +2576,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-85"],
     "artist": "sowsow",
-    "internal_id": 535169,
+    "internal_id": 202048,
     "linked": false
   },
   {
@@ -2606,7 +2606,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-86"],
     "artist": "Midori Harada",
-    "internal_id": 535297,
+    "internal_id": 202112,
     "linked": false
   },
   {
@@ -2640,7 +2640,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-87"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 535426,
+    "internal_id": 202177,
     "linked": false
   },
   {
@@ -2670,7 +2670,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-88"],
     "artist": "Kouki Saitou",
-    "internal_id": 535554,
+    "internal_id": 202241,
     "linked": false
   },
   {
@@ -2700,7 +2700,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-89"],
     "artist": "Yoshinobu Saito",
-    "internal_id": 535683,
+    "internal_id": 202306,
     "linked": false
   },
   {
@@ -2730,7 +2730,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-90"],
     "artist": "Hajime Kusajima",
-    "internal_id": 535809,
+    "internal_id": 202368,
     "linked": false
   },
   {
@@ -2760,7 +2760,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-91"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 535937,
+    "internal_id": 202432,
     "linked": false
   },
   {
@@ -2794,7 +2794,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-92", "A2-170", "A4b-212", "A4b-213"],
     "artist": "nagimiso",
-    "internal_id": 536067,
+    "internal_id": 202498,
     "linked": false
   },
   {
@@ -2824,7 +2824,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-93", "A2-171"],
     "artist": "Akira Komayama",
-    "internal_id": 536193,
+    "internal_id": 202560,
     "linked": false
   },
   {
@@ -2854,7 +2854,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-94"],
     "artist": "KEIICHIRO ITO",
-    "internal_id": 536322,
+    "internal_id": 202625,
     "linked": false
   },
   {
@@ -2884,7 +2884,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-95", "A2-185", "A2-200", "A3b-106", "A4b-215"],
     "artist": "PLANETA CG Works",
-    "internal_id": 536452,
+    "internal_id": 202691,
     "linked": false
   },
   {
@@ -2914,7 +2914,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-96"],
     "artist": "Yukiko Baba",
-    "internal_id": 536577,
+    "internal_id": 202752,
     "linked": false
   },
   {
@@ -2944,7 +2944,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-97"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 536706,
+    "internal_id": 202817,
     "linked": false
   },
   {
@@ -2974,7 +2974,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-98", "A4b-242", "A4b-243"],
     "artist": "Hasuno",
-    "internal_id": 536833,
+    "internal_id": 202880,
     "linked": false
   },
   {
@@ -3004,7 +3004,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-99", "A2-186", "A2-201", "A4-238", "A4b-244"],
     "artist": "PLANETA CG Works",
-    "internal_id": 536964,
+    "internal_id": 202947,
     "linked": false
   },
   {
@@ -3034,7 +3034,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-100"],
     "artist": "Midori Harada",
-    "internal_id": 537089,
+    "internal_id": 203008,
     "linked": false
   },
   {
@@ -3064,7 +3064,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-101"],
     "artist": "Kouki Saitou",
-    "internal_id": 537218,
+    "internal_id": 203073,
     "linked": false
   },
   {
@@ -3094,7 +3094,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-102"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 537345,
+    "internal_id": 203136,
     "linked": false
   },
   {
@@ -3124,7 +3124,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-103"],
     "artist": "kirisAki",
-    "internal_id": 537474,
+    "internal_id": 203201,
     "linked": false
   },
   {
@@ -3154,7 +3154,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-104", "A2-172"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 537602,
+    "internal_id": 203265,
     "linked": false
   },
   {
@@ -3184,7 +3184,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-105"],
     "artist": "Naoki Saito",
-    "internal_id": 537729,
+    "internal_id": 203328,
     "linked": false
   },
   {
@@ -3214,7 +3214,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-106"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 537858,
+    "internal_id": 203393,
     "linked": false
   },
   {
@@ -3244,7 +3244,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-107", "A2-173"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 537985,
+    "internal_id": 203456,
     "linked": false
   },
   {
@@ -3274,7 +3274,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-108"],
     "artist": "Hajime Kusajima",
-    "internal_id": 538114,
+    "internal_id": 203521,
     "linked": false
   },
   {
@@ -3304,7 +3304,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-109"],
     "artist": "Masako Tomii",
-    "internal_id": 538243,
+    "internal_id": 203586,
     "linked": false
   },
   {
@@ -3338,7 +3338,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-110", "A2-187", "A2-202", "P-A-42", "A4b-245", "A4b-378"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 538372,
+    "internal_id": 203651,
     "linked": false
   },
   {
@@ -3368,7 +3368,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-111", "P-A-39"],
     "artist": "Oswaldo KATO",
-    "internal_id": 538498,
+    "internal_id": 203713,
     "linked": false
   },
   {
@@ -3398,7 +3398,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-112"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 538626,
+    "internal_id": 203777,
     "linked": false
   },
   {
@@ -3428,7 +3428,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-113"],
     "artist": "Kouki Saitou",
-    "internal_id": 538754,
+    "internal_id": 203841,
     "linked": false
   },
   {
@@ -3462,7 +3462,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-114"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 538883,
+    "internal_id": 203906,
     "linked": false
   },
   {
@@ -3492,7 +3492,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-115"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 539009,
+    "internal_id": 203968,
     "linked": false
   },
   {
@@ -3522,7 +3522,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-116"],
     "artist": "Miki Tanaka",
-    "internal_id": 539137,
+    "internal_id": 204032,
     "linked": false
   },
   {
@@ -3552,7 +3552,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-117"],
     "artist": "Yuka Morii",
-    "internal_id": 539266,
+    "internal_id": 204097,
     "linked": false
   },
   {
@@ -3582,7 +3582,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-118"],
     "artist": "MAHOU",
-    "internal_id": 539394,
+    "internal_id": 204161,
     "linked": false
   },
   {
@@ -3618,7 +3618,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-119", "A2-188", "A2-205", "A2-207", "A4b-254", "A4b-368"],
     "artist": "PLANETA CG Works",
-    "internal_id": 539524,
+    "internal_id": 204227,
     "linked": false
   },
   {
@@ -3648,7 +3648,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-120", "A2-174"],
     "artist": "Oswaldo KATO",
-    "internal_id": 539651,
+    "internal_id": 204290,
     "linked": false
   },
   {
@@ -3678,7 +3678,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-121"],
     "artist": "Naoyo Kimura",
-    "internal_id": 539777,
+    "internal_id": 204352,
     "linked": false
   },
   {
@@ -3708,7 +3708,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-122"],
     "artist": "Shigenori Negishi",
-    "internal_id": 539906,
+    "internal_id": 204417,
     "linked": false
   },
   {
@@ -3742,7 +3742,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-123", "A2-175"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 540035,
+    "internal_id": 204482,
     "linked": false
   },
   {
@@ -3772,7 +3772,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-124", "A4-230", "A4b-282", "A4b-283"],
     "artist": "Yukiko Baba",
-    "internal_id": 540161,
+    "internal_id": 204544,
     "linked": false
   },
   {
@@ -3802,7 +3802,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-125", "A2-189", "A2-203", "A4-239", "A4b-284"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 540292,
+    "internal_id": 204611,
     "linked": false
   },
   {
@@ -3832,7 +3832,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-126"],
     "artist": "Shibuzoh.",
-    "internal_id": 540417,
+    "internal_id": 204672,
     "linked": false
   },
   {
@@ -3862,7 +3862,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-127"],
     "artist": "Shin Nagasawa",
-    "internal_id": 540545,
+    "internal_id": 204736,
     "linked": false
   },
   {
@@ -3892,7 +3892,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-128"],
     "artist": "sowsow",
-    "internal_id": 540674,
+    "internal_id": 204801,
     "linked": false
   },
   {
@@ -3922,7 +3922,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-129"],
     "artist": "Shin Nagasawa",
-    "internal_id": 540803,
+    "internal_id": 204866,
     "linked": false
   },
   {
@@ -3952,7 +3952,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-130"],
     "artist": "Miki Tanaka",
-    "internal_id": 540929,
+    "internal_id": 204928,
     "linked": false
   },
   {
@@ -3982,7 +3982,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-131"],
     "artist": "Naoyo Kimura",
-    "internal_id": 541057,
+    "internal_id": 204992,
     "linked": false
   },
   {
@@ -4012,7 +4012,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-132"],
     "artist": "Atsuko Nishida",
-    "internal_id": 541185,
+    "internal_id": 205056,
     "linked": false
   },
   {
@@ -4042,7 +4042,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-133"],
     "artist": "REND",
-    "internal_id": 541313,
+    "internal_id": 205120,
     "linked": false
   },
   {
@@ -4072,7 +4072,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-134", "A2-176"],
     "artist": "Sekio",
-    "internal_id": 541442,
+    "internal_id": 205185,
     "linked": false
   },
   {
@@ -4102,7 +4102,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-135", "A2-177"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 541569,
+    "internal_id": 205248,
     "linked": false
   },
   {
@@ -4132,7 +4132,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-136"],
     "artist": "kirisAki",
-    "internal_id": 541697,
+    "internal_id": 205312,
     "linked": false
   },
   {
@@ -4162,7 +4162,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-137"],
     "artist": "Narumi Sato",
-    "internal_id": 541825,
+    "internal_id": 205376,
     "linked": false
   },
   {
@@ -4192,7 +4192,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-138"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 541953,
+    "internal_id": 205440,
     "linked": false
   },
   {
@@ -4222,7 +4222,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-139", "A2-178"],
     "artist": "sowsow",
-    "internal_id": 542081,
+    "internal_id": 205504,
     "linked": false
   },
   {
@@ -4252,7 +4252,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-140"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 542210,
+    "internal_id": 205569,
     "linked": false
   },
   {
@@ -4282,7 +4282,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-141"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 542337,
+    "internal_id": 205632,
     "linked": false
   },
   {
@@ -4312,7 +4312,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-142"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 542465,
+    "internal_id": 205696,
     "linked": false
   },
   {
@@ -4342,7 +4342,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-143", "A2-179", "P-A-115"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 542595,
+    "internal_id": 205762,
     "linked": false
   },
   {
@@ -4369,7 +4369,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-144"],
     "artist": "Toyste Beach",
-    "internal_id": 542721,
+    "internal_id": 205824,
     "linked": false
   },
   {
@@ -4396,7 +4396,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-145"],
     "artist": "Toyste Beach",
-    "internal_id": 542849,
+    "internal_id": 205888,
     "linked": false
   },
   {
@@ -4423,7 +4423,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-146", "A4b-316", "A4b-317"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 542978,
+    "internal_id": 205953,
     "linked": false
   },
   {
@@ -4450,7 +4450,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-147", "A4b-320", "A4b-321"],
     "artist": "Ryo Ueda",
-    "internal_id": 543106,
+    "internal_id": 206017,
     "linked": false
   },
   {
@@ -4477,7 +4477,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-148", "A4b-322", "A4b-323"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 543234,
+    "internal_id": 206081,
     "linked": false
   },
   {
@@ -4504,7 +4504,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-149"],
     "artist": "Yoshinobu Saito",
-    "internal_id": 543362,
+    "internal_id": 206145,
     "linked": false
   },
   {
@@ -4531,7 +4531,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-150", "A2-190", "A4b-326", "A4b-327"],
     "artist": "akagi",
-    "internal_id": 543490,
+    "internal_id": 206209,
     "linked": false
   },
   {
@@ -4558,7 +4558,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-151", "A2-191"],
     "artist": "GOSSAN",
-    "internal_id": 543618,
+    "internal_id": 206273,
     "linked": false
   },
   {
@@ -4585,7 +4585,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-152", "A2-192"],
     "artist": "Ryuta Fuse",
-    "internal_id": 543746,
+    "internal_id": 206337,
     "linked": false
   },
   {
@@ -4612,7 +4612,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-153", "A2-193"],
     "artist": "GIDORA",
-    "internal_id": 543874,
+    "internal_id": 206401,
     "linked": false
   },
   {
@@ -4639,7 +4639,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-154", "A2-194", "A4b-342", "A4b-343"],
     "artist": "saino misaki",
-    "internal_id": 544002,
+    "internal_id": 206465,
     "linked": false
   },
   {
@@ -4666,7 +4666,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-155", "A2-195", "A4b-344", "A4b-345"],
     "artist": "Yuu Nishida",
-    "internal_id": 544130,
+    "internal_id": 206529,
     "linked": false
   },
   {
@@ -4696,7 +4696,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-5", "A2-156"],
     "artist": "Saboteri",
-    "internal_id": 544261,
+    "internal_id": 206596,
     "linked": false
   },
   {
@@ -4726,7 +4726,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-17", "A2-157"],
     "artist": "Shibuzoh.",
-    "internal_id": 544389,
+    "internal_id": 206660,
     "linked": false
   },
   {
@@ -4756,7 +4756,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-19", "A2-158"],
     "artist": "Yoriyuki Ikegami",
-    "internal_id": 544517,
+    "internal_id": 206724,
     "linked": false
   },
   {
@@ -4790,7 +4790,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-22", "A2-159", "A4b-30", "A4b-31", "P-A-116"],
     "artist": "REND",
-    "internal_id": 544645,
+    "internal_id": 206788,
     "linked": false
   },
   {
@@ -4824,7 +4824,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-33", "A2-160"],
     "artist": "OKACHEKE",
-    "internal_id": 544773,
+    "internal_id": 206852,
     "linked": false
   },
   {
@@ -4854,7 +4854,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-41", "A2-161"],
     "artist": "takashi shiraishi",
-    "internal_id": 544901,
+    "internal_id": 206916,
     "linked": false
   },
   {
@@ -4884,7 +4884,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-50", "A2-162", "P-A-48", "A4b-108", "A4b-109"],
     "artist": "miki kudo",
-    "internal_id": 545029,
+    "internal_id": 206980,
     "linked": false
   },
   {
@@ -4914,7 +4914,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-58", "A2-163"],
     "artist": "Yuu Nishida",
-    "internal_id": 545157,
+    "internal_id": 207044,
     "linked": false
   },
   {
@@ -4944,7 +4944,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-62", "A2-164"],
     "artist": "Shimaris Yukichi",
-    "internal_id": 545285,
+    "internal_id": 207108,
     "linked": false
   },
   {
@@ -4974,7 +4974,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-73", "A2-165"],
     "artist": "Orca",
-    "internal_id": 545413,
+    "internal_id": 207172,
     "linked": false
   },
   {
@@ -5004,7 +5004,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-76", "A2-166"],
     "artist": "Orca",
-    "internal_id": 545541,
+    "internal_id": 207236,
     "linked": false
   },
   {
@@ -5038,7 +5038,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-78", "A2-167", "A4b-170", "A4b-171"],
     "artist": "Rond",
-    "internal_id": 545669,
+    "internal_id": 207300,
     "linked": false
   },
   {
@@ -5068,7 +5068,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-79", "A2-168"],
     "artist": "rika",
-    "internal_id": 545797,
+    "internal_id": 207364,
     "linked": false
   },
   {
@@ -5098,7 +5098,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-82", "A2-169"],
     "artist": "Taiga Kayama",
-    "internal_id": 545925,
+    "internal_id": 207428,
     "linked": false
   },
   {
@@ -5132,7 +5132,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-92", "A2-170", "A4b-212", "A4b-213"],
     "artist": "Akira Komayama",
-    "internal_id": 546053,
+    "internal_id": 207492,
     "linked": false
   },
   {
@@ -5162,7 +5162,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-93", "A2-171"],
     "artist": "Teeziro",
-    "internal_id": 546181,
+    "internal_id": 207556,
     "linked": false
   },
   {
@@ -5192,7 +5192,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-104", "A2-172"],
     "artist": "Shinji Kanda",
-    "internal_id": 546309,
+    "internal_id": 207620,
     "linked": false
   },
   {
@@ -5222,7 +5222,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-107", "A2-173"],
     "artist": "GOSSAN",
-    "internal_id": 546437,
+    "internal_id": 207684,
     "linked": false
   },
   {
@@ -5252,7 +5252,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-120", "A2-174"],
     "artist": "OKUBO",
-    "internal_id": 546565,
+    "internal_id": 207748,
     "linked": false
   },
   {
@@ -5286,7 +5286,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-123", "A2-175"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 546693,
+    "internal_id": 207812,
     "linked": false
   },
   {
@@ -5316,7 +5316,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-134", "A2-176"],
     "artist": "Ryota Murayama",
-    "internal_id": 546821,
+    "internal_id": 207876,
     "linked": false
   },
   {
@@ -5346,7 +5346,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-135", "A2-177"],
     "artist": "Shinya Komatsu",
-    "internal_id": 546949,
+    "internal_id": 207940,
     "linked": false
   },
   {
@@ -5376,7 +5376,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-139", "A2-178"],
     "artist": "matazo",
-    "internal_id": 547077,
+    "internal_id": 208004,
     "linked": false
   },
   {
@@ -5406,7 +5406,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-143", "A2-179", "P-A-115"],
     "artist": "Tetsu Kayama",
-    "internal_id": 547205,
+    "internal_id": 208068,
     "linked": false
   },
   {
@@ -5436,7 +5436,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-7", "A2-180", "A2-196", "A4-232", "A4b-22"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 547334,
+    "internal_id": 208133,
     "linked": false
   },
   {
@@ -5466,7 +5466,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-29", "A2-181", "A2-197", "A4a-101", "A4b-75"],
     "artist": "PLANETA CG Works",
-    "internal_id": 547462,
+    "internal_id": 208197,
     "linked": false
   },
   {
@@ -5502,7 +5502,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-49", "A2-182", "A2-204", "A2-206", "A4b-107", "A4b-363"],
     "artist": "PLANETA CG Works",
-    "internal_id": 547590,
+    "internal_id": 208261,
     "linked": false
   },
   {
@@ -5532,7 +5532,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-61", "A2-183", "A2-198", "A4-236", "A4b-145"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 547718,
+    "internal_id": 208325,
     "linked": false
   },
   {
@@ -5562,7 +5562,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-67", "A2-184", "A2-199", "A4-237", "A4b-163"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 547846,
+    "internal_id": 208389,
     "linked": false
   },
   {
@@ -5592,7 +5592,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-95", "A2-185", "A2-200", "A3b-106", "A4b-215"],
     "artist": "PLANETA CG Works",
-    "internal_id": 547974,
+    "internal_id": 208453,
     "linked": false
   },
   {
@@ -5622,7 +5622,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-99", "A2-186", "A2-201", "A4-238", "A4b-244"],
     "artist": "PLANETA CG Works",
-    "internal_id": 548102,
+    "internal_id": 208517,
     "linked": false
   },
   {
@@ -5656,7 +5656,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-110", "A2-187", "A2-202", "P-A-42", "A4b-245", "A4b-378"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 548230,
+    "internal_id": 208581,
     "linked": false
   },
   {
@@ -5692,7 +5692,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-119", "A2-188", "A2-205", "A2-207", "A4b-254", "A4b-368"],
     "artist": "PLANETA CG Works",
-    "internal_id": 548358,
+    "internal_id": 208645,
     "linked": false
   },
   {
@@ -5722,7 +5722,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-125", "A2-189", "A2-203", "A4-239", "A4b-284"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 548486,
+    "internal_id": 208709,
     "linked": false
   },
   {
@@ -5749,7 +5749,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-150", "A2-190", "A4b-326", "A4b-327"],
     "artist": "akagi",
-    "internal_id": 548614,
+    "internal_id": 208773,
     "linked": false
   },
   {
@@ -5776,7 +5776,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-151", "A2-191"],
     "artist": "GOSSAN",
-    "internal_id": 548742,
+    "internal_id": 208837,
     "linked": false
   },
   {
@@ -5803,7 +5803,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-152", "A2-192"],
     "artist": "Ryuta Fuse",
-    "internal_id": 548870,
+    "internal_id": 208901,
     "linked": false
   },
   {
@@ -5830,7 +5830,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-153", "A2-193"],
     "artist": "GIDORA",
-    "internal_id": 548998,
+    "internal_id": 208965,
     "linked": false
   },
   {
@@ -5857,7 +5857,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-154", "A2-194", "A4b-342", "A4b-343"],
     "artist": "saino misaki",
-    "internal_id": 549126,
+    "internal_id": 209029,
     "linked": false
   },
   {
@@ -5884,7 +5884,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-155", "A2-195", "A4b-344", "A4b-345"],
     "artist": "Yuu Nishida",
-    "internal_id": 549254,
+    "internal_id": 209093,
     "linked": false
   },
   {
@@ -5914,7 +5914,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-7", "A2-180", "A2-196", "A4-232", "A4b-22"],
     "artist": "Mina Nakai",
-    "internal_id": 549382,
+    "internal_id": 209157,
     "linked": false
   },
   {
@@ -5944,7 +5944,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-29", "A2-181", "A2-197", "A4a-101", "A4b-75"],
     "artist": "nagimiso",
-    "internal_id": 549510,
+    "internal_id": 209221,
     "linked": false
   },
   {
@@ -5974,7 +5974,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-61", "A2-183", "A2-198", "A4-236", "A4b-145"],
     "artist": "Nurikabe",
-    "internal_id": 549638,
+    "internal_id": 209285,
     "linked": false
   },
   {
@@ -6004,7 +6004,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-67", "A2-184", "A2-199", "A4-237", "A4b-163"],
     "artist": "Kuroimori",
-    "internal_id": 549766,
+    "internal_id": 209349,
     "linked": false
   },
   {
@@ -6034,7 +6034,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-95", "A2-185", "A2-200", "A3b-106", "A4b-215"],
     "artist": "Takumi Wada",
-    "internal_id": 549894,
+    "internal_id": 209413,
     "linked": false
   },
   {
@@ -6064,7 +6064,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-99", "A2-186", "A2-201", "A4-238", "A4b-244"],
     "artist": "hncl",
-    "internal_id": 550022,
+    "internal_id": 209477,
     "linked": false
   },
   {
@@ -6098,7 +6098,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-110", "A2-187", "A2-202", "P-A-42", "A4b-245", "A4b-378"],
     "artist": "Oswaldo KATO",
-    "internal_id": 550150,
+    "internal_id": 209541,
     "linked": false
   },
   {
@@ -6128,7 +6128,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-125", "A2-189", "A2-203", "A4-239", "A4b-284"],
     "artist": "Jerky",
-    "internal_id": 550278,
+    "internal_id": 209605,
     "linked": false
   },
   {
@@ -6164,7 +6164,7 @@
     "pack": "palkiapack",
     "alternate_versions": ["A2-49", "A2-182", "A2-204", "A2-206", "A4b-107", "A4b-363"],
     "artist": "N-DESIGN Inc.",
-    "internal_id": 550407,
+    "internal_id": 209670,
     "linked": false
   },
   {
@@ -6200,7 +6200,7 @@
     "pack": "dialgapack",
     "alternate_versions": ["A2-119", "A2-188", "A2-205", "A2-207", "A4b-254", "A4b-368"],
     "artist": "N-DESIGN Inc.",
-    "internal_id": 550535,
+    "internal_id": 209734,
     "linked": false
   },
   {
@@ -6236,7 +6236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-49", "A2-182", "A2-204", "A2-206", "A4b-107", "A4b-363"],
     "artist": "PLANETA CG Works",
-    "internal_id": 550666,
+    "internal_id": 209804,
     "linked": false
   },
   {
@@ -6272,7 +6272,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-119", "A2-188", "A2-205", "A2-207", "A4b-254", "A4b-368"],
     "artist": "PLANETA CG Works",
-    "internal_id": 550794,
+    "internal_id": 209868,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A2a.json
+++ b/frontend/assets/cards/A2a.json
@@ -26,7 +26,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-1"],
     "artist": "Satoshi Shirai",
-    "internal_id": 655490,
+    "internal_id": 262209,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-2"],
     "artist": "miki kudo",
-    "internal_id": 655617,
+    "internal_id": 262272,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-3"],
     "artist": "MAHOU",
-    "internal_id": 655746,
+    "internal_id": 262337,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-4"],
     "artist": "Akira Komayama",
-    "internal_id": 655873,
+    "internal_id": 262400,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-5"],
     "artist": "kawayoo",
-    "internal_id": 656002,
+    "internal_id": 262465,
     "linked": false
   },
   {
@@ -176,7 +176,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-6"],
     "artist": "Atsuko Nishida",
-    "internal_id": 656129,
+    "internal_id": 262528,
     "linked": false
   },
   {
@@ -206,7 +206,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-7"],
     "artist": "Midori Harada",
-    "internal_id": 656258,
+    "internal_id": 262593,
     "linked": false
   },
   {
@@ -236,7 +236,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-8", "P-A-43"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 656386,
+    "internal_id": 262657,
     "linked": false
   },
   {
@@ -270,7 +270,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-9"],
     "artist": "Shiburingaru",
-    "internal_id": 656515,
+    "internal_id": 262722,
     "linked": false
   },
   {
@@ -304,7 +304,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-10", "A2a-82", "A2a-91", "A4-233", "A4b-29"],
     "artist": "PLANETA CG Works",
-    "internal_id": 656644,
+    "internal_id": 262787,
     "linked": false
   },
   {
@@ -334,7 +334,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-11"],
     "artist": "Kouki Saitou",
-    "internal_id": 656769,
+    "internal_id": 262848,
     "linked": false
   },
   {
@@ -364,7 +364,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-12", "A2a-76"],
     "artist": "Hajime Kusajima",
-    "internal_id": 656898,
+    "internal_id": 262913,
     "linked": false
   },
   {
@@ -398,7 +398,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-13", "A4b-76", "A4b-77"],
     "artist": "Kazumasa Yasukuni",
-    "internal_id": 657027,
+    "internal_id": 262978,
     "linked": false
   },
   {
@@ -428,7 +428,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-14", "A2a-77"],
     "artist": "Tika Matsuno",
-    "internal_id": 657153,
+    "internal_id": 263040,
     "linked": false
   },
   {
@@ -458,7 +458,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-15"],
     "artist": "miki kudo",
-    "internal_id": 657281,
+    "internal_id": 263104,
     "linked": false
   },
   {
@@ -488,7 +488,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-16"],
     "artist": "sui",
-    "internal_id": 657409,
+    "internal_id": 263168,
     "linked": false
   },
   {
@@ -518,7 +518,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-17"],
     "artist": "Shinya Komatsu",
-    "internal_id": 657538,
+    "internal_id": 263233,
     "linked": false
   },
   {
@@ -548,7 +548,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-18"],
     "artist": "sowsow",
-    "internal_id": 657665,
+    "internal_id": 263296,
     "linked": false
   },
   {
@@ -578,7 +578,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-19"],
     "artist": "Mizue",
-    "internal_id": 657794,
+    "internal_id": 263361,
     "linked": false
   },
   {
@@ -608,7 +608,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-20"],
     "artist": "otumami",
-    "internal_id": 657921,
+    "internal_id": 263424,
     "linked": false
   },
   {
@@ -642,7 +642,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-21"],
     "artist": "nagimiso",
-    "internal_id": 658051,
+    "internal_id": 263490,
     "linked": false
   },
   {
@@ -676,7 +676,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-22", "A2a-83", "A2a-92", "A4-235", "A4b-106"],
     "artist": "PLANETA CG Works",
-    "internal_id": 658180,
+    "internal_id": 263555,
     "linked": false
   },
   {
@@ -706,7 +706,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-23"],
     "artist": "toriyufu",
-    "internal_id": 658307,
+    "internal_id": 263618,
     "linked": false
   },
   {
@@ -736,7 +736,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-24"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 658434,
+    "internal_id": 263681,
     "linked": false
   },
   {
@@ -766,7 +766,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-25"],
     "artist": "MAHOU",
-    "internal_id": 658561,
+    "internal_id": 263744,
     "linked": false
   },
   {
@@ -800,7 +800,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-26", "P-A-44"],
     "artist": "Nisota Niso",
-    "internal_id": 658691,
+    "internal_id": 263810,
     "linked": false
   },
   {
@@ -830,7 +830,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-27"],
     "artist": "Shin Nagasawa",
-    "internal_id": 658817,
+    "internal_id": 263872,
     "linked": false
   },
   {
@@ -860,7 +860,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-28"],
     "artist": "match",
-    "internal_id": 658946,
+    "internal_id": 263937,
     "linked": false
   },
   {
@@ -890,7 +890,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-29"],
     "artist": "rika",
-    "internal_id": 659073,
+    "internal_id": 264000,
     "linked": false
   },
   {
@@ -920,7 +920,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-30"],
     "artist": "sui",
-    "internal_id": 659202,
+    "internal_id": 264065,
     "linked": false
   },
   {
@@ -950,7 +950,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-31", "A3-220"],
     "artist": "Yuu Nishida",
-    "internal_id": 659329,
+    "internal_id": 264128,
     "linked": false
   },
   {
@@ -980,7 +980,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-32"],
     "artist": "Eri Yamaki",
-    "internal_id": 659457,
+    "internal_id": 264192,
     "linked": false
   },
   {
@@ -1010,7 +1010,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-33"],
     "artist": "Midori Harada",
-    "internal_id": 659586,
+    "internal_id": 264257,
     "linked": false
   },
   {
@@ -1044,7 +1044,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-34", "A2a-78"],
     "artist": "Tetsu Kayama",
-    "internal_id": 659714,
+    "internal_id": 264321,
     "linked": false
   },
   {
@@ -1078,7 +1078,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-35"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 659843,
+    "internal_id": 264386,
     "linked": false
   },
   {
@@ -1108,7 +1108,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-36", "A2a-79", "A4b-198", "A4b-199"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 659970,
+    "internal_id": 264449,
     "linked": false
   },
   {
@@ -1138,7 +1138,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-37"],
     "artist": "Asako Ito",
-    "internal_id": 660097,
+    "internal_id": 264512,
     "linked": false
   },
   {
@@ -1168,7 +1168,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-38"],
     "artist": "Shin Nagasawa",
-    "internal_id": 660226,
+    "internal_id": 264577,
     "linked": false
   },
   {
@@ -1198,7 +1198,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-39"],
     "artist": "Yukiko Baba",
-    "internal_id": 660353,
+    "internal_id": 264640,
     "linked": false
   },
   {
@@ -1228,7 +1228,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-40"],
     "artist": "match",
-    "internal_id": 660482,
+    "internal_id": 264705,
     "linked": false
   },
   {
@@ -1262,7 +1262,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-41"],
     "artist": "kawayoo",
-    "internal_id": 660611,
+    "internal_id": 264770,
     "linked": false
   },
   {
@@ -1292,7 +1292,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-42", "A4b-203", "A4b-204"],
     "artist": "Satoshi Shirai",
-    "internal_id": 660737,
+    "internal_id": 264832,
     "linked": false
   },
   {
@@ -1322,7 +1322,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-43"],
     "artist": "Mina Nakai",
-    "internal_id": 660865,
+    "internal_id": 264896,
     "linked": false
   },
   {
@@ -1352,7 +1352,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-44"],
     "artist": "Tetsu Kayama",
-    "internal_id": 660994,
+    "internal_id": 264961,
     "linked": false
   },
   {
@@ -1382,7 +1382,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-45", "P-A-46", "A4a-98", "A4b-205", "A4b-206"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 661121,
+    "internal_id": 265024,
     "linked": false
   },
   {
@@ -1412,7 +1412,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-46", "A4a-99", "A4b-207", "A4b-208"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 661249,
+    "internal_id": 265088,
     "linked": false
   },
   {
@@ -1448,7 +1448,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-47", "A2a-84", "A2a-93", "A4a-103", "A4b-209"],
     "artist": "PLANETA CG Works",
-    "internal_id": 661380,
+    "internal_id": 265155,
     "linked": false
   },
   {
@@ -1478,7 +1478,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-48", "A4b-226", "A4b-227"],
     "artist": "Sekio",
-    "internal_id": 661505,
+    "internal_id": 265216,
     "linked": false
   },
   {
@@ -1508,7 +1508,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-49", "A4b-228", "A4b-229"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 661633,
+    "internal_id": 265280,
     "linked": false
   },
   {
@@ -1542,7 +1542,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-50", "A4b-230", "A4b-231"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 661763,
+    "internal_id": 265346,
     "linked": false
   },
   {
@@ -1572,7 +1572,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-51"],
     "artist": "SATOSHI NAKAI",
-    "internal_id": 661889,
+    "internal_id": 265408,
     "linked": false
   },
   {
@@ -1602,7 +1602,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-52"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 662018,
+    "internal_id": 265473,
     "linked": false
   },
   {
@@ -1632,7 +1632,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-53", "A2a-80"],
     "artist": "OKACHEKE",
-    "internal_id": 662145,
+    "internal_id": 265536,
     "linked": false
   },
   {
@@ -1662,7 +1662,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-54"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 662273,
+    "internal_id": 265600,
     "linked": false
   },
   {
@@ -1696,7 +1696,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-55"],
     "artist": "toriyufu",
-    "internal_id": 662403,
+    "internal_id": 265666,
     "linked": false
   },
   {
@@ -1726,7 +1726,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-56"],
     "artist": "tetsuya koizumi",
-    "internal_id": 662529,
+    "internal_id": 265728,
     "linked": false
   },
   {
@@ -1756,7 +1756,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-57", "A2a-85", "A2a-94", "A4b-253"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 662660,
+    "internal_id": 265795,
     "linked": false
   },
   {
@@ -1786,7 +1786,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-58"],
     "artist": "Akira Komayama",
-    "internal_id": 662785,
+    "internal_id": 265856,
     "linked": false
   },
   {
@@ -1816,7 +1816,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-59"],
     "artist": "Naoki Saito",
-    "internal_id": 662914,
+    "internal_id": 265921,
     "linked": false
   },
   {
@@ -1846,7 +1846,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-60"],
     "artist": "akagi",
-    "internal_id": 663043,
+    "internal_id": 265986,
     "linked": false
   },
   {
@@ -1876,7 +1876,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-61"],
     "artist": "Shin Nagasawa",
-    "internal_id": 663171,
+    "internal_id": 266050,
     "linked": false
   },
   {
@@ -1906,7 +1906,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-62"],
     "artist": "Naoyo Kimura",
-    "internal_id": 663297,
+    "internal_id": 266112,
     "linked": false
   },
   {
@@ -1936,7 +1936,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-63", "P-A-49"],
     "artist": "burari",
-    "internal_id": 663426,
+    "internal_id": 266177,
     "linked": false
   },
   {
@@ -1966,7 +1966,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-64"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 663553,
+    "internal_id": 266240,
     "linked": false
   },
   {
@@ -1996,7 +1996,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-65"],
     "artist": "DOM",
-    "internal_id": 663682,
+    "internal_id": 266305,
     "linked": false
   },
   {
@@ -2026,7 +2026,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-66"],
     "artist": "Apios",
-    "internal_id": 663809,
+    "internal_id": 266368,
     "linked": false
   },
   {
@@ -2056,7 +2056,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-67"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 663937,
+    "internal_id": 266432,
     "linked": false
   },
   {
@@ -2086,7 +2086,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-68"],
     "artist": "Minahamu",
-    "internal_id": 664066,
+    "internal_id": 266497,
     "linked": false
   },
   {
@@ -2120,7 +2120,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-69", "A2a-81", "A4b-297", "A4b-298"],
     "artist": "Mizue",
-    "internal_id": 664195,
+    "internal_id": 266562,
     "linked": false
   },
   {
@@ -2150,7 +2150,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-70"],
     "artist": "Nurikabe",
-    "internal_id": 664323,
+    "internal_id": 266626,
     "linked": false
   },
   {
@@ -2184,7 +2184,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-71", "A2a-86", "A2a-95", "A2a-96", "A4b-299", "A4b-372"],
     "artist": "PLANETA CG Works",
-    "internal_id": 664452,
+    "internal_id": 266691,
     "linked": false
   },
   {
@@ -2211,7 +2211,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-72", "A2a-87", "A4b-330", "A4b-331"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 664578,
+    "internal_id": 266753,
     "linked": false
   },
   {
@@ -2238,7 +2238,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-73", "A2a-88"],
     "artist": "Yuu Nishida",
-    "internal_id": 664706,
+    "internal_id": 266817,
     "linked": false
   },
   {
@@ -2265,7 +2265,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-74", "A2a-89"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 664834,
+    "internal_id": 266881,
     "linked": false
   },
   {
@@ -2292,7 +2292,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-75", "A2a-90"],
     "artist": "akagi",
-    "internal_id": 664962,
+    "internal_id": 266945,
     "linked": false
   },
   {
@@ -2322,7 +2322,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-12", "A2a-76"],
     "artist": "matazo",
-    "internal_id": 665093,
+    "internal_id": 267012,
     "linked": false
   },
   {
@@ -2352,7 +2352,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-14", "A2a-77"],
     "artist": "Taiga Kayama",
-    "internal_id": 665221,
+    "internal_id": 267076,
     "linked": false
   },
   {
@@ -2386,7 +2386,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-34", "A2a-78"],
     "artist": "IKEDA Saki",
-    "internal_id": 665349,
+    "internal_id": 267140,
     "linked": false
   },
   {
@@ -2416,7 +2416,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-36", "A2a-79", "A4b-198", "A4b-199"],
     "artist": "Yuriko Akase",
-    "internal_id": 665477,
+    "internal_id": 267204,
     "linked": false
   },
   {
@@ -2446,7 +2446,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-53", "A2a-80"],
     "artist": "Yukihiro Tada",
-    "internal_id": 665605,
+    "internal_id": 267268,
     "linked": false
   },
   {
@@ -2480,7 +2480,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-69", "A2a-81", "A4b-297", "A4b-298"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 665733,
+    "internal_id": 267332,
     "linked": false
   },
   {
@@ -2514,7 +2514,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-10", "A2a-82", "A2a-91", "A4-233", "A4b-29"],
     "artist": "PLANETA CG Works",
-    "internal_id": 665862,
+    "internal_id": 267397,
     "linked": false
   },
   {
@@ -2548,7 +2548,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-22", "A2a-83", "A2a-92", "A4-235", "A4b-106"],
     "artist": "PLANETA CG Works",
-    "internal_id": 665990,
+    "internal_id": 267461,
     "linked": false
   },
   {
@@ -2584,7 +2584,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-47", "A2a-84", "A2a-93", "A4a-103", "A4b-209"],
     "artist": "PLANETA CG Works",
-    "internal_id": 666118,
+    "internal_id": 267525,
     "linked": false
   },
   {
@@ -2614,7 +2614,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-57", "A2a-85", "A2a-94", "A4b-253"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 666246,
+    "internal_id": 267589,
     "linked": false
   },
   {
@@ -2648,7 +2648,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-71", "A2a-86", "A2a-95", "A2a-96", "A4b-299", "A4b-372"],
     "artist": "PLANETA CG Works",
-    "internal_id": 666374,
+    "internal_id": 267653,
     "linked": false
   },
   {
@@ -2675,7 +2675,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-72", "A2a-87", "A4b-330", "A4b-331"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 666502,
+    "internal_id": 267717,
     "linked": false
   },
   {
@@ -2702,7 +2702,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-73", "A2a-88"],
     "artist": "Yuu Nishida",
-    "internal_id": 666630,
+    "internal_id": 267781,
     "linked": false
   },
   {
@@ -2729,7 +2729,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-74", "A2a-89"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 666758,
+    "internal_id": 267845,
     "linked": false
   },
   {
@@ -2756,7 +2756,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-75", "A2a-90"],
     "artist": "akagi",
-    "internal_id": 666886,
+    "internal_id": 267909,
     "linked": false
   },
   {
@@ -2790,7 +2790,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-10", "A2a-82", "A2a-91", "A4-233", "A4b-29"],
     "artist": "saino misaki",
-    "internal_id": 667014,
+    "internal_id": 267973,
     "linked": false
   },
   {
@@ -2824,7 +2824,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-22", "A2a-83", "A2a-92", "A4-235", "A4b-106"],
     "artist": "rika",
-    "internal_id": 667142,
+    "internal_id": 268037,
     "linked": false
   },
   {
@@ -2860,7 +2860,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-47", "A2a-84", "A2a-93", "A4a-103", "A4b-209"],
     "artist": "toriyufu",
-    "internal_id": 667270,
+    "internal_id": 268101,
     "linked": false
   },
   {
@@ -2890,7 +2890,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-57", "A2a-85", "A2a-94", "A4b-253"],
     "artist": "Masa",
-    "internal_id": 667398,
+    "internal_id": 268165,
     "linked": false
   },
   {
@@ -2924,7 +2924,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-71", "A2a-86", "A2a-95", "A2a-96", "A4b-299", "A4b-372"],
     "artist": "Takumi Wada",
-    "internal_id": 667527,
+    "internal_id": 268230,
     "linked": false
   },
   {
@@ -2958,7 +2958,7 @@
     "pack": "arceuspack",
     "alternate_versions": ["A2a-71", "A2a-86", "A2a-95", "A2a-96", "A4b-299", "A4b-372"],
     "artist": "PLANETA CG Works",
-    "internal_id": 667658,
+    "internal_id": 268300,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A2b.json
+++ b/frontend/assets/cards/A2b.json
@@ -26,7 +26,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-1", "A2b-97", "A4b-6", "A4b-7"],
     "artist": "Akira Komayama",
-    "internal_id": 786561,
+    "internal_id": 327744,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-2", "A2b-98", "A4b-8", "A4b-9"],
     "artist": "Yuka Morii",
-    "internal_id": 786690,
+    "internal_id": 327809,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-3", "A2b-79", "A2b-107", "A4b-10"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 786820,
+    "internal_id": 327875,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-4", "A3b-93"],
     "artist": "Satoshi Shirai",
-    "internal_id": 786945,
+    "internal_id": 327936,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-5", "P-A-52", "A4b-49", "A4b-50"],
     "artist": "mashu",
-    "internal_id": 787073,
+    "internal_id": 328000,
     "linked": false
   },
   {
@@ -176,7 +176,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-6", "A4b-51", "A4b-52", "A4b-354"],
     "artist": "mashu",
-    "internal_id": 787202,
+    "internal_id": 328065,
     "linked": false
   },
   {
@@ -206,7 +206,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-7", "A2b-73", "A4b-53", "A4b-54"],
     "artist": "mashu",
-    "internal_id": 787331,
+    "internal_id": 328130,
     "linked": false
   },
   {
@@ -236,7 +236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-8", "A2b-99"],
     "artist": "Megumi Mizutani",
-    "internal_id": 787457,
+    "internal_id": 328192,
     "linked": false
   },
   {
@@ -266,7 +266,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-9", "A2b-100"],
     "artist": "kodama",
-    "internal_id": 787586,
+    "internal_id": 328257,
     "linked": false
   },
   {
@@ -302,7 +302,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-10", "A2b-80", "A2b-108", "A4b-60"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 787716,
+    "internal_id": 328323,
     "linked": false
   },
   {
@@ -332,7 +332,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-11"],
     "artist": "Miki Tanaka",
-    "internal_id": 787841,
+    "internal_id": 328384,
     "linked": false
   },
   {
@@ -362,7 +362,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-12"],
     "artist": "Miki Tanaka",
-    "internal_id": 787971,
+    "internal_id": 328450,
     "linked": false
   },
   {
@@ -392,7 +392,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-13"],
     "artist": "Minahamu",
-    "internal_id": 788098,
+    "internal_id": 328513,
     "linked": false
   },
   {
@@ -422,7 +422,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-14"],
     "artist": "Shibuzoh.",
-    "internal_id": 788225,
+    "internal_id": 328576,
     "linked": false
   },
   {
@@ -452,7 +452,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-15"],
     "artist": "match",
-    "internal_id": 788354,
+    "internal_id": 328641,
     "linked": false
   },
   {
@@ -482,7 +482,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-16", "A2b-74"],
     "artist": "sui",
-    "internal_id": 788481,
+    "internal_id": 328704,
     "linked": false
   },
   {
@@ -512,7 +512,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-17"],
     "artist": "Kouki Saitou",
-    "internal_id": 788610,
+    "internal_id": 328769,
     "linked": false
   },
   {
@@ -542,7 +542,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-18", "A2b-101", "A4b-125", "A4b-126"],
     "artist": "miki kudo",
-    "internal_id": 788737,
+    "internal_id": 328832,
     "linked": false
   },
   {
@@ -572,7 +572,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-19", "A2b-81", "A2b-109", "A4b-127"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 788868,
+    "internal_id": 328899,
     "linked": false
   },
   {
@@ -602,7 +602,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-20", "A2b-102"],
     "artist": "Tomowaka",
-    "internal_id": 788995,
+    "internal_id": 328962,
     "linked": false
   },
   {
@@ -636,7 +636,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-21", "A2b-75"],
     "artist": "Tomowaka",
-    "internal_id": 789122,
+    "internal_id": 329025,
     "linked": false
   },
   {
@@ -666,7 +666,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-22", "A2b-82", "A2b-92", "A4b-132"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 789252,
+    "internal_id": 329091,
     "linked": false
   },
   {
@@ -696,7 +696,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-23"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 789377,
+    "internal_id": 329152,
     "linked": false
   },
   {
@@ -726,7 +726,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-24"],
     "artist": "Shigenori Negishi",
-    "internal_id": 789506,
+    "internal_id": 329217,
     "linked": false
   },
   {
@@ -756,7 +756,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-25", "A2b-103", "P-A-58", "A4b-143", "A4b-144"],
     "artist": "imoniii",
-    "internal_id": 789634,
+    "internal_id": 329281,
     "linked": false
   },
   {
@@ -786,7 +786,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-26"],
     "artist": "Saboteri",
-    "internal_id": 789761,
+    "internal_id": 329344,
     "linked": false
   },
   {
@@ -816,7 +816,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-27"],
     "artist": "Saboteri",
-    "internal_id": 789890,
+    "internal_id": 329409,
     "linked": false
   },
   {
@@ -850,7 +850,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-28", "P-A-54"],
     "artist": "Saboteri",
-    "internal_id": 790019,
+    "internal_id": 329474,
     "linked": false
   },
   {
@@ -880,7 +880,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-29"],
     "artist": "Mousho",
-    "internal_id": 790145,
+    "internal_id": 329536,
     "linked": false
   },
   {
@@ -910,7 +910,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-30"],
     "artist": "Mousho",
-    "internal_id": 790274,
+    "internal_id": 329601,
     "linked": false
   },
   {
@@ -940,7 +940,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-31"],
     "artist": "Mousho",
-    "internal_id": 790403,
+    "internal_id": 329666,
     "linked": false
   },
   {
@@ -970,7 +970,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-32"],
     "artist": "Atsuko Nishida",
-    "internal_id": 790529,
+    "internal_id": 329728,
     "linked": false
   },
   {
@@ -1000,7 +1000,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-33"],
     "artist": "kodama",
-    "internal_id": 790657,
+    "internal_id": 329792,
     "linked": false
   },
   {
@@ -1030,7 +1030,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-34"],
     "artist": "Hajime Kusajima",
-    "internal_id": 790786,
+    "internal_id": 329857,
     "linked": false
   },
   {
@@ -1064,7 +1064,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-35", "A2b-83", "A2b-96", "A4b-172", "A4b-377"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 790916,
+    "internal_id": 329923,
     "linked": false
   },
   {
@@ -1094,7 +1094,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-36"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 791041,
+    "internal_id": 329984,
     "linked": false
   },
   {
@@ -1124,7 +1124,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-37"],
     "artist": "Mina Nakai",
-    "internal_id": 791169,
+    "internal_id": 330048,
     "linked": false
   },
   {
@@ -1154,7 +1154,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-38"],
     "artist": "Kouki Saitou",
-    "internal_id": 791297,
+    "internal_id": 330112,
     "linked": false
   },
   {
@@ -1184,7 +1184,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-39", "P-A-55", "A3-225"],
     "artist": "Kouki Saitou",
-    "internal_id": 791427,
+    "internal_id": 330178,
     "linked": false
   },
   {
@@ -1214,7 +1214,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-40"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 791553,
+    "internal_id": 330240,
     "linked": false
   },
   {
@@ -1244,7 +1244,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-41"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 791681,
+    "internal_id": 330304,
     "linked": false
   },
   {
@@ -1274,7 +1274,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-42", "A2b-104", "P-A-59", "A4b-210", "A4b-211"],
     "artist": "You Iribi",
-    "internal_id": 791809,
+    "internal_id": 330368,
     "linked": false
   },
   {
@@ -1304,7 +1304,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-43", "A2b-84", "A2b-110", "A4b-214"],
     "artist": "PLANETA CG Works",
-    "internal_id": 791940,
+    "internal_id": 330435,
     "linked": false
   },
   {
@@ -1334,7 +1334,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-44"],
     "artist": "REND",
-    "internal_id": 792066,
+    "internal_id": 330497,
     "linked": false
   },
   {
@@ -1364,7 +1364,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-45"],
     "artist": "Midori Harada",
-    "internal_id": 792193,
+    "internal_id": 330560,
     "linked": false
   },
   {
@@ -1394,7 +1394,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-46"],
     "artist": "Midori Harada",
-    "internal_id": 792322,
+    "internal_id": 330625,
     "linked": false
   },
   {
@@ -1424,7 +1424,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-47", "A4a-100", "A4b-236", "A4b-237"],
     "artist": "Mori Yuu",
-    "internal_id": 792449,
+    "internal_id": 330688,
     "linked": false
   },
   {
@@ -1454,7 +1454,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-48", "A2b-85", "A2b-93", "A4a-104", "A4b-238"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 792580,
+    "internal_id": 330755,
     "linked": false
   },
   {
@@ -1484,7 +1484,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-49"],
     "artist": "Shin Nagasawa",
-    "internal_id": 792706,
+    "internal_id": 330817,
     "linked": false
   },
   {
@@ -1514,7 +1514,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-50"],
     "artist": "Krgc",
-    "internal_id": 792833,
+    "internal_id": 330880,
     "linked": false
   },
   {
@@ -1548,7 +1548,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-51", "A2b-76"],
     "artist": "Krgc",
-    "internal_id": 792963,
+    "internal_id": 330946,
     "linked": false
   },
   {
@@ -1578,7 +1578,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-52", "A4b-262", "A4b-263"],
     "artist": "miki kudo",
-    "internal_id": 793089,
+    "internal_id": 331008,
     "linked": false
   },
   {
@@ -1608,7 +1608,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-53", "A4b-264", "A4b-265"],
     "artist": "miki kudo",
-    "internal_id": 793218,
+    "internal_id": 331073,
     "linked": false
   },
   {
@@ -1638,7 +1638,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-54", "A2b-86", "A2b-94", "A4b-266"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 793348,
+    "internal_id": 331139,
     "linked": false
   },
   {
@@ -1668,7 +1668,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-55", "A2b-105"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 793473,
+    "internal_id": 331200,
     "linked": false
   },
   {
@@ -1698,7 +1698,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-56", "A2b-106"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 793602,
+    "internal_id": 331265,
     "linked": false
   },
   {
@@ -1728,7 +1728,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-57", "A2b-77"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 793731,
+    "internal_id": 331330,
     "linked": false
   },
   {
@@ -1758,7 +1758,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-58"],
     "artist": "Eri Yamaki",
-    "internal_id": 793857,
+    "internal_id": 331392,
     "linked": false
   },
   {
@@ -1788,7 +1788,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-59"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 793985,
+    "internal_id": 331456,
     "linked": false
   },
   {
@@ -1818,7 +1818,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-60", "A3-228"],
     "artist": "Kanako Eo",
-    "internal_id": 794113,
+    "internal_id": 331520,
     "linked": false
   },
   {
@@ -1852,7 +1852,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-61", "A2b-78", "A3-229"],
     "artist": "miki kudo",
-    "internal_id": 794243,
+    "internal_id": 331586,
     "linked": false
   },
   {
@@ -1882,7 +1882,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-62"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 794369,
+    "internal_id": 331648,
     "linked": false
   },
   {
@@ -1912,7 +1912,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-63"],
     "artist": "Suwama Chiaki",
-    "internal_id": 794497,
+    "internal_id": 331712,
     "linked": false
   },
   {
@@ -1942,7 +1942,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-64", "P-A-57", "A4b-294", "A4b-295"],
     "artist": "Sekio",
-    "internal_id": 794625,
+    "internal_id": 331776,
     "linked": false
   },
   {
@@ -1972,7 +1972,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-65", "A2b-87", "A2b-95", "A4b-296"],
     "artist": "PLANETA CG Works",
-    "internal_id": 794756,
+    "internal_id": 331843,
     "linked": false
   },
   {
@@ -2002,7 +2002,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-66"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 794881,
+    "internal_id": 331904,
     "linked": false
   },
   {
@@ -2032,7 +2032,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-67"],
     "artist": "Minahamu",
-    "internal_id": 795009,
+    "internal_id": 331968,
     "linked": false
   },
   {
@@ -2062,7 +2062,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-68", "P-A-51", "A4b-306", "A4b-307"],
     "artist": "HAGIYA Kaoru",
-    "internal_id": 795138,
+    "internal_id": 332033,
     "linked": false
   },
   {
@@ -2089,7 +2089,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-69", "A2b-88", "A4b-340", "A4b-341"],
     "artist": "saino misaki",
-    "internal_id": 795266,
+    "internal_id": 332097,
     "linked": false
   },
   {
@@ -2116,7 +2116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-70", "A2b-89"],
     "artist": "Susumu Maeya",
-    "internal_id": 795394,
+    "internal_id": 332161,
     "linked": false
   },
   {
@@ -2143,7 +2143,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-71", "A2b-90", "A4b-352", "A4b-353"],
     "artist": "Teeziro",
-    "internal_id": 795522,
+    "internal_id": 332225,
     "linked": false
   },
   {
@@ -2170,7 +2170,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-72", "A2b-91"],
     "artist": "kantaro",
-    "internal_id": 795650,
+    "internal_id": 332289,
     "linked": false
   },
   {
@@ -2200,7 +2200,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-7", "A2b-73", "A4b-53", "A4b-54"],
     "artist": "danciao",
-    "internal_id": 795781,
+    "internal_id": 332356,
     "linked": false
   },
   {
@@ -2230,7 +2230,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-16", "A2b-74"],
     "artist": "Shimaris Yukichi",
-    "internal_id": 795909,
+    "internal_id": 332420,
     "linked": false
   },
   {
@@ -2264,7 +2264,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-21", "A2b-75"],
     "artist": "cochi8i",
-    "internal_id": 796037,
+    "internal_id": 332484,
     "linked": false
   },
   {
@@ -2298,7 +2298,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-51", "A2b-76"],
     "artist": "Teeziro",
-    "internal_id": 796165,
+    "internal_id": 332548,
     "linked": false
   },
   {
@@ -2328,7 +2328,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-57", "A2b-77"],
     "artist": "Jerky",
-    "internal_id": 796293,
+    "internal_id": 332612,
     "linked": false
   },
   {
@@ -2362,7 +2362,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-61", "A2b-78", "A3-229"],
     "artist": "5ban Graphics",
-    "internal_id": 796421,
+    "internal_id": 332676,
     "linked": false
   },
   {
@@ -2392,7 +2392,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-3", "A2b-79", "A2b-107", "A4b-10"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 796550,
+    "internal_id": 332741,
     "linked": false
   },
   {
@@ -2428,7 +2428,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-10", "A2b-80", "A2b-108", "A4b-60"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 796678,
+    "internal_id": 332805,
     "linked": false
   },
   {
@@ -2458,7 +2458,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-19", "A2b-81", "A2b-109", "A4b-127"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 796806,
+    "internal_id": 332869,
     "linked": false
   },
   {
@@ -2488,7 +2488,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-22", "A2b-82", "A2b-92", "A4b-132"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 796934,
+    "internal_id": 332933,
     "linked": false
   },
   {
@@ -2522,7 +2522,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-35", "A2b-83", "A2b-96", "A4b-172", "A4b-377"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 797062,
+    "internal_id": 332997,
     "linked": false
   },
   {
@@ -2552,7 +2552,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-43", "A2b-84", "A2b-110", "A4b-214"],
     "artist": "PLANETA CG Works",
-    "internal_id": 797190,
+    "internal_id": 333061,
     "linked": false
   },
   {
@@ -2582,7 +2582,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-48", "A2b-85", "A2b-93", "A4a-104", "A4b-238"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 797318,
+    "internal_id": 333125,
     "linked": false
   },
   {
@@ -2612,7 +2612,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-54", "A2b-86", "A2b-94", "A4b-266"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 797446,
+    "internal_id": 333189,
     "linked": false
   },
   {
@@ -2642,7 +2642,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-65", "A2b-87", "A2b-95", "A4b-296"],
     "artist": "PLANETA CG Works",
-    "internal_id": 797574,
+    "internal_id": 333253,
     "linked": false
   },
   {
@@ -2669,7 +2669,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-69", "A2b-88", "A4b-340", "A4b-341"],
     "artist": "saino misaki",
-    "internal_id": 797702,
+    "internal_id": 333317,
     "linked": false
   },
   {
@@ -2696,7 +2696,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-70", "A2b-89"],
     "artist": "Susumu Maeya",
-    "internal_id": 797830,
+    "internal_id": 333381,
     "linked": false
   },
   {
@@ -2723,7 +2723,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-71", "A2b-90", "A4b-352", "A4b-353"],
     "artist": "Teeziro",
-    "internal_id": 797958,
+    "internal_id": 333445,
     "linked": false
   },
   {
@@ -2750,7 +2750,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-72", "A2b-91"],
     "artist": "kantaro",
-    "internal_id": 798086,
+    "internal_id": 333509,
     "linked": false
   },
   {
@@ -2780,7 +2780,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-22", "A2b-82", "A2b-92", "A4b-132"],
     "artist": "You Iribi",
-    "internal_id": 798214,
+    "internal_id": 333573,
     "linked": false
   },
   {
@@ -2810,7 +2810,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-48", "A2b-85", "A2b-93", "A4a-104", "A4b-238"],
     "artist": "REND",
-    "internal_id": 798342,
+    "internal_id": 333637,
     "linked": false
   },
   {
@@ -2840,7 +2840,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-54", "A2b-86", "A2b-94", "A4b-266"],
     "artist": "kurumitsu",
-    "internal_id": 798470,
+    "internal_id": 333701,
     "linked": false
   },
   {
@@ -2870,7 +2870,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-65", "A2b-87", "A2b-95", "A4b-296"],
     "artist": "USGMEN",
-    "internal_id": 798598,
+    "internal_id": 333765,
     "linked": false
   },
   {
@@ -2904,7 +2904,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-35", "A2b-83", "A2b-96", "A4b-172", "A4b-377"],
     "artist": "Shinji Kanda",
-    "internal_id": 798727,
+    "internal_id": 333830,
     "linked": false
   },
   {
@@ -2934,7 +2934,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-1", "A2b-97", "A4b-6", "A4b-7"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 798856,
+    "internal_id": 333896,
     "linked": false
   },
   {
@@ -2964,7 +2964,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-2", "A2b-98", "A4b-8", "A4b-9"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 798984,
+    "internal_id": 333960,
     "linked": false
   },
   {
@@ -2994,7 +2994,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-8", "A2b-99"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 799112,
+    "internal_id": 334024,
     "linked": false
   },
   {
@@ -3024,7 +3024,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-9", "A2b-100"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 799240,
+    "internal_id": 334088,
     "linked": false
   },
   {
@@ -3054,7 +3054,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-18", "A2b-101", "A4b-125", "A4b-126"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 799368,
+    "internal_id": 334152,
     "linked": false
   },
   {
@@ -3084,7 +3084,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-20", "A2b-102"],
     "artist": "GOSSAN",
-    "internal_id": 799496,
+    "internal_id": 334216,
     "linked": false
   },
   {
@@ -3114,7 +3114,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-25", "A2b-103", "P-A-58", "A4b-143", "A4b-144"],
     "artist": "Tomowaka",
-    "internal_id": 799624,
+    "internal_id": 334280,
     "linked": false
   },
   {
@@ -3144,7 +3144,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-42", "A2b-104", "P-A-59", "A4b-210", "A4b-211"],
     "artist": "GOSSAN",
-    "internal_id": 799752,
+    "internal_id": 334344,
     "linked": false
   },
   {
@@ -3174,7 +3174,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-55", "A2b-105"],
     "artist": "nagimiso",
-    "internal_id": 799880,
+    "internal_id": 334408,
     "linked": false
   },
   {
@@ -3204,7 +3204,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-56", "A2b-106"],
     "artist": "nagimiso",
-    "internal_id": 800008,
+    "internal_id": 334472,
     "linked": false
   },
   {
@@ -3234,7 +3234,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-3", "A2b-79", "A2b-107", "A4b-10"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 800137,
+    "internal_id": 334537,
     "linked": false
   },
   {
@@ -3270,7 +3270,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-10", "A2b-80", "A2b-108", "A4b-60"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 800265,
+    "internal_id": 334601,
     "linked": false
   },
   {
@@ -3300,7 +3300,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-19", "A2b-81", "A2b-109", "A4b-127"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 800393,
+    "internal_id": 334665,
     "linked": false
   },
   {
@@ -3330,7 +3330,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-43", "A2b-84", "A2b-110", "A4b-214"],
     "artist": "PLANETA CG Works",
-    "internal_id": 800521,
+    "internal_id": 334729,
     "linked": false
   },
   {
@@ -3357,7 +3357,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-5", "A2b-111"],
     "artist": "Toyste Beach",
-    "internal_id": 800650,
+    "internal_id": 334796,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A3.json
+++ b/frontend/assets/cards/A3.json
@@ -26,7 +26,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-1", "A3-213"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 917633,
+    "internal_id": 393280,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-2", "A3-156", "P-A-69"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 917763,
+    "internal_id": 393346,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-3"],
     "artist": "Miki Tanaka",
-    "internal_id": 917889,
+    "internal_id": 393408,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-4"],
     "artist": "Kanako Eo",
-    "internal_id": 918018,
+    "internal_id": 393473,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-5"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 918145,
+    "internal_id": 393536,
     "linked": false
   },
   {
@@ -176,7 +176,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-6"],
     "artist": "OOYAMA",
-    "internal_id": 918273,
+    "internal_id": 393600,
     "linked": false
   },
   {
@@ -206,7 +206,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-7"],
     "artist": "miki kudo",
-    "internal_id": 918401,
+    "internal_id": 393664,
     "linked": false
   },
   {
@@ -236,7 +236,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-8"],
     "artist": "Shin Nagasawa",
-    "internal_id": 918530,
+    "internal_id": 393729,
     "linked": false
   },
   {
@@ -266,7 +266,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-9"],
     "artist": "Megumi Mizutani",
-    "internal_id": 918657,
+    "internal_id": 393792,
     "linked": false
   },
   {
@@ -296,7 +296,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-10", "A4b-38", "A4b-39"],
     "artist": "Saya Tsuruta",
-    "internal_id": 918785,
+    "internal_id": 393856,
     "linked": false
   },
   {
@@ -326,7 +326,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-11", "A4b-40", "A4b-41"],
     "artist": "Mizue",
-    "internal_id": 918914,
+    "internal_id": 393921,
     "linked": false
   },
   {
@@ -362,7 +362,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-12", "A3-180", "A3-198", "A4b-42"],
     "artist": "PLANETA CG Works",
-    "internal_id": 919044,
+    "internal_id": 393987,
     "linked": false
   },
   {
@@ -392,7 +392,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-13"],
     "artist": "Yuka Morii",
-    "internal_id": 919169,
+    "internal_id": 394048,
     "linked": false
   },
   {
@@ -422,7 +422,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-14"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 919297,
+    "internal_id": 394112,
     "linked": false
   },
   {
@@ -452,7 +452,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-15"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 919426,
+    "internal_id": 394177,
     "linked": false
   },
   {
@@ -482,7 +482,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-16", "A3-157"],
     "artist": "You Iribi",
-    "internal_id": 919553,
+    "internal_id": 394240,
     "linked": false
   },
   {
@@ -512,7 +512,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-17"],
     "artist": "Suwama Chiaki",
-    "internal_id": 919682,
+    "internal_id": 394305,
     "linked": false
   },
   {
@@ -542,7 +542,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-18"],
     "artist": "Akira Komayama",
-    "internal_id": 919809,
+    "internal_id": 394368,
     "linked": false
   },
   {
@@ -572,7 +572,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-19"],
     "artist": "Mizue",
-    "internal_id": 919938,
+    "internal_id": 394433,
     "linked": false
   },
   {
@@ -602,7 +602,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-20", "A3-158"],
     "artist": "Hasuno",
-    "internal_id": 920067,
+    "internal_id": 394498,
     "linked": false
   },
   {
@@ -636,7 +636,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-21"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 920193,
+    "internal_id": 394560,
     "linked": false
   },
   {
@@ -666,7 +666,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-22"],
     "artist": "Kouki Saitou",
-    "internal_id": 920323,
+    "internal_id": 394626,
     "linked": false
   },
   {
@@ -696,7 +696,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-23", "A3-181", "A3-199", "A4b-43"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 920452,
+    "internal_id": 394691,
     "linked": false
   },
   {
@@ -726,7 +726,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-24", "A3-159"],
     "artist": "Satoshi Shirai",
-    "internal_id": 920579,
+    "internal_id": 394754,
     "linked": false
   },
   {
@@ -756,7 +756,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-25"],
     "artist": "Naoyo Kimura",
-    "internal_id": 920705,
+    "internal_id": 394816,
     "linked": false
   },
   {
@@ -786,7 +786,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-26"],
     "artist": "match",
-    "internal_id": 920834,
+    "internal_id": 394881,
     "linked": false
   },
   {
@@ -816,7 +816,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-27", "A3-160"],
     "artist": "miki kudo",
-    "internal_id": 920962,
+    "internal_id": 394945,
     "linked": false
   },
   {
@@ -846,7 +846,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-28"],
     "artist": "Mina Nakai",
-    "internal_id": 921089,
+    "internal_id": 395008,
     "linked": false
   },
   {
@@ -876,7 +876,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-29"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 921219,
+    "internal_id": 395074,
     "linked": false
   },
   {
@@ -906,7 +906,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-30", "A4b-78", "A4b-79"],
     "artist": "Akira Komayama",
-    "internal_id": 921345,
+    "internal_id": 395136,
     "linked": false
   },
   {
@@ -936,7 +936,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-31"],
     "artist": "sui",
-    "internal_id": 921473,
+    "internal_id": 395200,
     "linked": false
   },
   {
@@ -966,7 +966,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-32", "A4b-80", "A4b-81"],
     "artist": "tetsuya koizumi",
-    "internal_id": 921602,
+    "internal_id": 395265,
     "linked": false
   },
   {
@@ -1002,7 +1002,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-33", "A3-182", "A3-200", "A4b-82"],
     "artist": "PLANETA CG Works",
-    "internal_id": 921732,
+    "internal_id": 395331,
     "linked": false
   },
   {
@@ -1032,7 +1032,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-34"],
     "artist": "Jerky",
-    "internal_id": 921858,
+    "internal_id": 395393,
     "linked": false
   },
   {
@@ -1062,7 +1062,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-35"],
     "artist": "Yukiko Baba",
-    "internal_id": 921985,
+    "internal_id": 395456,
     "linked": false
   },
   {
@@ -1092,7 +1092,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-36"],
     "artist": "Naoki Saito",
-    "internal_id": 922113,
+    "internal_id": 395520,
     "linked": false
   },
   {
@@ -1122,7 +1122,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-37", "A3-161"],
     "artist": "Shin Nagasawa",
-    "internal_id": 922243,
+    "internal_id": 395586,
     "linked": false
   },
   {
@@ -1152,7 +1152,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-38"],
     "artist": "ryoma uratsuka",
-    "internal_id": 922369,
+    "internal_id": 395648,
     "linked": false
   },
   {
@@ -1182,7 +1182,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-39"],
     "artist": "Hasuno",
-    "internal_id": 922498,
+    "internal_id": 395713,
     "linked": false
   },
   {
@@ -1212,7 +1212,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-40", "A3-162"],
     "artist": "You Iribi",
-    "internal_id": 922625,
+    "internal_id": 395776,
     "linked": false
   },
   {
@@ -1242,7 +1242,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-41", "P-A-70"],
     "artist": "Eri Yamaki",
-    "internal_id": 922755,
+    "internal_id": 395842,
     "linked": false
   },
   {
@@ -1272,7 +1272,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-42"],
     "artist": "Midori Harada",
-    "internal_id": 922881,
+    "internal_id": 395904,
     "linked": false
   },
   {
@@ -1302,7 +1302,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-43"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 923010,
+    "internal_id": 395969,
     "linked": false
   },
   {
@@ -1332,7 +1332,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-44"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 923138,
+    "internal_id": 396033,
     "linked": false
   },
   {
@@ -1362,7 +1362,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-45"],
     "artist": "Kanami Ogata",
-    "internal_id": 923265,
+    "internal_id": 396096,
     "linked": false
   },
   {
@@ -1392,7 +1392,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-46"],
     "artist": "Kouki Saitou",
-    "internal_id": 923393,
+    "internal_id": 396160,
     "linked": false
   },
   {
@@ -1422,7 +1422,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-47"],
     "artist": "Saya Tsuruta",
-    "internal_id": 923522,
+    "internal_id": 396225,
     "linked": false
   },
   {
@@ -1456,7 +1456,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-48"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 923651,
+    "internal_id": 396290,
     "linked": false
   },
   {
@@ -1486,7 +1486,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-49", "A3-183", "A3-201", "A4b-121"],
     "artist": "PLANETA CG Works",
-    "internal_id": 923780,
+    "internal_id": 396355,
     "linked": false
   },
   {
@@ -1516,7 +1516,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-50", "A4b-122", "A4b-123"],
     "artist": "Kouki Saitou",
-    "internal_id": 923905,
+    "internal_id": 396416,
     "linked": false
   },
   {
@@ -1546,7 +1546,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-51", "A3-184", "A3-202", "A4b-124"],
     "artist": "PLANETA CG Works",
-    "internal_id": 924036,
+    "internal_id": 396483,
     "linked": false
   },
   {
@@ -1576,7 +1576,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-52"],
     "artist": "Atsuko Nishida",
-    "internal_id": 924161,
+    "internal_id": 396544,
     "linked": false
   },
   {
@@ -1606,7 +1606,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-53"],
     "artist": "kodama",
-    "internal_id": 924290,
+    "internal_id": 396609,
     "linked": false
   },
   {
@@ -1640,7 +1640,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-54", "A3-163", "A4a-97"],
     "artist": "You Iribi",
-    "internal_id": 924417,
+    "internal_id": 396672,
     "linked": false
   },
   {
@@ -1670,7 +1670,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-55"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 924545,
+    "internal_id": 396736,
     "linked": false
   },
   {
@@ -1700,7 +1700,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-56", "A3-164"],
     "artist": "chibi",
-    "internal_id": 924675,
+    "internal_id": 396802,
     "linked": false
   },
   {
@@ -1730,7 +1730,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-57"],
     "artist": "Naoyo Kimura",
-    "internal_id": 924801,
+    "internal_id": 396864,
     "linked": false
   },
   {
@@ -1760,7 +1760,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-58", "A3-185", "A3-203", "A4b-130"],
     "artist": "PLANETA CG Works",
-    "internal_id": 924932,
+    "internal_id": 396931,
     "linked": false
   },
   {
@@ -1790,7 +1790,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-59"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 925057,
+    "internal_id": 396992,
     "linked": false
   },
   {
@@ -1820,7 +1820,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-60"],
     "artist": "match",
-    "internal_id": 925186,
+    "internal_id": 397057,
     "linked": false
   },
   {
@@ -1850,7 +1850,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-61"],
     "artist": "kawayoo",
-    "internal_id": 925315,
+    "internal_id": 397122,
     "linked": false
   },
   {
@@ -1880,7 +1880,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-62"],
     "artist": "0313",
-    "internal_id": 925441,
+    "internal_id": 397184,
     "linked": false
   },
   {
@@ -1910,7 +1910,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-63"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 925569,
+    "internal_id": 397248,
     "linked": false
   },
   {
@@ -1940,7 +1940,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-64"],
     "artist": "Naoki Saito",
-    "internal_id": 925698,
+    "internal_id": 397313,
     "linked": false
   },
   {
@@ -1970,7 +1970,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-65"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 925827,
+    "internal_id": 397378,
     "linked": false
   },
   {
@@ -2004,7 +2004,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-66", "A3-165", "A4b-146", "A4b-147"],
     "artist": "Jerky",
-    "internal_id": 925955,
+    "internal_id": 397442,
     "linked": false
   },
   {
@@ -2034,7 +2034,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-67"],
     "artist": "Misa Tsutsui",
-    "internal_id": 926081,
+    "internal_id": 397504,
     "linked": false
   },
   {
@@ -2064,7 +2064,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-68", "A3-166"],
     "artist": "kirisAki",
-    "internal_id": 926211,
+    "internal_id": 397570,
     "linked": false
   },
   {
@@ -2094,7 +2094,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-69"],
     "artist": "Yukihiro Tada",
-    "internal_id": 926338,
+    "internal_id": 397633,
     "linked": false
   },
   {
@@ -2124,7 +2124,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-70"],
     "artist": "Aya Kusube",
-    "internal_id": 926466,
+    "internal_id": 397697,
     "linked": false
   },
   {
@@ -2154,7 +2154,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-71"],
     "artist": "Sekio",
-    "internal_id": 926593,
+    "internal_id": 397760,
     "linked": false
   },
   {
@@ -2184,7 +2184,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-72"],
     "artist": "Yukiko Baba",
-    "internal_id": 926722,
+    "internal_id": 397825,
     "linked": false
   },
   {
@@ -2214,7 +2214,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-73"],
     "artist": "Hisao Nakamura",
-    "internal_id": 926849,
+    "internal_id": 397888,
     "linked": false
   },
   {
@@ -2244,7 +2244,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-74"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 926977,
+    "internal_id": 397952,
     "linked": false
   },
   {
@@ -2274,7 +2274,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-75"],
     "artist": "Aya Kusube",
-    "internal_id": 927105,
+    "internal_id": 398016,
     "linked": false
   },
   {
@@ -2304,7 +2304,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-76"],
     "artist": "Jerky",
-    "internal_id": 927234,
+    "internal_id": 398081,
     "linked": false
   },
   {
@@ -2334,7 +2334,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-77", "A4b-178", "A4b-179"],
     "artist": "Jerky",
-    "internal_id": 927362,
+    "internal_id": 398145,
     "linked": false
   },
   {
@@ -2364,7 +2364,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-78", "A3-167"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 927489,
+    "internal_id": 398208,
     "linked": false
   },
   {
@@ -2394,7 +2394,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-79"],
     "artist": "Megumi Mizutani",
-    "internal_id": 927617,
+    "internal_id": 398272,
     "linked": false
   },
   {
@@ -2428,7 +2428,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-80", "A3-168"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 927747,
+    "internal_id": 398338,
     "linked": false
   },
   {
@@ -2458,7 +2458,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-81", "A3-169"],
     "artist": "Akira Komayama",
-    "internal_id": 927873,
+    "internal_id": 398400,
     "linked": false
   },
   {
@@ -2488,7 +2488,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-82"],
     "artist": "OOYAMA",
-    "internal_id": 928003,
+    "internal_id": 398466,
     "linked": false
   },
   {
@@ -2518,7 +2518,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-83", "P-A-66"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 928129,
+    "internal_id": 398528,
     "linked": false
   },
   {
@@ -2548,7 +2548,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-84", "A3-170"],
     "artist": "Misa Tsutsui",
-    "internal_id": 928259,
+    "internal_id": 398594,
     "linked": false
   },
   {
@@ -2578,7 +2578,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-85", "A3-171", "P-A-67", "A4b-180", "A4b-181"],
     "artist": "sui",
-    "internal_id": 928385,
+    "internal_id": 398656,
     "linked": false
   },
   {
@@ -2608,7 +2608,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-86", "A4b-182", "A4b-183"],
     "artist": "Aya Kusube",
-    "internal_id": 928514,
+    "internal_id": 398721,
     "linked": false
   },
   {
@@ -2642,7 +2642,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-87", "A3-186", "A3-204", "A3-238", "A4b-184", "A4b-367"],
     "artist": "PLANETA CG Works",
-    "internal_id": 928644,
+    "internal_id": 398787,
     "linked": false
   },
   {
@@ -2672,7 +2672,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-88"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 928771,
+    "internal_id": 398850,
     "linked": false
   },
   {
@@ -2702,7 +2702,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-89"],
     "artist": "kawayoo",
-    "internal_id": 928897,
+    "internal_id": 398912,
     "linked": false
   },
   {
@@ -2732,7 +2732,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-90"],
     "artist": "Mina Nakai",
-    "internal_id": 929025,
+    "internal_id": 398976,
     "linked": false
   },
   {
@@ -2762,7 +2762,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-91"],
     "artist": "Miki Tanaka",
-    "internal_id": 929154,
+    "internal_id": 399041,
     "linked": false
   },
   {
@@ -2792,7 +2792,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-92"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 929281,
+    "internal_id": 399104,
     "linked": false
   },
   {
@@ -2822,7 +2822,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-93", "A4b-216", "A4b-217"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 929409,
+    "internal_id": 399168,
     "linked": false
   },
   {
@@ -2852,7 +2852,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-94"],
     "artist": "Mizue",
-    "internal_id": 929537,
+    "internal_id": 399232,
     "linked": false
   },
   {
@@ -2882,7 +2882,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-95"],
     "artist": "Naoki Saito",
-    "internal_id": 929666,
+    "internal_id": 399297,
     "linked": false
   },
   {
@@ -2916,7 +2916,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-96"],
     "artist": "kawayoo",
-    "internal_id": 929795,
+    "internal_id": 399362,
     "linked": false
   },
   {
@@ -2946,7 +2946,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-97", "P-A-71", "A4b-218", "A4b-219"],
     "artist": "kirisAki",
-    "internal_id": 929921,
+    "internal_id": 399424,
     "linked": false
   },
   {
@@ -2976,7 +2976,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-98", "A3-172"],
     "artist": "Oswaldo KATO",
-    "internal_id": 930049,
+    "internal_id": 399488,
     "linked": false
   },
   {
@@ -3006,7 +3006,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-99"],
     "artist": "Oswaldo KATO",
-    "internal_id": 930177,
+    "internal_id": 399552,
     "linked": false
   },
   {
@@ -3036,7 +3036,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-100", "P-A-68"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 930307,
+    "internal_id": 399618,
     "linked": false
   },
   {
@@ -3066,7 +3066,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-101"],
     "artist": "5ban Graphics",
-    "internal_id": 930435,
+    "internal_id": 399682,
     "linked": false
   },
   {
@@ -3096,7 +3096,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-102"],
     "artist": "Saya Tsuruta",
-    "internal_id": 930561,
+    "internal_id": 399744,
     "linked": false
   },
   {
@@ -3126,7 +3126,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-103", "A3-173"],
     "artist": "Takeshi Nakamura",
-    "internal_id": 930690,
+    "internal_id": 399809,
     "linked": false
   },
   {
@@ -3160,7 +3160,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-104", "A3-187", "A3-205", "A4b-223"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 930820,
+    "internal_id": 399875,
     "linked": false
   },
   {
@@ -3190,7 +3190,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-105", "A3-174"],
     "artist": "Amelicart",
-    "internal_id": 930946,
+    "internal_id": 399937,
     "linked": false
   },
   {
@@ -3220,7 +3220,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-106"],
     "artist": "nagimiso",
-    "internal_id": 931073,
+    "internal_id": 400000,
     "linked": false
   },
   {
@@ -3250,7 +3250,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-107"],
     "artist": "nagimiso",
-    "internal_id": 931202,
+    "internal_id": 400065,
     "linked": false
   },
   {
@@ -3280,7 +3280,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-108"],
     "artist": "sui",
-    "internal_id": 931329,
+    "internal_id": 400128,
     "linked": false
   },
   {
@@ -3314,7 +3314,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-109"],
     "artist": "kirisAki",
-    "internal_id": 931459,
+    "internal_id": 400194,
     "linked": false
   },
   {
@@ -3344,7 +3344,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-110", "A4b-233", "A4b-234"],
     "artist": "Akira Komayama",
-    "internal_id": 931585,
+    "internal_id": 400256,
     "linked": false
   },
   {
@@ -3374,7 +3374,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-111", "A3-188", "A3-206", "A4b-235"],
     "artist": "PLANETA CG Works",
-    "internal_id": 931716,
+    "internal_id": 400323,
     "linked": false
   },
   {
@@ -3404,7 +3404,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-112"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 931843,
+    "internal_id": 400386,
     "linked": false
   },
   {
@@ -3434,7 +3434,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-113"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 931969,
+    "internal_id": 400448,
     "linked": false
   },
   {
@@ -3464,7 +3464,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-114"],
     "artist": "match",
-    "internal_id": 932098,
+    "internal_id": 400513,
     "linked": false
   },
   {
@@ -3494,7 +3494,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-115"],
     "artist": "Saya Tsuruta",
-    "internal_id": 932225,
+    "internal_id": 400576,
     "linked": false
   },
   {
@@ -3524,7 +3524,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-116"],
     "artist": "chibi",
-    "internal_id": 932353,
+    "internal_id": 400640,
     "linked": false
   },
   {
@@ -3554,7 +3554,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-117"],
     "artist": "Naoyo Kimura",
-    "internal_id": 932481,
+    "internal_id": 400704,
     "linked": false
   },
   {
@@ -3584,7 +3584,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-118"],
     "artist": "Yuka Morii",
-    "internal_id": 932609,
+    "internal_id": 400768,
     "linked": false
   },
   {
@@ -3614,7 +3614,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-119", "A4b-255", "A4b-256"],
     "artist": "SATOSHI NAKAI",
-    "internal_id": 932738,
+    "internal_id": 400833,
     "linked": false
   },
   {
@@ -3644,7 +3644,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-120"],
     "artist": "Satoshi Shirai",
-    "internal_id": 932866,
+    "internal_id": 400897,
     "linked": false
   },
   {
@@ -3674,7 +3674,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-121", "A4b-257", "A4b-258"],
     "artist": "Shin Nagasawa",
-    "internal_id": 932995,
+    "internal_id": 400962,
     "linked": false
   },
   {
@@ -3708,7 +3708,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-122", "A3-189", "A3-207", "A3-239", "A4b-259", "A4b-369"],
     "artist": "PLANETA CG Works",
-    "internal_id": 933124,
+    "internal_id": 401027,
     "linked": false
   },
   {
@@ -3738,7 +3738,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-123", "A3-175", "A4b-260", "A4b-261"],
     "artist": "kawayoo",
-    "internal_id": 933251,
+    "internal_id": 401090,
     "linked": false
   },
   {
@@ -3768,7 +3768,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-124", "A3-176"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 933379,
+    "internal_id": 401154,
     "linked": false
   },
   {
@@ -3798,7 +3798,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-125"],
     "artist": "Naoki Saito",
-    "internal_id": 933505,
+    "internal_id": 401216,
     "linked": false
   },
   {
@@ -3828,7 +3828,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-126"],
     "artist": "Ryuta Fuse",
-    "internal_id": 933634,
+    "internal_id": 401281,
     "linked": false
   },
   {
@@ -3858,7 +3858,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-127"],
     "artist": "hatachu",
-    "internal_id": 933763,
+    "internal_id": 401346,
     "linked": false
   },
   {
@@ -3888,7 +3888,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-128"],
     "artist": "Kazumasa Yasukuni",
-    "internal_id": 933890,
+    "internal_id": 401409,
     "linked": false
   },
   {
@@ -3918,7 +3918,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-129", "A4b-290", "A4b-291"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 934017,
+    "internal_id": 401472,
     "linked": false
   },
   {
@@ -3948,7 +3948,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-130", "A4b-292", "A4b-293"],
     "artist": "0313",
-    "internal_id": 934146,
+    "internal_id": 401537,
     "linked": false
   },
   {
@@ -3978,7 +3978,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-131"],
     "artist": "5ban Graphics",
-    "internal_id": 934273,
+    "internal_id": 401600,
     "linked": false
   },
   {
@@ -4008,7 +4008,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-132"],
     "artist": "miki kudo",
-    "internal_id": 934402,
+    "internal_id": 401665,
     "linked": false
   },
   {
@@ -4038,7 +4038,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-133", "A3-177"],
     "artist": "Shin Nagasawa",
-    "internal_id": 934529,
+    "internal_id": 401728,
     "linked": false
   },
   {
@@ -4068,7 +4068,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-134"],
     "artist": "Kouki Saitou",
-    "internal_id": 934657,
+    "internal_id": 401792,
     "linked": false
   },
   {
@@ -4098,7 +4098,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-135"],
     "artist": "Megumi Mizutani",
-    "internal_id": 934786,
+    "internal_id": 401857,
     "linked": false
   },
   {
@@ -4128,7 +4128,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-136"],
     "artist": "Shigenori Negishi",
-    "internal_id": 934913,
+    "internal_id": 401920,
     "linked": false
   },
   {
@@ -4158,7 +4158,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-137"],
     "artist": "Shigenori Negishi",
-    "internal_id": 935041,
+    "internal_id": 401984,
     "linked": false
   },
   {
@@ -4188,7 +4188,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-138"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 935169,
+    "internal_id": 402048,
     "linked": false
   },
   {
@@ -4218,7 +4218,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-139", "A3-178"],
     "artist": "kirisAki",
-    "internal_id": 935299,
+    "internal_id": 402114,
     "linked": false
   },
   {
@@ -4248,7 +4248,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-140"],
     "artist": "Naoki Saito",
-    "internal_id": 935427,
+    "internal_id": 402178,
     "linked": false
   },
   {
@@ -4282,7 +4282,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-141", "A3-179"],
     "artist": "Kouki Saitou",
-    "internal_id": 935554,
+    "internal_id": 402241,
     "linked": false
   },
   {
@@ -4309,7 +4309,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-142"],
     "artist": "5ban Graphics",
-    "internal_id": 935682,
+    "internal_id": 402305,
     "linked": false
   },
   {
@@ -4336,7 +4336,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-143"],
     "artist": "Toyste Beach",
-    "internal_id": 935810,
+    "internal_id": 402369,
     "linked": false
   },
   {
@@ -4363,7 +4363,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-144", "A4b-314", "A4b-315", "A4b-379"],
     "artist": "Toyste Beach",
-    "internal_id": 935938,
+    "internal_id": 402433,
     "linked": false
   },
   {
@@ -4390,7 +4390,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-145"],
     "artist": "5ban Graphics",
-    "internal_id": 936066,
+    "internal_id": 402497,
     "linked": false
   },
   {
@@ -4417,7 +4417,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-146"],
     "artist": "Toyste Beach",
-    "internal_id": 936194,
+    "internal_id": 402561,
     "linked": false
   },
   {
@@ -4444,7 +4444,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-147", "A4b-324", "A4b-325"],
     "artist": "Toyste Beach",
-    "internal_id": 936322,
+    "internal_id": 402625,
     "linked": false
   },
   {
@@ -4471,7 +4471,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-148", "A3-190"],
     "artist": "Susumu Maeya",
-    "internal_id": 936450,
+    "internal_id": 402689,
     "linked": false
   },
   {
@@ -4498,7 +4498,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-149", "A3-191"],
     "artist": "Teeziro",
-    "internal_id": 936578,
+    "internal_id": 402753,
     "linked": false
   },
   {
@@ -4525,7 +4525,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-150", "A3-192"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 936706,
+    "internal_id": 402817,
     "linked": false
   },
   {
@@ -4552,7 +4552,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-151", "A3-193", "A3-208"],
     "artist": "GOSSAN",
-    "internal_id": 936834,
+    "internal_id": 402881,
     "linked": false
   },
   {
@@ -4579,7 +4579,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-152", "A3-194"],
     "artist": "Yuu Nishida",
-    "internal_id": 936962,
+    "internal_id": 402945,
     "linked": false
   },
   {
@@ -4606,7 +4606,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-153", "A3-195"],
     "artist": "Akira Komayama",
-    "internal_id": 937090,
+    "internal_id": 403009,
     "linked": false
   },
   {
@@ -4633,7 +4633,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-154", "A3-196"],
     "artist": "En Morikura",
-    "internal_id": 937218,
+    "internal_id": 403073,
     "linked": false
   },
   {
@@ -4660,7 +4660,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-155", "A3-197", "A3-209", "A4b-348", "A4b-349", "A4b-374"],
     "artist": "hechima",
-    "internal_id": 937346,
+    "internal_id": 403137,
     "linked": false
   },
   {
@@ -4690,7 +4690,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-2", "A3-156", "P-A-69"],
     "artist": "Saboteri",
-    "internal_id": 937477,
+    "internal_id": 403204,
     "linked": false
   },
   {
@@ -4720,7 +4720,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-16", "A3-157"],
     "artist": "kamonabe",
-    "internal_id": 937605,
+    "internal_id": 403268,
     "linked": false
   },
   {
@@ -4750,7 +4750,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-20", "A3-158"],
     "artist": "Ligton",
-    "internal_id": 937733,
+    "internal_id": 403332,
     "linked": false
   },
   {
@@ -4780,7 +4780,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-24", "A3-159"],
     "artist": "OKACHEKE",
-    "internal_id": 937861,
+    "internal_id": 403396,
     "linked": false
   },
   {
@@ -4810,7 +4810,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-27", "A3-160"],
     "artist": "Gemi",
-    "internal_id": 937989,
+    "internal_id": 403460,
     "linked": false
   },
   {
@@ -4840,7 +4840,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-37", "A3-161"],
     "artist": "akagi",
-    "internal_id": 938117,
+    "internal_id": 403524,
     "linked": false
   },
   {
@@ -4870,7 +4870,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-40", "A3-162"],
     "artist": "tono",
-    "internal_id": 938245,
+    "internal_id": 403588,
     "linked": false
   },
   {
@@ -4904,7 +4904,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-54", "A3-163", "A4a-97"],
     "artist": "Toshinao Aoki",
-    "internal_id": 938373,
+    "internal_id": 403652,
     "linked": false
   },
   {
@@ -4934,7 +4934,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-56", "A3-164"],
     "artist": "OKACHEKE",
-    "internal_id": 938501,
+    "internal_id": 403716,
     "linked": false
   },
   {
@@ -4968,7 +4968,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-66", "A3-165", "A4b-146", "A4b-147"],
     "artist": "USGMEN",
-    "internal_id": 938629,
+    "internal_id": 403780,
     "linked": false
   },
   {
@@ -4998,7 +4998,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-68", "A3-166"],
     "artist": "OKACHEKE",
-    "internal_id": 938757,
+    "internal_id": 403844,
     "linked": false
   },
   {
@@ -5028,7 +5028,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-78", "A3-167"],
     "artist": "kamonabe",
-    "internal_id": 938885,
+    "internal_id": 403908,
     "linked": false
   },
   {
@@ -5062,7 +5062,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-80", "A3-168"],
     "artist": "mashu",
-    "internal_id": 939013,
+    "internal_id": 403972,
     "linked": false
   },
   {
@@ -5092,7 +5092,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-81", "A3-169"],
     "artist": "Yukihiro Tada",
-    "internal_id": 939141,
+    "internal_id": 404036,
     "linked": false
   },
   {
@@ -5122,7 +5122,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-84", "A3-170"],
     "artist": "OKACHEKE",
-    "internal_id": 939269,
+    "internal_id": 404100,
     "linked": false
   },
   {
@@ -5152,7 +5152,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-85", "A3-171", "P-A-67", "A4b-180", "A4b-181"],
     "artist": "Yoko Hishida",
-    "internal_id": 939397,
+    "internal_id": 404164,
     "linked": false
   },
   {
@@ -5182,7 +5182,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-98", "A3-172"],
     "artist": "mele",
-    "internal_id": 939525,
+    "internal_id": 404228,
     "linked": false
   },
   {
@@ -5212,7 +5212,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-103", "A3-173"],
     "artist": "Teeziro",
-    "internal_id": 939653,
+    "internal_id": 404292,
     "linked": false
   },
   {
@@ -5242,7 +5242,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-105", "A3-174"],
     "artist": "imoniii",
-    "internal_id": 939781,
+    "internal_id": 404356,
     "linked": false
   },
   {
@@ -5272,7 +5272,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-123", "A3-175", "A4b-260", "A4b-261"],
     "artist": "Kuroimori",
-    "internal_id": 939909,
+    "internal_id": 404420,
     "linked": false
   },
   {
@@ -5302,7 +5302,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-124", "A3-176"],
     "artist": "Shinji Kanda",
-    "internal_id": 940037,
+    "internal_id": 404484,
     "linked": false
   },
   {
@@ -5332,7 +5332,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-133", "A3-177"],
     "artist": "Narumi Sato",
-    "internal_id": 940165,
+    "internal_id": 404548,
     "linked": false
   },
   {
@@ -5362,7 +5362,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-139", "A3-178"],
     "artist": "Tomowaka",
-    "internal_id": 940293,
+    "internal_id": 404612,
     "linked": false
   },
   {
@@ -5396,7 +5396,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-141", "A3-179"],
     "artist": "GOTO minori",
-    "internal_id": 940421,
+    "internal_id": 404676,
     "linked": false
   },
   {
@@ -5432,7 +5432,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-12", "A3-180", "A3-198", "A4b-42"],
     "artist": "PLANETA CG Works",
-    "internal_id": 940550,
+    "internal_id": 404741,
     "linked": false
   },
   {
@@ -5462,7 +5462,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-23", "A3-181", "A3-199", "A4b-43"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 940678,
+    "internal_id": 404805,
     "linked": false
   },
   {
@@ -5498,7 +5498,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-33", "A3-182", "A3-200", "A4b-82"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 940806,
+    "internal_id": 404869,
     "linked": false
   },
   {
@@ -5528,7 +5528,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-49", "A3-183", "A3-201", "A4b-121"],
     "artist": "PLANETA CG Works",
-    "internal_id": 940934,
+    "internal_id": 404933,
     "linked": false
   },
   {
@@ -5558,7 +5558,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-51", "A3-184", "A3-202", "A4b-124"],
     "artist": "PLANETA CG Works",
-    "internal_id": 941062,
+    "internal_id": 404997,
     "linked": false
   },
   {
@@ -5588,7 +5588,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-58", "A3-185", "A3-203", "A4b-130"],
     "artist": "PLANETA CG Works",
-    "internal_id": 941190,
+    "internal_id": 405061,
     "linked": false
   },
   {
@@ -5622,7 +5622,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-87", "A3-186", "A3-204", "A3-238", "A4b-184", "A4b-367"],
     "artist": "PLANETA CG Works",
-    "internal_id": 941318,
+    "internal_id": 405125,
     "linked": false
   },
   {
@@ -5656,7 +5656,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-104", "A3-187", "A3-205", "A4b-223"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 941446,
+    "internal_id": 405189,
     "linked": false
   },
   {
@@ -5686,7 +5686,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-111", "A3-188", "A3-206", "A4b-235"],
     "artist": "PLANETA CG Works",
-    "internal_id": 941574,
+    "internal_id": 405253,
     "linked": false
   },
   {
@@ -5720,7 +5720,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-122", "A3-189", "A3-207", "A3-239", "A4b-259", "A4b-369"],
     "artist": "PLANETA CG Works",
-    "internal_id": 941702,
+    "internal_id": 405317,
     "linked": false
   },
   {
@@ -5747,7 +5747,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-148", "A3-190"],
     "artist": "Susumu Maeya",
-    "internal_id": 941830,
+    "internal_id": 405381,
     "linked": false
   },
   {
@@ -5774,7 +5774,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-149", "A3-191"],
     "artist": "Teeziro",
-    "internal_id": 941958,
+    "internal_id": 405445,
     "linked": false
   },
   {
@@ -5801,7 +5801,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-150", "A3-192"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 942086,
+    "internal_id": 405509,
     "linked": false
   },
   {
@@ -5828,7 +5828,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-151", "A3-193", "A3-208"],
     "artist": "GOSSAN",
-    "internal_id": 942214,
+    "internal_id": 405573,
     "linked": false
   },
   {
@@ -5855,7 +5855,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-152", "A3-194"],
     "artist": "Yuu Nishida",
-    "internal_id": 942342,
+    "internal_id": 405637,
     "linked": false
   },
   {
@@ -5882,7 +5882,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-153", "A3-195"],
     "artist": "Akira Komayama",
-    "internal_id": 942470,
+    "internal_id": 405701,
     "linked": false
   },
   {
@@ -5909,7 +5909,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-154", "A3-196"],
     "artist": "En Morikura",
-    "internal_id": 942598,
+    "internal_id": 405765,
     "linked": false
   },
   {
@@ -5936,7 +5936,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-155", "A3-197", "A3-209", "A4b-348", "A4b-349", "A4b-374"],
     "artist": "hechima",
-    "internal_id": 942726,
+    "internal_id": 405829,
     "linked": false
   },
   {
@@ -5972,7 +5972,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-12", "A3-180", "A3-198", "A4b-42"],
     "artist": "Takumi Wada",
-    "internal_id": 942854,
+    "internal_id": 405893,
     "linked": false
   },
   {
@@ -6002,7 +6002,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-23", "A3-181", "A3-199", "A4b-43"],
     "artist": "IKEDA Saki",
-    "internal_id": 942982,
+    "internal_id": 405957,
     "linked": false
   },
   {
@@ -6038,7 +6038,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-33", "A3-182", "A3-200", "A4b-82"],
     "artist": "Kazumasa Yasukuni",
-    "internal_id": 943110,
+    "internal_id": 406021,
     "linked": false
   },
   {
@@ -6068,7 +6068,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-49", "A3-183", "A3-201", "A4b-121"],
     "artist": "Miki Tanaka",
-    "internal_id": 943238,
+    "internal_id": 406085,
     "linked": false
   },
   {
@@ -6098,7 +6098,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-51", "A3-184", "A3-202", "A4b-124"],
     "artist": "Nurikabe",
-    "internal_id": 943366,
+    "internal_id": 406149,
     "linked": false
   },
   {
@@ -6128,7 +6128,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-58", "A3-185", "A3-203", "A4b-130"],
     "artist": "Yoshimi Miyoshi",
-    "internal_id": 943494,
+    "internal_id": 406213,
     "linked": false
   },
   {
@@ -6162,7 +6162,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-87", "A3-186", "A3-204", "A3-238", "A4b-184", "A4b-367"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 943622,
+    "internal_id": 406277,
     "linked": false
   },
   {
@@ -6196,7 +6196,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-104", "A3-187", "A3-205", "A4b-223"],
     "artist": "Taiga Kayama",
-    "internal_id": 943750,
+    "internal_id": 406341,
     "linked": false
   },
   {
@@ -6226,7 +6226,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-111", "A3-188", "A3-206", "A4b-235"],
     "artist": "Jerky",
-    "internal_id": 943878,
+    "internal_id": 406405,
     "linked": false
   },
   {
@@ -6260,7 +6260,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-122", "A3-189", "A3-207", "A3-239", "A4b-259", "A4b-369"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 944006,
+    "internal_id": 406469,
     "linked": false
   },
   {
@@ -6287,7 +6287,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-151", "A3-193", "A3-208"],
     "artist": "danciao",
-    "internal_id": 944135,
+    "internal_id": 406534,
     "linked": false
   },
   {
@@ -6314,7 +6314,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A3-155", "A3-197", "A3-209", "A4b-348", "A4b-349", "A4b-374"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 944263,
+    "internal_id": 406598,
     "linked": false
   },
   {
@@ -6344,7 +6344,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-1", "A1-227", "P-A-23", "A3-210", "A4b-1", "A4b-2"],
     "artist": "Ryuta Fuse",
-    "internal_id": 944392,
+    "internal_id": 406664,
     "linked": false
   },
   {
@@ -6374,7 +6374,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-2", "A3-211", "A4b-3", "A4b-4"],
     "artist": "Ryuta Fuse",
-    "internal_id": 944520,
+    "internal_id": 406728,
     "linked": false
   },
   {
@@ -6404,7 +6404,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-3", "P-A-18", "A3-212"],
     "artist": "Ryuta Fuse",
-    "internal_id": 944648,
+    "internal_id": 406792,
     "linked": false
   },
   {
@@ -6434,7 +6434,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A3-1", "A3-213"],
     "artist": "Shigenori Negishi",
-    "internal_id": 944776,
+    "internal_id": 406856,
     "linked": false
   },
   {
@@ -6464,7 +6464,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1a-2", "A1a-69", "A3-214"],
     "artist": "Shigenori Negishi",
-    "internal_id": 944904,
+    "internal_id": 406920,
     "linked": false
   },
   {
@@ -6494,7 +6494,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-53", "A1-232", "P-A-33", "A3-215", "A4b-83", "A4b-84"],
     "artist": "Nisota Niso",
-    "internal_id": 945032,
+    "internal_id": 406984,
     "linked": false
   },
   {
@@ -6524,7 +6524,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-54", "A3-216", "A4b-85", "A4b-86"],
     "artist": "Nisota Niso",
-    "internal_id": 945160,
+    "internal_id": 407048,
     "linked": false
   },
   {
@@ -6554,7 +6554,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-55", "P-A-29", "A3-217"],
     "artist": "Nisota Niso",
-    "internal_id": 945288,
+    "internal_id": 407112,
     "linked": false
   },
   {
@@ -6584,7 +6584,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-74", "A3-218", "A4b-93", "A4b-94"],
     "artist": "MAHOU",
-    "internal_id": 945416,
+    "internal_id": 407176,
     "linked": false
   },
   {
@@ -6614,7 +6614,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-75", "A3-219"],
     "artist": "MAHOU",
-    "internal_id": 945544,
+    "internal_id": 407240,
     "linked": false
   },
   {
@@ -6644,7 +6644,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A2a-31", "A3-220"],
     "artist": "kurumitsu",
-    "internal_id": 945672,
+    "internal_id": 407304,
     "linked": false
   },
   {
@@ -6674,7 +6674,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-121", "A3-221", "A4b-153", "A4b-154"],
     "artist": "kurumitsu",
-    "internal_id": 945800,
+    "internal_id": 407368,
     "linked": false
   },
   {
@@ -6704,7 +6704,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-122", "A3-222"],
     "artist": "kurumitsu",
-    "internal_id": 945928,
+    "internal_id": 407432,
     "linked": false
   },
   {
@@ -6734,7 +6734,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-143", "A3-223", "A4b-189", "A4b-190"],
     "artist": "Shin Nagasawa",
-    "internal_id": 946056,
+    "internal_id": 407496,
     "linked": false
   },
   {
@@ -6764,7 +6764,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-144", "A3-224", "A4b-191", "A4b-192"],
     "artist": "Shin Nagasawa",
-    "internal_id": 946184,
+    "internal_id": 407560,
     "linked": false
   },
   {
@@ -6794,7 +6794,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A2b-39", "P-A-55", "A3-225"],
     "artist": "Shin Nagasawa",
-    "internal_id": 946312,
+    "internal_id": 407624,
     "linked": false
   },
   {
@@ -6824,7 +6824,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-151", "A1-239", "A3-226", "A4b-194", "A4b-195"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 946440,
+    "internal_id": 407688,
     "linked": false
   },
   {
@@ -6854,7 +6854,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-152", "A3-227"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 946568,
+    "internal_id": 407752,
     "linked": false
   },
   {
@@ -6884,7 +6884,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A2b-60", "A3-228"],
     "artist": "Tomowaka",
-    "internal_id": 946696,
+    "internal_id": 407816,
     "linked": false
   },
   {
@@ -6918,7 +6918,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A2b-61", "A2b-78", "A3-229"],
     "artist": "Tomowaka",
-    "internal_id": 946824,
+    "internal_id": 407880,
     "linked": false
   },
   {
@@ -6954,7 +6954,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-4", "A1-251", "A3-230", "A4b-5"],
     "artist": "PLANETA CG Works",
-    "internal_id": 946953,
+    "internal_id": 407945,
     "linked": false
   },
   {
@@ -6984,7 +6984,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-23", "A1-252", "A3-231", "A4b-13"],
     "artist": "PLANETA CG Works",
-    "internal_id": 947081,
+    "internal_id": 408009,
     "linked": false
   },
   {
@@ -7020,7 +7020,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-56", "A1-256", "A3-232", "A4b-87"],
     "artist": "PLANETA CG Works",
-    "internal_id": 947209,
+    "internal_id": 408073,
     "linked": false
   },
   {
@@ -7050,7 +7050,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-76", "A1-257", "A3-233", "A4b-95"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 947337,
+    "internal_id": 408137,
     "linked": false
   },
   {
@@ -7084,7 +7084,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-123", "A1-261", "A1-277", "A3-234", "A4b-155"],
     "artist": "PLANETA CG Works",
-    "internal_id": 947465,
+    "internal_id": 408201,
     "linked": false
   },
   {
@@ -7114,7 +7114,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-146", "A1-263", "A1-278", "A3-235", "A4b-193"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 947593,
+    "internal_id": 408265,
     "linked": false
   },
   {
@@ -7144,7 +7144,7 @@
     "pack": "lunalapack",
     "alternate_versions": ["A1-153", "A1-264", "A3-236", "A4b-196"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 947721,
+    "internal_id": 408329,
     "linked": false
   },
   {
@@ -7174,7 +7174,7 @@
     "pack": "solgaleopack",
     "alternate_versions": ["A1-195", "A1-265", "A1-279", "A3-237", "A4b-279"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 947849,
+    "internal_id": 408393,
     "linked": false
   },
   {
@@ -7208,7 +7208,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-87", "A3-186", "A3-204", "A3-238", "A4b-184", "A4b-367"],
     "artist": "PLANETA CG Works",
-    "internal_id": 947978,
+    "internal_id": 408460,
     "linked": false
   },
   {
@@ -7242,7 +7242,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-122", "A3-189", "A3-207", "A3-239", "A4b-259", "A4b-369"],
     "artist": "PLANETA CG Works",
-    "internal_id": 948106,
+    "internal_id": 408524,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A3a.json
+++ b/frontend/assets/cards/A3a.json
@@ -26,7 +26,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-1"],
     "artist": "sui",
-    "internal_id": 1048705,
+    "internal_id": 458816,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-2"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1048833,
+    "internal_id": 458880,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-3", "A3a-70"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1048961,
+    "internal_id": 458944,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-4"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1049090,
+    "internal_id": 459009,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-5"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1049219,
+    "internal_id": 459074,
     "linked": false
   },
   {
@@ -182,7 +182,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-6", "A3a-76", "A3a-88", "A4b-44", "A4b-360"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1049348,
+    "internal_id": 459139,
     "linked": false
   },
   {
@@ -212,7 +212,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-7", "A3a-71", "A4b-45", "A4b-46"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1049474,
+    "internal_id": 459201,
     "linked": false
   },
   {
@@ -242,7 +242,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-8", "P-A-75", "A4b-47", "A4b-48"],
     "artist": "nagimiso",
-    "internal_id": 1049601,
+    "internal_id": 459264,
     "linked": false
   },
   {
@@ -272,7 +272,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-9", "A3a-72", "P-A-76"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 1049730,
+    "internal_id": 459329,
     "linked": false
   },
   {
@@ -302,7 +302,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-10"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1049857,
+    "internal_id": 459392,
     "linked": false
   },
   {
@@ -332,7 +332,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-11"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1049985,
+    "internal_id": 459456,
     "linked": false
   },
   {
@@ -362,7 +362,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-12"],
     "artist": "Yumi",
-    "internal_id": 1050114,
+    "internal_id": 459521,
     "linked": false
   },
   {
@@ -392,7 +392,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-13"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1050241,
+    "internal_id": 459584,
     "linked": false
   },
   {
@@ -422,7 +422,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-14"],
     "artist": "Kouki Saitou",
-    "internal_id": 1050369,
+    "internal_id": 459648,
     "linked": false
   },
   {
@@ -456,7 +456,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-15"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1050499,
+    "internal_id": 459714,
     "linked": false
   },
   {
@@ -486,7 +486,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-16"],
     "artist": "Miki Tanaka",
-    "internal_id": 1050625,
+    "internal_id": 459776,
     "linked": false
   },
   {
@@ -516,7 +516,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-17"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1050753,
+    "internal_id": 459840,
     "linked": false
   },
   {
@@ -546,7 +546,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-18"],
     "artist": "Naoki Saito",
-    "internal_id": 1050881,
+    "internal_id": 459904,
     "linked": false
   },
   {
@@ -582,7 +582,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-19", "A3a-77", "A3a-84", "P-A-84", "A4b-148"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1051012,
+    "internal_id": 459971,
     "linked": false
   },
   {
@@ -612,7 +612,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-20", "P-A-77"],
     "artist": "Satoshi Shirai",
-    "internal_id": 1051138,
+    "internal_id": 460033,
     "linked": false
   },
   {
@@ -646,7 +646,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-21", "P-A-74", "A4b-149", "A4b-150"],
     "artist": "kawayoo",
-    "internal_id": 1051267,
+    "internal_id": 460098,
     "linked": false
   },
   {
@@ -676,7 +676,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-22"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1051393,
+    "internal_id": 460160,
     "linked": false
   },
   {
@@ -706,7 +706,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-23"],
     "artist": "miki kudo",
-    "internal_id": 1051522,
+    "internal_id": 460225,
     "linked": false
   },
   {
@@ -736,7 +736,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-24"],
     "artist": "sui",
-    "internal_id": 1051649,
+    "internal_id": 460288,
     "linked": false
   },
   {
@@ -766,7 +766,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-25"],
     "artist": "Kouki Saitou",
-    "internal_id": 1051777,
+    "internal_id": 460352,
     "linked": false
   },
   {
@@ -796,7 +796,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-26"],
     "artist": "Midori Harada",
-    "internal_id": 1051905,
+    "internal_id": 460416,
     "linked": false
   },
   {
@@ -830,7 +830,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-27"],
     "artist": "kawayoo",
-    "internal_id": 1052035,
+    "internal_id": 460482,
     "linked": false
   },
   {
@@ -860,7 +860,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-28"],
     "artist": "Yukiko Baba",
-    "internal_id": 1052161,
+    "internal_id": 460544,
     "linked": false
   },
   {
@@ -890,7 +890,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-29"],
     "artist": "Misa Tsutsui",
-    "internal_id": 1052290,
+    "internal_id": 460609,
     "linked": false
   },
   {
@@ -920,7 +920,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-30"],
     "artist": "Uta",
-    "internal_id": 1052417,
+    "internal_id": 460672,
     "linked": false
   },
   {
@@ -954,7 +954,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-31"],
     "artist": "Satoshi Shirai",
-    "internal_id": 1052546,
+    "internal_id": 460737,
     "linked": false
   },
   {
@@ -984,7 +984,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-32", "A4b-220", "A4b-221"],
     "artist": "match",
-    "internal_id": 1052673,
+    "internal_id": 460800,
     "linked": false
   },
   {
@@ -1014,7 +1014,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-33", "A3a-78", "A3a-85", "A4b-222"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1052804,
+    "internal_id": 460867,
     "linked": false
   },
   {
@@ -1044,7 +1044,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-34"],
     "artist": "Naoki Saito",
-    "internal_id": 1052929,
+    "internal_id": 460928,
     "linked": false
   },
   {
@@ -1074,7 +1074,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-35"],
     "artist": "Yuka Morii",
-    "internal_id": 1053057,
+    "internal_id": 460992,
     "linked": false
   },
   {
@@ -1104,7 +1104,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-36"],
     "artist": "Hasuno",
-    "internal_id": 1053186,
+    "internal_id": 461057,
     "linked": false
   },
   {
@@ -1134,7 +1134,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-37", "A3a-73"],
     "artist": "Sekio",
-    "internal_id": 1053313,
+    "internal_id": 461120,
     "linked": false
   },
   {
@@ -1164,7 +1164,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-38"],
     "artist": "ryoma uratsuka",
-    "internal_id": 1053442,
+    "internal_id": 461185,
     "linked": false
   },
   {
@@ -1194,7 +1194,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-39"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1053569,
+    "internal_id": 461248,
     "linked": false
   },
   {
@@ -1224,7 +1224,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-40"],
     "artist": "Akira Komayama",
-    "internal_id": 1053697,
+    "internal_id": 461312,
     "linked": false
   },
   {
@@ -1254,7 +1254,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-41"],
     "artist": "Naoki Saito",
-    "internal_id": 1053826,
+    "internal_id": 461377,
     "linked": false
   },
   {
@@ -1288,7 +1288,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-42", "A3a-103", "A4b-246", "A4b-247"],
     "artist": "nagimiso",
-    "internal_id": 1053955,
+    "internal_id": 461442,
     "linked": false
   },
   {
@@ -1324,7 +1324,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-43", "A3a-79", "A3a-86", "A4b-248"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1054084,
+    "internal_id": 461507,
     "linked": false
   },
   {
@@ -1354,7 +1354,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-44", "P-A-82"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1054209,
+    "internal_id": 461568,
     "linked": false
   },
   {
@@ -1384,7 +1384,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-45"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1054339,
+    "internal_id": 461634,
     "linked": false
   },
   {
@@ -1414,7 +1414,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-46", "A4b-249", "A4b-250"],
     "artist": "Megumi Mizutani",
-    "internal_id": 1054465,
+    "internal_id": 461696,
     "linked": false
   },
   {
@@ -1444,7 +1444,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-47", "A3a-80", "A3a-87", "A4b-251"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1054596,
+    "internal_id": 461763,
     "linked": false
   },
   {
@@ -1474,7 +1474,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-48"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1054721,
+    "internal_id": 461824,
     "linked": false
   },
   {
@@ -1504,7 +1504,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-49"],
     "artist": "Mizue",
-    "internal_id": 1054849,
+    "internal_id": 461888,
     "linked": false
   },
   {
@@ -1534,7 +1534,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-50"],
     "artist": "Satoshi Shirai",
-    "internal_id": 1054978,
+    "internal_id": 461953,
     "linked": false
   },
   {
@@ -1564,7 +1564,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-51"],
     "artist": "Midori Harada",
-    "internal_id": 1055105,
+    "internal_id": 462016,
     "linked": false
   },
   {
@@ -1598,7 +1598,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-52"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1055234,
+    "internal_id": 462081,
     "linked": false
   },
   {
@@ -1628,7 +1628,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-53", "P-A-80"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 1055362,
+    "internal_id": 462145,
     "linked": false
   },
   {
@@ -1658,7 +1658,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-54"],
     "artist": "Mizue",
-    "internal_id": 1055489,
+    "internal_id": 462208,
     "linked": false
   },
   {
@@ -1688,7 +1688,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-55"],
     "artist": "Midori Harada",
-    "internal_id": 1055617,
+    "internal_id": 462272,
     "linked": false
   },
   {
@@ -1722,7 +1722,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-56"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1055746,
+    "internal_id": 462337,
     "linked": false
   },
   {
@@ -1752,7 +1752,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-57", "P-A-83"],
     "artist": "Sekio",
-    "internal_id": 1055873,
+    "internal_id": 462400,
     "linked": false
   },
   {
@@ -1782,7 +1782,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-58"],
     "artist": "Ryuta Fuse",
-    "internal_id": 1056002,
+    "internal_id": 462465,
     "linked": false
   },
   {
@@ -1812,7 +1812,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-59"],
     "artist": "Kouki Saitou",
-    "internal_id": 1056129,
+    "internal_id": 462528,
     "linked": false
   },
   {
@@ -1842,7 +1842,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-60", "A4b-300", "A4b-301"],
     "artist": "match",
-    "internal_id": 1056258,
+    "internal_id": 462593,
     "linked": false
   },
   {
@@ -1872,7 +1872,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-61", "A3a-74", "A4b-302", "A4b-303"],
     "artist": "Eske Yoshinob",
-    "internal_id": 1056387,
+    "internal_id": 462658,
     "linked": false
   },
   {
@@ -1906,7 +1906,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-62", "A3a-75", "A4b-304", "A4b-305"],
     "artist": "kawayoo",
-    "internal_id": 1056515,
+    "internal_id": 462722,
     "linked": false
   },
   {
@@ -1933,7 +1933,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-63"],
     "artist": "Toyste Beach",
-    "internal_id": 1056642,
+    "internal_id": 462785,
     "linked": false
   },
   {
@@ -1960,7 +1960,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-64"],
     "artist": "Yoshinobu Saito",
-    "internal_id": 1056770,
+    "internal_id": 462849,
     "linked": false
   },
   {
@@ -1987,7 +1987,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-65", "A4b-318", "A4b-319"],
     "artist": "Toyste Beach",
-    "internal_id": 1056898,
+    "internal_id": 462913,
     "linked": false
   },
   {
@@ -2014,7 +2014,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-66"],
     "artist": "inose yukie",
-    "internal_id": 1057026,
+    "internal_id": 462977,
     "linked": false
   },
   {
@@ -2041,7 +2041,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-67", "A3a-81"],
     "artist": "hncl",
-    "internal_id": 1057154,
+    "internal_id": 463041,
     "linked": false
   },
   {
@@ -2068,7 +2068,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-68", "A3a-82"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1057282,
+    "internal_id": 463105,
     "linked": false
   },
   {
@@ -2095,7 +2095,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-69", "A3a-83", "A4b-350", "A4b-351", "A4b-375"],
     "artist": "Taira Akitsu",
-    "internal_id": 1057410,
+    "internal_id": 463169,
     "linked": false
   },
   {
@@ -2125,7 +2125,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-3", "A3a-70"],
     "artist": "OKACHEKE",
-    "internal_id": 1057541,
+    "internal_id": 463236,
     "linked": false
   },
   {
@@ -2155,7 +2155,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-7", "A3a-71", "A4b-45", "A4b-46"],
     "artist": "matazo",
-    "internal_id": 1057669,
+    "internal_id": 463300,
     "linked": false
   },
   {
@@ -2185,7 +2185,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-9", "A3a-72", "P-A-76"],
     "artist": "akagi",
-    "internal_id": 1057797,
+    "internal_id": 463364,
     "linked": false
   },
   {
@@ -2215,7 +2215,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-37", "A3a-73"],
     "artist": "Mina Nakai",
-    "internal_id": 1057925,
+    "internal_id": 463428,
     "linked": false
   },
   {
@@ -2245,7 +2245,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-61", "A3a-74", "A4b-302", "A4b-303"],
     "artist": "hncl",
-    "internal_id": 1058053,
+    "internal_id": 463492,
     "linked": false
   },
   {
@@ -2279,7 +2279,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-62", "A3a-75", "A4b-304", "A4b-305"],
     "artist": "REND",
-    "internal_id": 1058181,
+    "internal_id": 463556,
     "linked": false
   },
   {
@@ -2315,7 +2315,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-6", "A3a-76", "A3a-88", "A4b-44", "A4b-360"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1058310,
+    "internal_id": 463621,
     "linked": false
   },
   {
@@ -2351,7 +2351,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-19", "A3a-77", "A3a-84", "P-A-84", "A4b-148"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1058438,
+    "internal_id": 463685,
     "linked": false
   },
   {
@@ -2381,7 +2381,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-33", "A3a-78", "A3a-85", "A4b-222"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1058566,
+    "internal_id": 463749,
     "linked": false
   },
   {
@@ -2417,7 +2417,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-43", "A3a-79", "A3a-86", "A4b-248"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1058694,
+    "internal_id": 463813,
     "linked": false
   },
   {
@@ -2447,7 +2447,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-47", "A3a-80", "A3a-87", "A4b-251"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1058822,
+    "internal_id": 463877,
     "linked": false
   },
   {
@@ -2474,7 +2474,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-67", "A3a-81"],
     "artist": "hncl",
-    "internal_id": 1058950,
+    "internal_id": 463941,
     "linked": false
   },
   {
@@ -2501,7 +2501,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-68", "A3a-82"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1059078,
+    "internal_id": 464005,
     "linked": false
   },
   {
@@ -2528,7 +2528,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-69", "A3a-83", "A4b-350", "A4b-351", "A4b-375"],
     "artist": "Taira Akitsu",
-    "internal_id": 1059206,
+    "internal_id": 464069,
     "linked": false
   },
   {
@@ -2564,7 +2564,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-19", "A3a-77", "A3a-84", "P-A-84", "A4b-148"],
     "artist": "Dsuke",
-    "internal_id": 1059334,
+    "internal_id": 464133,
     "linked": false
   },
   {
@@ -2594,7 +2594,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-33", "A3a-78", "A3a-85", "A4b-222"],
     "artist": "Jiro Sasumo",
-    "internal_id": 1059462,
+    "internal_id": 464197,
     "linked": false
   },
   {
@@ -2630,7 +2630,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-43", "A3a-79", "A3a-86", "A4b-248"],
     "artist": "Nurikabe",
-    "internal_id": 1059590,
+    "internal_id": 464261,
     "linked": false
   },
   {
@@ -2660,7 +2660,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-47", "A3a-80", "A3a-87", "A4b-251"],
     "artist": "KEIICHIRO ITO",
-    "internal_id": 1059718,
+    "internal_id": 464325,
     "linked": false
   },
   {
@@ -2696,7 +2696,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-6", "A3a-76", "A3a-88", "A4b-44", "A4b-360"],
     "artist": "akagi",
-    "internal_id": 1059847,
+    "internal_id": 464390,
     "linked": false
   },
   {
@@ -2726,7 +2726,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-39", "A3a-89", "A4b-61", "A4b-62"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1059976,
+    "internal_id": 464456,
     "linked": false
   },
   {
@@ -2756,7 +2756,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-40", "A3a-90"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1060104,
+    "internal_id": 464520,
     "linked": false
   },
   {
@@ -2786,7 +2786,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-87", "P-A-61", "A3a-91", "A4b-110", "A4b-111"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1060232,
+    "internal_id": 464584,
     "linked": false
   },
   {
@@ -2816,7 +2816,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-88", "A3a-92", "A4b-112", "A4b-113"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1060360,
+    "internal_id": 464648,
     "linked": false
   },
   {
@@ -2850,7 +2850,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-89", "P-A-19", "A3a-93", "A4b-114", "A4b-115", "A4b-356"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1060488,
+    "internal_id": 464712,
     "linked": false
   },
   {
@@ -2880,7 +2880,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-127", "A3a-94", "A4b-156", "A4b-157"],
     "artist": "MAHOU",
-    "internal_id": 1060616,
+    "internal_id": 464776,
     "linked": false
   },
   {
@@ -2910,7 +2910,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-186", "A3a-95"],
     "artist": "Misa Tsutsui",
-    "internal_id": 1060744,
+    "internal_id": 464840,
     "linked": false
   },
   {
@@ -2940,7 +2940,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-187", "A3a-96"],
     "artist": "Misa Tsutsui",
-    "internal_id": 1060872,
+    "internal_id": 464904,
     "linked": false
   },
   {
@@ -2974,7 +2974,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-188", "A1-245", "A3a-97"],
     "artist": "Misa Tsutsui",
-    "internal_id": 1061000,
+    "internal_id": 464968,
     "linked": false
   },
   {
@@ -3004,7 +3004,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-210", "A3a-98"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1061128,
+    "internal_id": 465032,
     "linked": false
   },
   {
@@ -3034,7 +3034,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-3", "A1a-75", "A1a-85", "A3a-99", "A4b-24"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1061257,
+    "internal_id": 465097,
     "linked": false
   },
   {
@@ -3064,7 +3064,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-41", "A1-254", "A3a-100", "A4b-63"],
     "artist": "PLANETA Saito",
-    "internal_id": 1061385,
+    "internal_id": 465161,
     "linked": false
   },
   {
@@ -3098,7 +3098,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-46", "A1a-78", "A1a-84", "A3a-101", "A4b-197"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1061513,
+    "internal_id": 465225,
     "linked": false
   },
   {
@@ -3128,7 +3128,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-59", "A1a-79", "A3a-102", "A4b-276"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1061641,
+    "internal_id": 465289,
     "linked": false
   },
   {
@@ -3162,7 +3162,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-42", "A3a-103", "A4b-246", "A4b-247"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1061770,
+    "internal_id": 465356,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A3b.json
+++ b/frontend/assets/cards/A3b.json
@@ -26,7 +26,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-1"],
     "artist": "Oswaldo KATO",
-    "internal_id": 1179778,
+    "internal_id": 524353,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-2", "A3b-70"],
     "artist": "chibi",
-    "internal_id": 1179907,
+    "internal_id": 524418,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-3"],
     "artist": "Yuka Morii",
-    "internal_id": 1180033,
+    "internal_id": 524480,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-4"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1180161,
+    "internal_id": 524544,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-5"],
     "artist": "Naoki Saito",
-    "internal_id": 1180290,
+    "internal_id": 524609,
     "linked": false
   },
   {
@@ -176,7 +176,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-6"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1180417,
+    "internal_id": 524672,
     "linked": false
   },
   {
@@ -206,7 +206,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-7"],
     "artist": "Akira Komayama",
-    "internal_id": 1180546,
+    "internal_id": 524737,
     "linked": false
   },
   {
@@ -236,7 +236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-8", "A3b-71", "A4-213", "A4b-64", "A4b-65"],
     "artist": "Eri Yamaki",
-    "internal_id": 1180675,
+    "internal_id": 524802,
     "linked": false
   },
   {
@@ -270,7 +270,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-9", "A3b-79", "A3b-87", "A4b-66"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1180804,
+    "internal_id": 524867,
     "linked": false
   },
   {
@@ -300,7 +300,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-10", "A4b-69", "A4b-70"],
     "artist": "sui",
-    "internal_id": 1180929,
+    "internal_id": 524928,
     "linked": false
   },
   {
@@ -330,7 +330,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-11"],
     "artist": "0313",
-    "internal_id": 1181057,
+    "internal_id": 524992,
     "linked": false
   },
   {
@@ -360,7 +360,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-12"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1181185,
+    "internal_id": 525056,
     "linked": false
   },
   {
@@ -390,7 +390,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-13"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 1181314,
+    "internal_id": 525121,
     "linked": false
   },
   {
@@ -420,7 +420,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-14"],
     "artist": "tetsuya koizumi",
-    "internal_id": 1181441,
+    "internal_id": 525184,
     "linked": false
   },
   {
@@ -450,7 +450,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-15"],
     "artist": "Shibuzoh.",
-    "internal_id": 1181570,
+    "internal_id": 525249,
     "linked": false
   },
   {
@@ -480,7 +480,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-16", "A3b-72"],
     "artist": "sui",
-    "internal_id": 1181699,
+    "internal_id": 525314,
     "linked": false
   },
   {
@@ -510,7 +510,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-17", "A3b-73"],
     "artist": "Mizue",
-    "internal_id": 1181827,
+    "internal_id": 525378,
     "linked": false
   },
   {
@@ -540,7 +540,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-18", "P-A-85"],
     "artist": "MAHOU",
-    "internal_id": 1181953,
+    "internal_id": 525440,
     "linked": false
   },
   {
@@ -570,7 +570,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-19"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1182081,
+    "internal_id": 525504,
     "linked": false
   },
   {
@@ -600,7 +600,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-20"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 1182210,
+    "internal_id": 525569,
     "linked": false
   },
   {
@@ -630,7 +630,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-21"],
     "artist": "Miki Tanaka",
-    "internal_id": 1182337,
+    "internal_id": 525632,
     "linked": false
   },
   {
@@ -660,7 +660,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-22", "A4b-116", "A4b-117"],
     "artist": "match",
-    "internal_id": 1182465,
+    "internal_id": 525696,
     "linked": false
   },
   {
@@ -690,7 +690,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-23", "A4b-118", "A4b-119"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1182593,
+    "internal_id": 525760,
     "linked": false
   },
   {
@@ -726,7 +726,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-24", "A3b-80", "A3b-88", "A4b-120"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1182724,
+    "internal_id": 525827,
     "linked": false
   },
   {
@@ -756,7 +756,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-25", "A3b-74", "P-A-86", "A4-219"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1182851,
+    "internal_id": 525890,
     "linked": false
   },
   {
@@ -786,7 +786,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-26"],
     "artist": "Kouki Saitou",
-    "internal_id": 1182977,
+    "internal_id": 525952,
     "linked": false
   },
   {
@@ -816,7 +816,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-27"],
     "artist": "otumami",
-    "internal_id": 1183106,
+    "internal_id": 526017,
     "linked": false
   },
   {
@@ -846,7 +846,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-28", "A3b-75"],
     "artist": "Ryota Murayama",
-    "internal_id": 1183235,
+    "internal_id": 526082,
     "linked": false
   },
   {
@@ -876,7 +876,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-29"],
     "artist": "match",
-    "internal_id": 1183361,
+    "internal_id": 526144,
     "linked": false
   },
   {
@@ -906,7 +906,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-30"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1183490,
+    "internal_id": 526209,
     "linked": false
   },
   {
@@ -936,7 +936,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-31", "A4b-173", "A4b-174"],
     "artist": "MAHOU",
-    "internal_id": 1183617,
+    "internal_id": 526272,
     "linked": false
   },
   {
@@ -966,7 +966,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-32", "A4b-175", "A4b-176", "A4b-358"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1183746,
+    "internal_id": 526337,
     "linked": false
   },
   {
@@ -996,7 +996,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-33", "A3b-76"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1183875,
+    "internal_id": 526402,
     "linked": false
   },
   {
@@ -1030,7 +1030,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-34", "A3b-81", "A3b-89", "A4b-177"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1184004,
+    "internal_id": 526467,
     "linked": false
   },
   {
@@ -1060,7 +1060,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-35", "P-A-113"],
     "artist": "Eri Yamaki",
-    "internal_id": 1184130,
+    "internal_id": 526529,
     "linked": false
   },
   {
@@ -1090,7 +1090,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-36", "A4b-185", "A4b-186"],
     "artist": "Mina Nakai",
-    "internal_id": 1184257,
+    "internal_id": 526592,
     "linked": false
   },
   {
@@ -1120,7 +1120,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-37", "P-A-87", "A4b-187", "A4b-188"],
     "artist": "Mizue",
-    "internal_id": 1184386,
+    "internal_id": 526657,
     "linked": false
   },
   {
@@ -1150,7 +1150,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-38"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1184513,
+    "internal_id": 526720,
     "linked": false
   },
   {
@@ -1180,7 +1180,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-39"],
     "artist": "Shinji Kanda",
-    "internal_id": 1184642,
+    "internal_id": 526785,
     "linked": false
   },
   {
@@ -1210,7 +1210,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-40"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1184769,
+    "internal_id": 526848,
     "linked": false
   },
   {
@@ -1240,7 +1240,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-41"],
     "artist": "Shibuzoh.",
-    "internal_id": 1184898,
+    "internal_id": 526913,
     "linked": false
   },
   {
@@ -1270,7 +1270,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-42"],
     "artist": "5ban Graphics",
-    "internal_id": 1185025,
+    "internal_id": 526976,
     "linked": false
   },
   {
@@ -1300,7 +1300,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-43", "A3b-77", "A4b-239", "A4b-240"],
     "artist": "Ryota Murayama",
-    "internal_id": 1185155,
+    "internal_id": 527042,
     "linked": false
   },
   {
@@ -1330,7 +1330,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-44"],
     "artist": "Yukiko Baba",
-    "internal_id": 1185281,
+    "internal_id": 527104,
     "linked": false
   },
   {
@@ -1360,7 +1360,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-45"],
     "artist": "Kouki Saitou",
-    "internal_id": 1185409,
+    "internal_id": 527168,
     "linked": false
   },
   {
@@ -1390,7 +1390,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-46"],
     "artist": "kawayoo",
-    "internal_id": 1185538,
+    "internal_id": 527233,
     "linked": false
   },
   {
@@ -1420,7 +1420,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-47"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1185665,
+    "internal_id": 527296,
     "linked": false
   },
   {
@@ -1450,7 +1450,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-48", "P-A-90"],
     "artist": "Oswaldo KATO",
-    "internal_id": 1185793,
+    "internal_id": 527360,
     "linked": false
   },
   {
@@ -1480,7 +1480,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-49"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 1185921,
+    "internal_id": 527424,
     "linked": false
   },
   {
@@ -1510,7 +1510,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-50"],
     "artist": "NC Empire",
-    "internal_id": 1186050,
+    "internal_id": 527489,
     "linked": false
   },
   {
@@ -1540,7 +1540,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-51", "A4b-267", "A4b-268"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1186177,
+    "internal_id": 527552,
     "linked": false
   },
   {
@@ -1570,7 +1570,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-52", "A4b-269", "A4b-270"],
     "artist": "sui",
-    "internal_id": 1186305,
+    "internal_id": 527616,
     "linked": false
   },
   {
@@ -1600,7 +1600,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-53", "A3b-82", "A3b-90", "A4b-271"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1186436,
+    "internal_id": 527683,
     "linked": false
   },
   {
@@ -1630,7 +1630,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-54"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1186562,
+    "internal_id": 527745,
     "linked": false
   },
   {
@@ -1660,7 +1660,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-55", "A3b-78", "A4b-285", "A4b-286"],
     "artist": "Naoki Saito",
-    "internal_id": 1186689,
+    "internal_id": 527808,
     "linked": false
   },
   {
@@ -1694,7 +1694,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-56", "A3b-83", "A3b-92", "A4b-287", "A4b-370", "P-A-109"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1186820,
+    "internal_id": 527875,
     "linked": false
   },
   {
@@ -1728,7 +1728,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-57", "A3b-84", "A3b-91", "A4b-288"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1186948,
+    "internal_id": 527939,
     "linked": false
   },
   {
@@ -1758,7 +1758,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-58"],
     "artist": "Shibuzoh.",
-    "internal_id": 1187073,
+    "internal_id": 528000,
     "linked": false
   },
   {
@@ -1792,7 +1792,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-59"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1187202,
+    "internal_id": 528065,
     "linked": false
   },
   {
@@ -1822,7 +1822,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-60"],
     "artist": "Akira Komayama",
-    "internal_id": 1187329,
+    "internal_id": 528128,
     "linked": false
   },
   {
@@ -1852,7 +1852,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-61"],
     "artist": "sui",
-    "internal_id": 1187457,
+    "internal_id": 528192,
     "linked": false
   },
   {
@@ -1882,7 +1882,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-62"],
     "artist": "Sekio",
-    "internal_id": 1187585,
+    "internal_id": 528256,
     "linked": false
   },
   {
@@ -1912,7 +1912,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-63"],
     "artist": "Mizue",
-    "internal_id": 1187714,
+    "internal_id": 528321,
     "linked": false
   },
   {
@@ -1942,7 +1942,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-64"],
     "artist": "Akira Komayama",
-    "internal_id": 1187841,
+    "internal_id": 528384,
     "linked": false
   },
   {
@@ -1972,7 +1972,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-65", "P-A-91"],
     "artist": "kirisAki",
-    "internal_id": 1187970,
+    "internal_id": 528449,
     "linked": false
   },
   {
@@ -1999,7 +1999,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-66", "A3b-107", "A4b-308", "A4b-309"],
     "artist": "AYUMI ODASHIMA",
-    "internal_id": 1188098,
+    "internal_id": 528513,
     "linked": false
   },
   {
@@ -2026,7 +2026,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-67"],
     "artist": "Studio Bora Inc.",
-    "internal_id": 1188226,
+    "internal_id": 528577,
     "linked": false
   },
   {
@@ -2053,7 +2053,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-68", "A3b-85"],
     "artist": "Yuu Nishida",
-    "internal_id": 1188354,
+    "internal_id": 528641,
     "linked": false
   },
   {
@@ -2080,7 +2080,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-69", "A3b-86"],
     "artist": "Susumu Maeya",
-    "internal_id": 1188482,
+    "internal_id": 528705,
     "linked": false
   },
   {
@@ -2110,7 +2110,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-2", "A3b-70"],
     "artist": "Ryota Murayama",
-    "internal_id": 1188613,
+    "internal_id": 528772,
     "linked": false
   },
   {
@@ -2140,7 +2140,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-8", "A3b-71", "A4-213", "A4b-64", "A4b-65"],
     "artist": "Teeziro",
-    "internal_id": 1188741,
+    "internal_id": 528836,
     "linked": false
   },
   {
@@ -2170,7 +2170,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-16", "A3b-72"],
     "artist": "chibi",
-    "internal_id": 1188869,
+    "internal_id": 528900,
     "linked": false
   },
   {
@@ -2200,7 +2200,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-17", "A3b-73"],
     "artist": "Fujimoto Gold",
-    "internal_id": 1188997,
+    "internal_id": 528964,
     "linked": false
   },
   {
@@ -2230,7 +2230,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-25", "A3b-74", "P-A-86", "A4-219"],
     "artist": "Nisota Niso",
-    "internal_id": 1189125,
+    "internal_id": 529028,
     "linked": false
   },
   {
@@ -2260,7 +2260,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-28", "A3b-75"],
     "artist": "rika",
-    "internal_id": 1189253,
+    "internal_id": 529092,
     "linked": false
   },
   {
@@ -2290,7 +2290,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-33", "A3b-76"],
     "artist": "saino misaki",
-    "internal_id": 1189381,
+    "internal_id": 529156,
     "linked": false
   },
   {
@@ -2320,7 +2320,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-43", "A3b-77", "A4b-239", "A4b-240"],
     "artist": "kawayoo",
-    "internal_id": 1189509,
+    "internal_id": 529220,
     "linked": false
   },
   {
@@ -2350,7 +2350,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-55", "A3b-78", "A4b-285", "A4b-286"],
     "artist": "Narumi Sato",
-    "internal_id": 1189637,
+    "internal_id": 529284,
     "linked": false
   },
   {
@@ -2384,7 +2384,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-9", "A3b-79", "A3b-87", "A4b-66"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1189766,
+    "internal_id": 529349,
     "linked": false
   },
   {
@@ -2420,7 +2420,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-24", "A3b-80", "A3b-88", "A4b-120"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1189894,
+    "internal_id": 529413,
     "linked": false
   },
   {
@@ -2454,7 +2454,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-34", "A3b-81", "A3b-89", "A4b-177"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1190022,
+    "internal_id": 529477,
     "linked": false
   },
   {
@@ -2484,7 +2484,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-53", "A3b-82", "A3b-90", "A4b-271"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1190150,
+    "internal_id": 529541,
     "linked": false
   },
   {
@@ -2518,7 +2518,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-56", "A3b-83", "A3b-92", "A4b-287", "A4b-370", "P-A-109"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1190278,
+    "internal_id": 529605,
     "linked": false
   },
   {
@@ -2552,7 +2552,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-57", "A3b-84", "A3b-91", "A4b-288"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1190406,
+    "internal_id": 529669,
     "linked": false
   },
   {
@@ -2579,7 +2579,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-68", "A3b-85"],
     "artist": "Yuu Nishida",
-    "internal_id": 1190534,
+    "internal_id": 529733,
     "linked": false
   },
   {
@@ -2606,7 +2606,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-69", "A3b-86"],
     "artist": "Susumu Maeya",
-    "internal_id": 1190662,
+    "internal_id": 529797,
     "linked": false
   },
   {
@@ -2640,7 +2640,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-9", "A3b-79", "A3b-87", "A4b-66"],
     "artist": "Kuroimori",
-    "internal_id": 1190790,
+    "internal_id": 529861,
     "linked": false
   },
   {
@@ -2676,7 +2676,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-24", "A3b-80", "A3b-88", "A4b-120"],
     "artist": "DOM",
-    "internal_id": 1190918,
+    "internal_id": 529925,
     "linked": false
   },
   {
@@ -2710,7 +2710,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-34", "A3b-81", "A3b-89", "A4b-177"],
     "artist": "Yuu Nishida",
-    "internal_id": 1191046,
+    "internal_id": 529989,
     "linked": false
   },
   {
@@ -2740,7 +2740,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-53", "A3b-82", "A3b-90", "A4b-271"],
     "artist": "Mori Yuu",
-    "internal_id": 1191174,
+    "internal_id": 530053,
     "linked": false
   },
   {
@@ -2774,7 +2774,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-57", "A3b-84", "A3b-91", "A4b-288"],
     "artist": "Mékayu",
-    "internal_id": 1191302,
+    "internal_id": 530117,
     "linked": false
   },
   {
@@ -2808,7 +2808,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-56", "A3b-83", "A3b-92", "A4b-287", "A4b-370", "P-A-109"],
     "artist": "kurumitsu",
-    "internal_id": 1191431,
+    "internal_id": 530182,
     "linked": false
   },
   {
@@ -2838,7 +2838,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-4", "A3b-93"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1191560,
+    "internal_id": 530248,
     "linked": false
   },
   {
@@ -2868,7 +2868,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-79", "A1-234", "A3b-94"],
     "artist": "Nelnal",
-    "internal_id": 1191688,
+    "internal_id": 530312,
     "linked": false
   },
   {
@@ -2898,7 +2898,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-54", "A3b-95"],
     "artist": "Scav",
-    "internal_id": 1191816,
+    "internal_id": 530376,
     "linked": false
   },
   {
@@ -2928,7 +2928,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-55", "A3b-96"],
     "artist": "Scav",
-    "internal_id": 1191944,
+    "internal_id": 530440,
     "linked": false
   },
   {
@@ -2958,7 +2958,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-68", "A3b-97", "A4b-164", "A4b-165"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1192072,
+    "internal_id": 530504,
     "linked": false
   },
   {
@@ -2988,7 +2988,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-69", "A3b-98", "A4b-166", "A4b-167"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1192200,
+    "internal_id": 530568,
     "linked": false
   },
   {
@@ -3022,7 +3022,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-132", "A3b-99", "A4b-168", "A4b-169", "A4b-357"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1192328,
+    "internal_id": 530632,
     "linked": false
   },
   {
@@ -3052,7 +3052,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-164", "A3b-100"],
     "artist": "SATOSHI NAKAI",
-    "internal_id": 1192456,
+    "internal_id": 530696,
     "linked": false
   },
   {
@@ -3082,7 +3082,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-165", "A3b-101"],
     "artist": "SATOSHI NAKAI",
-    "internal_id": 1192584,
+    "internal_id": 530760,
     "linked": false
   },
   {
@@ -3112,7 +3112,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-198", "P-A-62", "A3b-102", "A4b-280", "A4b-281", "A4b-359"],
     "artist": "MAHOU",
-    "internal_id": 1192712,
+    "internal_id": 530824,
     "linked": false
   },
   {
@@ -3148,7 +3148,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-47", "A1-255", "A1-274", "P-A-25", "A3b-103", "A4b-67"],
     "artist": "PLANETA Saito",
-    "internal_id": 1192841,
+    "internal_id": 530889,
     "linked": false
   },
   {
@@ -3184,7 +3184,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-84", "A1-258", "A1-275", "A3b-104", "A4b-101"],
     "artist": "PLANETA Saito",
-    "internal_id": 1192969,
+    "internal_id": 530953,
     "linked": false
   },
   {
@@ -3220,7 +3220,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-104", "A1-260", "A1-276", "A3b-105", "A4b-139"],
     "artist": "PLANETA Saito",
-    "internal_id": 1193097,
+    "internal_id": 531017,
     "linked": false
   },
   {
@@ -3250,7 +3250,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-95", "A2-185", "A2-200", "A3b-106", "A4b-215"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1193225,
+    "internal_id": 531081,
     "linked": false
   },
   {
@@ -3277,7 +3277,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-66", "A3b-107", "A4b-308", "A4b-309"],
     "artist": "AYUMI ODASHIMA",
-    "internal_id": 1193354,
+    "internal_id": 531148,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A4.json
+++ b/frontend/assets/cards/A4.json
@@ -26,7 +26,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-1"],
     "artist": "ryoma uratsuka",
-    "internal_id": 1310849,
+    "internal_id": 589888,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-2"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1310978,
+    "internal_id": 589953,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-3", "A4-163"],
     "artist": "Nagomi Nijo",
-    "internal_id": 1311107,
+    "internal_id": 590018,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-4"],
     "artist": "OOYAMA",
-    "internal_id": 1311233,
+    "internal_id": 590080,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-5"],
     "artist": "tetsuya koizumi",
-    "internal_id": 1311363,
+    "internal_id": 590146,
     "linked": false
   },
   {
@@ -176,7 +176,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-6"],
     "artist": "Narumi Sato",
-    "internal_id": 1311489,
+    "internal_id": 590208,
     "linked": false
   },
   {
@@ -206,7 +206,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-7"],
     "artist": "Toshinao Aoki",
-    "internal_id": 1311617,
+    "internal_id": 590272,
     "linked": false
   },
   {
@@ -236,7 +236,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-8", "A4-162"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1311745,
+    "internal_id": 590336,
     "linked": false
   },
   {
@@ -266,7 +266,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-9"],
     "artist": "Mizue",
-    "internal_id": 1311874,
+    "internal_id": 590401,
     "linked": false
   },
   {
@@ -296,7 +296,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-10"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1312003,
+    "internal_id": 590466,
     "linked": false
   },
   {
@@ -326,7 +326,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-11"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1312129,
+    "internal_id": 590528,
     "linked": false
   },
   {
@@ -356,7 +356,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-12"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 1312257,
+    "internal_id": 590592,
     "linked": false
   },
   {
@@ -386,7 +386,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-13", "A4b-14", "A4b-15"],
     "artist": "Mékayu",
-    "internal_id": 1312385,
+    "internal_id": 590656,
     "linked": false
   },
   {
@@ -416,7 +416,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-14", "A4b-16", "A4b-17"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1312514,
+    "internal_id": 590721,
     "linked": false
   },
   {
@@ -450,7 +450,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-15", "A4b-18", "A4b-19"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1312643,
+    "internal_id": 590786,
     "linked": false
   },
   {
@@ -480,7 +480,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-16"],
     "artist": "0313",
-    "internal_id": 1312769,
+    "internal_id": 590848,
     "linked": false
   },
   {
@@ -510,7 +510,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-17"],
     "artist": "Yumi",
-    "internal_id": 1312898,
+    "internal_id": 590913,
     "linked": false
   },
   {
@@ -540,7 +540,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-18", "A4-212"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1313025,
+    "internal_id": 590976,
     "linked": false
   },
   {
@@ -570,7 +570,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-19"],
     "artist": "Uta",
-    "internal_id": 1313154,
+    "internal_id": 591041,
     "linked": false
   },
   {
@@ -600,7 +600,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-20"],
     "artist": "Suwama Chiaki",
-    "internal_id": 1313281,
+    "internal_id": 591104,
     "linked": false
   },
   {
@@ -634,7 +634,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-21", "A4-186", "A4-202", "A4b-23"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1313412,
+    "internal_id": 591171,
     "linked": false
   },
   {
@@ -664,7 +664,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-22", "A4-164"],
     "artist": "Naoki Saito",
-    "internal_id": 1313539,
+    "internal_id": 591234,
     "linked": false
   },
   {
@@ -698,7 +698,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-23", "A4b-25", "A4b-26"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1313665,
+    "internal_id": 591296,
     "linked": false
   },
   {
@@ -728,7 +728,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-24", "A4b-27", "A4b-28"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1313794,
+    "internal_id": 591361,
     "linked": false
   },
   {
@@ -758,7 +758,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-25"],
     "artist": "Shibuzoh.",
-    "internal_id": 1313921,
+    "internal_id": 591424,
     "linked": false
   },
   {
@@ -788,7 +788,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-26"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1314051,
+    "internal_id": 591490,
     "linked": false
   },
   {
@@ -818,7 +818,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-27", "A4-165"],
     "artist": "kirisAki",
-    "internal_id": 1314177,
+    "internal_id": 591552,
     "linked": false
   },
   {
@@ -848,7 +848,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-28"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1314306,
+    "internal_id": 591617,
     "linked": false
   },
   {
@@ -882,7 +882,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-29"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1314435,
+    "internal_id": 591682,
     "linked": false
   },
   {
@@ -912,7 +912,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-30"],
     "artist": "Mékayu",
-    "internal_id": 1314561,
+    "internal_id": 591744,
     "linked": false
   },
   {
@@ -942,7 +942,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-31"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1314690,
+    "internal_id": 591809,
     "linked": false
   },
   {
@@ -972,7 +972,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-32", "A4-166"],
     "artist": "Yukiko Baba",
-    "internal_id": 1314819,
+    "internal_id": 591874,
     "linked": false
   },
   {
@@ -1002,7 +1002,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-33"],
     "artist": "kodama",
-    "internal_id": 1314947,
+    "internal_id": 591938,
     "linked": false
   },
   {
@@ -1032,7 +1032,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-34", "A4-187", "A4-210", "A4-240", "A4b-68", "A4b-362"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1315076,
+    "internal_id": 592003,
     "linked": false
   },
   {
@@ -1062,7 +1062,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-35"],
     "artist": "Yuka Morii",
-    "internal_id": 1315201,
+    "internal_id": 592064,
     "linked": false
   },
   {
@@ -1092,7 +1092,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-36"],
     "artist": "Naoki Saito",
-    "internal_id": 1315330,
+    "internal_id": 592129,
     "linked": false
   },
   {
@@ -1122,7 +1122,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-37"],
     "artist": "match",
-    "internal_id": 1315457,
+    "internal_id": 592192,
     "linked": false
   },
   {
@@ -1152,7 +1152,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-38"],
     "artist": "Asako Ito",
-    "internal_id": 1315585,
+    "internal_id": 592256,
     "linked": false
   },
   {
@@ -1182,7 +1182,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-39"],
     "artist": "Scav",
-    "internal_id": 1315714,
+    "internal_id": 592321,
     "linked": false
   },
   {
@@ -1216,7 +1216,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-40"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1315843,
+    "internal_id": 592386,
     "linked": false
   },
   {
@@ -1246,7 +1246,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-41", "A4b-88", "A4b-89"],
     "artist": "Yukiko Baba",
-    "internal_id": 1315969,
+    "internal_id": 592448,
     "linked": false
   },
   {
@@ -1276,7 +1276,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-42", "A4b-90", "A4b-91"],
     "artist": "sui",
-    "internal_id": 1316098,
+    "internal_id": 592513,
     "linked": false
   },
   {
@@ -1306,7 +1306,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-43", "A4-188", "A4-203", "A4b-92"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1316228,
+    "internal_id": 592579,
     "linked": false
   },
   {
@@ -1336,7 +1336,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-44"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1316353,
+    "internal_id": 592640,
     "linked": false
   },
   {
@@ -1366,7 +1366,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-45", "A4-215"],
     "artist": "hatachu",
-    "internal_id": 1316483,
+    "internal_id": 592706,
     "linked": false
   },
   {
@@ -1396,7 +1396,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-46", "A4-167"],
     "artist": "kawayoo",
-    "internal_id": 1316609,
+    "internal_id": 592768,
     "linked": false
   },
   {
@@ -1426,7 +1426,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-47"],
     "artist": "Naoki Saito",
-    "internal_id": 1316738,
+    "internal_id": 592833,
     "linked": false
   },
   {
@@ -1456,7 +1456,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-48"],
     "artist": "nagimiso",
-    "internal_id": 1316867,
+    "internal_id": 592898,
     "linked": false
   },
   {
@@ -1486,7 +1486,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-49", "P-A-99"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1316993,
+    "internal_id": 592960,
     "linked": false
   },
   {
@@ -1520,7 +1520,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-50"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1317122,
+    "internal_id": 593025,
     "linked": false
   },
   {
@@ -1550,7 +1550,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-51"],
     "artist": "Shibuzoh.",
-    "internal_id": 1317249,
+    "internal_id": 593088,
     "linked": false
   },
   {
@@ -1580,7 +1580,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-52"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1317378,
+    "internal_id": 593153,
     "linked": false
   },
   {
@@ -1610,7 +1610,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-53", "A4-168"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1317506,
+    "internal_id": 593217,
     "linked": false
   },
   {
@@ -1640,7 +1640,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-54"],
     "artist": "Mékayu",
-    "internal_id": 1317633,
+    "internal_id": 593280,
     "linked": false
   },
   {
@@ -1670,7 +1670,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-55"],
     "artist": "Suwama Chiaki",
-    "internal_id": 1317761,
+    "internal_id": 593344,
     "linked": false
   },
   {
@@ -1700,7 +1700,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-56", "A4-169"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1317891,
+    "internal_id": 593410,
     "linked": false
   },
   {
@@ -1730,7 +1730,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-57", "A4-170"],
     "artist": "Narumi Sato",
-    "internal_id": 1318018,
+    "internal_id": 593473,
     "linked": false
   },
   {
@@ -1760,7 +1760,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-58"],
     "artist": "0313",
-    "internal_id": 1318146,
+    "internal_id": 593537,
     "linked": false
   },
   {
@@ -1790,7 +1790,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-59"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 1318275,
+    "internal_id": 593602,
     "linked": false
   },
   {
@@ -1820,7 +1820,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-60", "A4b-102", "A4b-103"],
     "artist": "chibi",
-    "internal_id": 1318401,
+    "internal_id": 593664,
     "linked": false
   },
   {
@@ -1854,7 +1854,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-61", "A4b-104", "A4b-105", "A4b-355"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1318531,
+    "internal_id": 593730,
     "linked": false
   },
   {
@@ -1884,7 +1884,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-62"],
     "artist": "MAHOU",
-    "internal_id": 1318657,
+    "internal_id": 593792,
     "linked": false
   },
   {
@@ -1914,7 +1914,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-63"],
     "artist": "chibi",
-    "internal_id": 1318786,
+    "internal_id": 593857,
     "linked": false
   },
   {
@@ -1944,7 +1944,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-64", "A4b-140", "A4b-141"],
     "artist": "Miki Tanaka",
-    "internal_id": 1318913,
+    "internal_id": 593920,
     "linked": false
   },
   {
@@ -1974,7 +1974,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-65", "A4-189", "A4-204", "A4b-142"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1319044,
+    "internal_id": 593987,
     "linked": false
   },
   {
@@ -2004,7 +2004,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-66", "A4-171"],
     "artist": "Kariya",
-    "internal_id": 1319171,
+    "internal_id": 594050,
     "linked": false
   },
   {
@@ -2034,7 +2034,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-67"],
     "artist": "0313",
-    "internal_id": 1319297,
+    "internal_id": 594112,
     "linked": false
   },
   {
@@ -2064,7 +2064,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-68"],
     "artist": "MAHOU",
-    "internal_id": 1319426,
+    "internal_id": 594177,
     "linked": false
   },
   {
@@ -2094,7 +2094,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-69", "A4-172"],
     "artist": "Kouki Saitou",
-    "internal_id": 1319555,
+    "internal_id": 594242,
     "linked": false
   },
   {
@@ -2124,7 +2124,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-70"],
     "artist": "Miki Tanaka",
-    "internal_id": 1319683,
+    "internal_id": 594306,
     "linked": false
   },
   {
@@ -2154,7 +2154,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-71"],
     "artist": "Kazumasa Yasukuni",
-    "internal_id": 1319811,
+    "internal_id": 594370,
     "linked": false
   },
   {
@@ -2184,7 +2184,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-72"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1319937,
+    "internal_id": 594432,
     "linked": false
   },
   {
@@ -2214,7 +2214,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-73"],
     "artist": "Aya Kusube",
-    "internal_id": 1320065,
+    "internal_id": 594496,
     "linked": false
   },
   {
@@ -2244,7 +2244,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-74"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1320194,
+    "internal_id": 594561,
     "linked": false
   },
   {
@@ -2274,7 +2274,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-75"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1320323,
+    "internal_id": 594626,
     "linked": false
   },
   {
@@ -2304,7 +2304,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-76"],
     "artist": "Midori Harada",
-    "internal_id": 1320449,
+    "internal_id": 594688,
     "linked": false
   },
   {
@@ -2334,7 +2334,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-77", "P-A-93"],
     "artist": "Orca",
-    "internal_id": 1320579,
+    "internal_id": 594754,
     "linked": false
   },
   {
@@ -2364,7 +2364,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-78", "A4-173"],
     "artist": "Sekio",
-    "internal_id": 1320705,
+    "internal_id": 594816,
     "linked": false
   },
   {
@@ -2394,7 +2394,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-79"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1320834,
+    "internal_id": 594881,
     "linked": false
   },
   {
@@ -2428,7 +2428,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-80"],
     "artist": "sui",
-    "internal_id": 1320963,
+    "internal_id": 594946,
     "linked": false
   },
   {
@@ -2458,7 +2458,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-81"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1321089,
+    "internal_id": 595008,
     "linked": false
   },
   {
@@ -2488,7 +2488,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-82", "A4-174"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1321219,
+    "internal_id": 595074,
     "linked": false
   },
   {
@@ -2522,7 +2522,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-83", "A4-190", "A4-205", "A4b-160"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1321348,
+    "internal_id": 595139,
     "linked": false
   },
   {
@@ -2556,7 +2556,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-84"],
     "artist": "OKUBO",
-    "internal_id": 1321475,
+    "internal_id": 595202,
     "linked": false
   },
   {
@@ -2590,7 +2590,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-85"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 1321603,
+    "internal_id": 595266,
     "linked": false
   },
   {
@@ -2620,7 +2620,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-86", "A4-175"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1321729,
+    "internal_id": 595328,
     "linked": false
   },
   {
@@ -2650,7 +2650,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-87"],
     "artist": "Miki Tanaka",
-    "internal_id": 1321857,
+    "internal_id": 595392,
     "linked": false
   },
   {
@@ -2680,7 +2680,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-88"],
     "artist": "Akira Komayama",
-    "internal_id": 1321985,
+    "internal_id": 595456,
     "linked": false
   },
   {
@@ -2710,7 +2710,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-89"],
     "artist": "Suwama Chiaki",
-    "internal_id": 1322114,
+    "internal_id": 595521,
     "linked": false
   },
   {
@@ -2740,7 +2740,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-90"],
     "artist": "miki kudo",
-    "internal_id": 1322241,
+    "internal_id": 595584,
     "linked": false
   },
   {
@@ -2770,7 +2770,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-91"],
     "artist": "MAHOU",
-    "internal_id": 1322370,
+    "internal_id": 595649,
     "linked": false
   },
   {
@@ -2800,7 +2800,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-92"],
     "artist": "KEIICHIRO ITO",
-    "internal_id": 1322497,
+    "internal_id": 595712,
     "linked": false
   },
   {
@@ -2830,7 +2830,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-93"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1322625,
+    "internal_id": 595776,
     "linked": false
   },
   {
@@ -2860,7 +2860,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-94", "A4-176"],
     "artist": "Mina Nakai",
-    "internal_id": 1322753,
+    "internal_id": 595840,
     "linked": false
   },
   {
@@ -2890,7 +2890,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-95"],
     "artist": "Shiburingaru",
-    "internal_id": 1322882,
+    "internal_id": 595905,
     "linked": false
   },
   {
@@ -2920,7 +2920,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-96"],
     "artist": "Yukiko Baba",
-    "internal_id": 1323009,
+    "internal_id": 595968,
     "linked": false
   },
   {
@@ -2950,7 +2950,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-97"],
     "artist": "Midori Harada",
-    "internal_id": 1323138,
+    "internal_id": 596033,
     "linked": false
   },
   {
@@ -2980,7 +2980,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-98"],
     "artist": "Uta",
-    "internal_id": 1323267,
+    "internal_id": 596098,
     "linked": false
   },
   {
@@ -3010,7 +3010,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-99", "A4b-200", "A4b-201"],
     "artist": "Midori Harada",
-    "internal_id": 1323393,
+    "internal_id": 596160,
     "linked": false
   },
   {
@@ -3040,7 +3040,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-100", "A4-191", "A4-206", "A4b-202"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1323524,
+    "internal_id": 596227,
     "linked": false
   },
   {
@@ -3070,7 +3070,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-101"],
     "artist": "Mina Nakai",
-    "internal_id": 1323651,
+    "internal_id": 596290,
     "linked": false
   },
   {
@@ -3100,7 +3100,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-102"],
     "artist": "Hisao Nakamura",
-    "internal_id": 1323777,
+    "internal_id": 596352,
     "linked": false
   },
   {
@@ -3130,7 +3130,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-103"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1323905,
+    "internal_id": 596416,
     "linked": false
   },
   {
@@ -3160,7 +3160,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-104"],
     "artist": "Sekio",
-    "internal_id": 1324034,
+    "internal_id": 596481,
     "linked": false
   },
   {
@@ -3190,7 +3190,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-105"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1324161,
+    "internal_id": 596544,
     "linked": false
   },
   {
@@ -3220,7 +3220,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-106"],
     "artist": "Nurikabe",
-    "internal_id": 1324290,
+    "internal_id": 596609,
     "linked": false
   },
   {
@@ -3250,7 +3250,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-107"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1324417,
+    "internal_id": 596672,
     "linked": false
   },
   {
@@ -3280,7 +3280,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-108"],
     "artist": "kawayoo",
-    "internal_id": 1324546,
+    "internal_id": 596737,
     "linked": false
   },
   {
@@ -3310,7 +3310,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-109", "A4-192", "A4-207", "A4b-232"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1324676,
+    "internal_id": 596803,
     "linked": false
   },
   {
@@ -3340,7 +3340,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-110", "A4-177"],
     "artist": "Sachiko Adachi",
-    "internal_id": 1324801,
+    "internal_id": 596864,
     "linked": false
   },
   {
@@ -3370,7 +3370,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-111"],
     "artist": "Shinji Kanda",
-    "internal_id": 1324930,
+    "internal_id": 596929,
     "linked": false
   },
   {
@@ -3404,7 +3404,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-112", "A4-193", "A4-208", "A4b-241"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1325060,
+    "internal_id": 596995,
     "linked": false
   },
   {
@@ -3434,7 +3434,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-113", "A4-178"],
     "artist": "Sekio",
-    "internal_id": 1325185,
+    "internal_id": 597056,
     "linked": false
   },
   {
@@ -3464,7 +3464,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-114"],
     "artist": "Shiburingaru",
-    "internal_id": 1325314,
+    "internal_id": 597121,
     "linked": false
   },
   {
@@ -3494,7 +3494,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-115", "A4-229"],
     "artist": "yuu",
-    "internal_id": 1325441,
+    "internal_id": 597184,
     "linked": false
   },
   {
@@ -3524,7 +3524,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-116", "P-A-100"],
     "artist": "kawayoo",
-    "internal_id": 1325570,
+    "internal_id": 597249,
     "linked": false
   },
   {
@@ -3554,7 +3554,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-117"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1325697,
+    "internal_id": 597312,
     "linked": false
   },
   {
@@ -3584,7 +3584,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-118", "P-A-96"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1325826,
+    "internal_id": 597377,
     "linked": false
   },
   {
@@ -3618,7 +3618,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-119", "A4-179"],
     "artist": "Hasuno",
-    "internal_id": 1325955,
+    "internal_id": 597442,
     "linked": false
   },
   {
@@ -3648,7 +3648,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-120", "P-A-117"],
     "artist": "kodama",
-    "internal_id": 1326082,
+    "internal_id": 597505,
     "linked": false
   },
   {
@@ -3678,7 +3678,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-121"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1326210,
+    "internal_id": 597569,
     "linked": false
   },
   {
@@ -3708,7 +3708,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-122"],
     "artist": "KEIICHIRO ITO",
-    "internal_id": 1326339,
+    "internal_id": 597634,
     "linked": false
   },
   {
@@ -3738,7 +3738,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-123", "A4-180"],
     "artist": "Ryuta Fuse",
-    "internal_id": 1326467,
+    "internal_id": 597698,
     "linked": false
   },
   {
@@ -3768,7 +3768,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-124", "A4-194", "A4-209", "A4b-252"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1326596,
+    "internal_id": 597763,
     "linked": false
   },
   {
@@ -3798,7 +3798,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-125"],
     "artist": "Kouki Saitou",
-    "internal_id": 1326721,
+    "internal_id": 597824,
     "linked": false
   },
   {
@@ -3828,7 +3828,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-126"],
     "artist": "Akira Komayama",
-    "internal_id": 1326849,
+    "internal_id": 597888,
     "linked": false
   },
   {
@@ -3858,7 +3858,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-127"],
     "artist": "Akira Komayama",
-    "internal_id": 1326978,
+    "internal_id": 597953,
     "linked": false
   },
   {
@@ -3888,7 +3888,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-128"],
     "artist": "Akira Komayama",
-    "internal_id": 1327107,
+    "internal_id": 598018,
     "linked": false
   },
   {
@@ -3918,7 +3918,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-129"],
     "artist": "tetsuya koizumi",
-    "internal_id": 1327233,
+    "internal_id": 598080,
     "linked": false
   },
   {
@@ -3948,7 +3948,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-130"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1327361,
+    "internal_id": 598144,
     "linked": false
   },
   {
@@ -3978,7 +3978,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-131"],
     "artist": "miki kudo",
-    "internal_id": 1327489,
+    "internal_id": 598208,
     "linked": false
   },
   {
@@ -4008,7 +4008,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-132", "A4-185"],
     "artist": "Mizue",
-    "internal_id": 1327619,
+    "internal_id": 598274,
     "linked": false
   },
   {
@@ -4038,7 +4038,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-133", "P-A-97"],
     "artist": "Toshinao Aoki",
-    "internal_id": 1327747,
+    "internal_id": 598338,
     "linked": false
   },
   {
@@ -4068,7 +4068,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-134", "A4-231"],
     "artist": "sowsow",
-    "internal_id": 1327873,
+    "internal_id": 598400,
     "linked": false
   },
   {
@@ -4098,7 +4098,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-135"],
     "artist": "ryoma uratsuka",
-    "internal_id": 1328001,
+    "internal_id": 598464,
     "linked": false
   },
   {
@@ -4132,7 +4132,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-136"],
     "artist": "Nagomi Nijo",
-    "internal_id": 1328130,
+    "internal_id": 598529,
     "linked": false
   },
   {
@@ -4162,7 +4162,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-137"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1328259,
+    "internal_id": 598594,
     "linked": false
   },
   {
@@ -4192,7 +4192,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-138", "A4-181"],
     "artist": "Mina Nakai",
-    "internal_id": 1328385,
+    "internal_id": 598656,
     "linked": false
   },
   {
@@ -4222,7 +4222,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-139"],
     "artist": "tetsuya koizumi",
-    "internal_id": 1328513,
+    "internal_id": 598720,
     "linked": false
   },
   {
@@ -4256,7 +4256,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-140", "A4-182"],
     "artist": "Yumi",
-    "internal_id": 1328641,
+    "internal_id": 598784,
     "linked": false
   },
   {
@@ -4286,7 +4286,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-141"],
     "artist": "Nisota Niso",
-    "internal_id": 1328769,
+    "internal_id": 598848,
     "linked": false
   },
   {
@@ -4316,7 +4316,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-142"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1328897,
+    "internal_id": 598912,
     "linked": false
   },
   {
@@ -4346,7 +4346,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-143"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 1329025,
+    "internal_id": 598976,
     "linked": false
   },
   {
@@ -4376,7 +4376,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-144"],
     "artist": "Kazuma Koda",
-    "internal_id": 1329153,
+    "internal_id": 599040,
     "linked": false
   },
   {
@@ -4406,7 +4406,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-145"],
     "artist": "Mizue",
-    "internal_id": 1329281,
+    "internal_id": 599104,
     "linked": false
   },
   {
@@ -4436,7 +4436,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-146"],
     "artist": "Kouki Saitou",
-    "internal_id": 1329410,
+    "internal_id": 599169,
     "linked": false
   },
   {
@@ -4466,7 +4466,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-147", "A4-183"],
     "artist": "sui",
-    "internal_id": 1329538,
+    "internal_id": 599233,
     "linked": false
   },
   {
@@ -4496,7 +4496,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-148", "A4-184"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1329666,
+    "internal_id": 599297,
     "linked": false
   },
   {
@@ -4526,7 +4526,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-149", "A4-195", "A4-211", "A4-241", "A4b-289", "A4b-371"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1329796,
+    "internal_id": 599363,
     "linked": false
   },
   {
@@ -4556,7 +4556,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-150"],
     "artist": "nagimiso",
-    "internal_id": 1329922,
+    "internal_id": 599425,
     "linked": false
   },
   {
@@ -4583,7 +4583,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-151", "A4b-310", "A4b-311"],
     "artist": "Toyste Beach",
-    "internal_id": 1330050,
+    "internal_id": 599489,
     "linked": false
   },
   {
@@ -4610,7 +4610,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-152"],
     "artist": "AYUMI ODASHIMA",
-    "internal_id": 1330178,
+    "internal_id": 599553,
     "linked": false
   },
   {
@@ -4637,7 +4637,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-153"],
     "artist": "Studio Bora Inc.",
-    "internal_id": 1330306,
+    "internal_id": 599617,
     "linked": false
   },
   {
@@ -4664,7 +4664,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-154"],
     "artist": "Toyste Beach",
-    "internal_id": 1330434,
+    "internal_id": 599681,
     "linked": false
   },
   {
@@ -4691,7 +4691,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-155"],
     "artist": "Ryo Ueda",
-    "internal_id": 1330562,
+    "internal_id": 599745,
     "linked": false
   },
   {
@@ -4718,7 +4718,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-156", "A4-196"],
     "artist": "GIDORA",
-    "internal_id": 1330690,
+    "internal_id": 599809,
     "linked": false
   },
   {
@@ -4745,7 +4745,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-157", "A4-197", "A4b-332", "A4b-333"],
     "artist": "yuu",
-    "internal_id": 1330818,
+    "internal_id": 599873,
     "linked": false
   },
   {
@@ -4772,7 +4772,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-158", "A4-198", "A4b-336", "A4b-337"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1330946,
+    "internal_id": 599937,
     "linked": false
   },
   {
@@ -4799,7 +4799,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-159", "A4-199"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1331074,
+    "internal_id": 600001,
     "linked": false
   },
   {
@@ -4826,7 +4826,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-160", "A4-200"],
     "artist": "En Morikura",
-    "internal_id": 1331202,
+    "internal_id": 600065,
     "linked": false
   },
   {
@@ -4853,7 +4853,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-161", "A4-201"],
     "artist": "Hitoshi Ariga",
-    "internal_id": 1331330,
+    "internal_id": 600129,
     "linked": false
   },
   {
@@ -4883,7 +4883,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-8", "A4-162"],
     "artist": "Keisin",
-    "internal_id": 1331461,
+    "internal_id": 600196,
     "linked": false
   },
   {
@@ -4913,7 +4913,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-3", "A4-163"],
     "artist": "Yuka Tanaka",
-    "internal_id": 1331589,
+    "internal_id": 600260,
     "linked": false
   },
   {
@@ -4943,7 +4943,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-22", "A4-164"],
     "artist": "GOSSAN",
-    "internal_id": 1331717,
+    "internal_id": 600324,
     "linked": false
   },
   {
@@ -4973,7 +4973,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-27", "A4-165"],
     "artist": "buchi",
-    "internal_id": 1331845,
+    "internal_id": 600388,
     "linked": false
   },
   {
@@ -5003,7 +5003,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-32", "A4-166"],
     "artist": "Makura Tami",
-    "internal_id": 1331973,
+    "internal_id": 600452,
     "linked": false
   },
   {
@@ -5033,7 +5033,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-46", "A4-167"],
     "artist": "Ayako Ozaki",
-    "internal_id": 1332101,
+    "internal_id": 600516,
     "linked": false
   },
   {
@@ -5063,7 +5063,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-53", "A4-168"],
     "artist": "June",
-    "internal_id": 1332229,
+    "internal_id": 600580,
     "linked": false
   },
   {
@@ -5093,7 +5093,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-56", "A4-169"],
     "artist": "REND",
-    "internal_id": 1332357,
+    "internal_id": 600644,
     "linked": false
   },
   {
@@ -5123,7 +5123,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-57", "A4-170"],
     "artist": "Mékayu",
-    "internal_id": 1332485,
+    "internal_id": 600708,
     "linked": false
   },
   {
@@ -5153,7 +5153,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-66", "A4-171"],
     "artist": "Kanami Ogata",
-    "internal_id": 1332613,
+    "internal_id": 600772,
     "linked": false
   },
   {
@@ -5183,7 +5183,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-69", "A4-172"],
     "artist": "Whisker",
-    "internal_id": 1332741,
+    "internal_id": 600836,
     "linked": false
   },
   {
@@ -5213,7 +5213,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-78", "A4-173"],
     "artist": "Terada Tera",
-    "internal_id": 1332869,
+    "internal_id": 600900,
     "linked": false
   },
   {
@@ -5243,7 +5243,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-82", "A4-174"],
     "artist": "Masako Tomii",
-    "internal_id": 1332997,
+    "internal_id": 600964,
     "linked": false
   },
   {
@@ -5273,7 +5273,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-86", "A4-175"],
     "artist": "GOTO minori",
-    "internal_id": 1333125,
+    "internal_id": 601028,
     "linked": false
   },
   {
@@ -5303,7 +5303,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-94", "A4-176"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 1333253,
+    "internal_id": 601092,
     "linked": false
   },
   {
@@ -5333,7 +5333,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-110", "A4-177"],
     "artist": "IKEDA Saki",
-    "internal_id": 1333381,
+    "internal_id": 601156,
     "linked": false
   },
   {
@@ -5363,7 +5363,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-113", "A4-178"],
     "artist": "kamonabe",
-    "internal_id": 1333509,
+    "internal_id": 601220,
     "linked": false
   },
   {
@@ -5397,7 +5397,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-119", "A4-179"],
     "artist": "Saboteri",
-    "internal_id": 1333637,
+    "internal_id": 601284,
     "linked": false
   },
   {
@@ -5427,7 +5427,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-123", "A4-180"],
     "artist": "danciao",
-    "internal_id": 1333765,
+    "internal_id": 601348,
     "linked": false
   },
   {
@@ -5457,7 +5457,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-138", "A4-181"],
     "artist": "saino misaki",
-    "internal_id": 1333893,
+    "internal_id": 601412,
     "linked": false
   },
   {
@@ -5491,7 +5491,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-140", "A4-182"],
     "artist": "Uninori",
-    "internal_id": 1334021,
+    "internal_id": 601476,
     "linked": false
   },
   {
@@ -5521,7 +5521,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-147", "A4-183"],
     "artist": "Noriaki Tanimura",
-    "internal_id": 1334149,
+    "internal_id": 601540,
     "linked": false
   },
   {
@@ -5551,7 +5551,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-148", "A4-184"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 1334277,
+    "internal_id": 601604,
     "linked": false
   },
   {
@@ -5581,7 +5581,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-132", "A4-185"],
     "artist": "Natsumi Yoshida",
-    "internal_id": 1334405,
+    "internal_id": 601668,
     "linked": false
   },
   {
@@ -5615,7 +5615,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-21", "A4-186", "A4-202", "A4b-23"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1334534,
+    "internal_id": 601733,
     "linked": false
   },
   {
@@ -5645,7 +5645,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-34", "A4-187", "A4-210", "A4-240", "A4b-68", "A4b-362"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1334662,
+    "internal_id": 601797,
     "linked": false
   },
   {
@@ -5675,7 +5675,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-43", "A4-188", "A4-203", "A4b-92"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1334790,
+    "internal_id": 601861,
     "linked": false
   },
   {
@@ -5705,7 +5705,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-65", "A4-189", "A4-204", "A4b-142"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1334918,
+    "internal_id": 601925,
     "linked": false
   },
   {
@@ -5739,7 +5739,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-83", "A4-190", "A4-205", "A4b-160"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1335046,
+    "internal_id": 601989,
     "linked": false
   },
   {
@@ -5769,7 +5769,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-100", "A4-191", "A4-206", "A4b-202"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1335174,
+    "internal_id": 602053,
     "linked": false
   },
   {
@@ -5799,7 +5799,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-109", "A4-192", "A4-207", "A4b-232"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1335302,
+    "internal_id": 602117,
     "linked": false
   },
   {
@@ -5833,7 +5833,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-112", "A4-193", "A4-208", "A4b-241"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1335430,
+    "internal_id": 602181,
     "linked": false
   },
   {
@@ -5863,7 +5863,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-124", "A4-194", "A4-209", "A4b-252"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1335558,
+    "internal_id": 602245,
     "linked": false
   },
   {
@@ -5893,7 +5893,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-149", "A4-195", "A4-211", "A4-241", "A4b-289", "A4b-371"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1335686,
+    "internal_id": 602309,
     "linked": false
   },
   {
@@ -5920,7 +5920,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-156", "A4-196"],
     "artist": "GIDORA",
-    "internal_id": 1335814,
+    "internal_id": 602373,
     "linked": false
   },
   {
@@ -5947,7 +5947,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-157", "A4-197", "A4b-332", "A4b-333"],
     "artist": "yuu",
-    "internal_id": 1335942,
+    "internal_id": 602437,
     "linked": false
   },
   {
@@ -5974,7 +5974,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-158", "A4-198", "A4b-336", "A4b-337"],
     "artist": "Teeziro",
-    "internal_id": 1336070,
+    "internal_id": 602501,
     "linked": false
   },
   {
@@ -6001,7 +6001,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-159", "A4-199"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 1336198,
+    "internal_id": 602565,
     "linked": false
   },
   {
@@ -6028,7 +6028,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-160", "A4-200"],
     "artist": "En Morikura",
-    "internal_id": 1336326,
+    "internal_id": 602629,
     "linked": false
   },
   {
@@ -6055,7 +6055,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-161", "A4-201"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1336454,
+    "internal_id": 602693,
     "linked": false
   },
   {
@@ -6089,7 +6089,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-21", "A4-186", "A4-202", "A4b-23"],
     "artist": "Yoshimi Miyoshi",
-    "internal_id": 1336582,
+    "internal_id": 602757,
     "linked": false
   },
   {
@@ -6119,7 +6119,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-43", "A4-188", "A4-203", "A4b-92"],
     "artist": "Takumi Wada",
-    "internal_id": 1336710,
+    "internal_id": 602821,
     "linked": false
   },
   {
@@ -6149,7 +6149,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-65", "A4-189", "A4-204", "A4b-142"],
     "artist": "Fujimoto Gold",
-    "internal_id": 1336838,
+    "internal_id": 602885,
     "linked": false
   },
   {
@@ -6183,7 +6183,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-83", "A4-190", "A4-205", "A4b-160"],
     "artist": "Taira Akitsu",
-    "internal_id": 1336966,
+    "internal_id": 602949,
     "linked": false
   },
   {
@@ -6213,7 +6213,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-100", "A4-191", "A4-206", "A4b-202"],
     "artist": "Yuriko Akase",
-    "internal_id": 1337094,
+    "internal_id": 603013,
     "linked": false
   },
   {
@@ -6243,7 +6243,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-109", "A4-192", "A4-207", "A4b-232"],
     "artist": "Shinji Kanda",
-    "internal_id": 1337222,
+    "internal_id": 603077,
     "linked": false
   },
   {
@@ -6277,7 +6277,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-112", "A4-193", "A4-208", "A4b-241"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1337350,
+    "internal_id": 603141,
     "linked": false
   },
   {
@@ -6307,7 +6307,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-124", "A4-194", "A4-209", "A4b-252"],
     "artist": "toriyufu",
-    "internal_id": 1337478,
+    "internal_id": 603205,
     "linked": false
   },
   {
@@ -6337,7 +6337,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-34", "A4-187", "A4-210", "A4-240", "A4b-68", "A4b-362"],
     "artist": "SIE NANAHARA",
-    "internal_id": 1337607,
+    "internal_id": 603270,
     "linked": false
   },
   {
@@ -6367,7 +6367,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-149", "A4-195", "A4-211", "A4-241", "A4b-289", "A4b-371"],
     "artist": "SIE NANAHARA",
-    "internal_id": 1337735,
+    "internal_id": 603334,
     "linked": false
   },
   {
@@ -6397,7 +6397,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-18", "A4-212"],
     "artist": "MAHOU",
-    "internal_id": 1337864,
+    "internal_id": 603400,
     "linked": false
   },
   {
@@ -6427,7 +6427,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A3b-8", "A3b-71", "A4-213", "A4b-64", "A4b-65"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1337992,
+    "internal_id": 603464,
     "linked": false
   },
   {
@@ -6457,7 +6457,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1a-17", "A4-214", "A4b-96", "A4b-97"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1338120,
+    "internal_id": 603528,
     "linked": false
   },
   {
@@ -6487,7 +6487,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-45", "A4-215"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1338248,
+    "internal_id": 603592,
     "linked": false
   },
   {
@@ -6517,7 +6517,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1-80", "A4-216"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1338376,
+    "internal_id": 603656,
     "linked": false
   },
   {
@@ -6547,7 +6547,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1-97", "P-A-24", "A4-217", "A4b-133", "A4b-134"],
     "artist": "MAHOU",
-    "internal_id": 1338504,
+    "internal_id": 603720,
     "linked": false
   },
   {
@@ -6581,7 +6581,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1-98", "A4-218", "A4b-135", "A4b-136"],
     "artist": "MAHOU",
-    "internal_id": 1338632,
+    "internal_id": 603784,
     "linked": false
   },
   {
@@ -6611,7 +6611,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A3b-25", "A3b-74", "P-A-86", "A4-219"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1338760,
+    "internal_id": 603848,
     "linked": false
   },
   {
@@ -6641,7 +6641,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A2-66", "A4-220", "A4b-161", "A4b-162"],
     "artist": "MAHOU",
-    "internal_id": 1338888,
+    "internal_id": 603912,
     "linked": false
   },
   {
@@ -6671,7 +6671,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A1a-41", "A4-221"],
     "artist": "MAHOU",
-    "internal_id": 1339016,
+    "internal_id": 603976,
     "linked": false
   },
   {
@@ -6701,7 +6701,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A1-142", "A4-222"],
     "artist": "MAHOU",
-    "internal_id": 1339144,
+    "internal_id": 604040,
     "linked": false
   },
   {
@@ -6731,7 +6731,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1-166", "A4-223"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1339272,
+    "internal_id": 604104,
     "linked": false
   },
   {
@@ -6761,7 +6761,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1-167", "A4-224"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1339400,
+    "internal_id": 604168,
     "linked": false
   },
   {
@@ -6791,7 +6791,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1-168", "A1-240", "A4-225"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1339528,
+    "internal_id": 604232,
     "linked": false
   },
   {
@@ -6821,7 +6821,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A1-169", "A4-226"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1339656,
+    "internal_id": 604296,
     "linked": false
   },
   {
@@ -6851,7 +6851,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A1-170", "A4-227"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1339784,
+    "internal_id": 604360,
     "linked": false
   },
   {
@@ -6881,7 +6881,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A1-171", "A1-241", "A4-228"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1339912,
+    "internal_id": 604424,
     "linked": false
   },
   {
@@ -6911,7 +6911,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A4-115", "A4-229"],
     "artist": "MAHOU",
-    "internal_id": 1340040,
+    "internal_id": 604488,
     "linked": false
   },
   {
@@ -6941,7 +6941,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A2-124", "A4-230", "A4b-282", "A4b-283"],
     "artist": "MAHOU",
-    "internal_id": 1340168,
+    "internal_id": 604552,
     "linked": false
   },
   {
@@ -6971,7 +6971,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A4-134", "A4-231"],
     "artist": "MAHOU",
-    "internal_id": 1340296,
+    "internal_id": 604616,
     "linked": false
   },
   {
@@ -7001,7 +7001,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A2-7", "A2-180", "A2-196", "A4-232", "A4b-22"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1340425,
+    "internal_id": 604681,
     "linked": false
   },
   {
@@ -7035,7 +7035,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A2a-10", "A2a-82", "A2a-91", "A4-233", "A4b-29"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1340553,
+    "internal_id": 604745,
     "linked": false
   },
   {
@@ -7065,7 +7065,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A1a-18", "A1a-76", "A4-234", "A4b-98"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1340681,
+    "internal_id": 604809,
     "linked": false
   },
   {
@@ -7099,7 +7099,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A2a-22", "A2a-83", "A2a-92", "A4-235", "A4b-106"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1340809,
+    "internal_id": 604873,
     "linked": false
   },
   {
@@ -7129,7 +7129,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A2-61", "A2-183", "A2-198", "A4-236", "A4b-145"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1340937,
+    "internal_id": 604937,
     "linked": false
   },
   {
@@ -7159,7 +7159,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A2-67", "A2-184", "A2-199", "A4-237", "A4b-163"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1341065,
+    "internal_id": 605001,
     "linked": false
   },
   {
@@ -7189,7 +7189,7 @@
     "pack": "lugiapack",
     "alternate_versions": ["A2-99", "A2-186", "A2-201", "A4-238", "A4b-244"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1341193,
+    "internal_id": 605065,
     "linked": false
   },
   {
@@ -7219,7 +7219,7 @@
     "pack": "ho-ohpack",
     "alternate_versions": ["A2-125", "A2-189", "A2-203", "A4-239", "A4b-284"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1341321,
+    "internal_id": 605129,
     "linked": false
   },
   {
@@ -7249,7 +7249,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-34", "A4-187", "A4-210", "A4-240", "A4b-68", "A4b-362"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1341450,
+    "internal_id": 605196,
     "linked": false
   },
   {
@@ -7279,7 +7279,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-149", "A4-195", "A4-211", "A4-241", "A4b-289", "A4b-371"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1341578,
+    "internal_id": 605260,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A4a.json
+++ b/frontend/assets/cards/A4a.json
@@ -26,7 +26,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-1"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1441921,
+    "internal_id": 655424,
     "linked": false
   },
   {
@@ -56,7 +56,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-2"],
     "artist": "Dsuke",
-    "internal_id": 1442050,
+    "internal_id": 655489,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-3", "A4a-78", "A4a-86"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1442180,
+    "internal_id": 655555,
     "linked": false
   },
   {
@@ -116,7 +116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-4"],
     "artist": "Toshinao Aoki",
-    "internal_id": 1442305,
+    "internal_id": 655616,
     "linked": false
   },
   {
@@ -146,7 +146,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-5"],
     "artist": "Miki Tanaka",
-    "internal_id": 1442434,
+    "internal_id": 655681,
     "linked": false
   },
   {
@@ -176,7 +176,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-6"],
     "artist": "Yuu Nishida",
-    "internal_id": 1442563,
+    "internal_id": 655746,
     "linked": false
   },
   {
@@ -206,7 +206,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-7"],
     "artist": "Midori Harada",
-    "internal_id": 1442689,
+    "internal_id": 655808,
     "linked": false
   },
   {
@@ -236,7 +236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-8"],
     "artist": "Yukiko Baba",
-    "internal_id": 1442817,
+    "internal_id": 655872,
     "linked": false
   },
   {
@@ -266,7 +266,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-9"],
     "artist": "Eri Yamaki",
-    "internal_id": 1442946,
+    "internal_id": 655937,
     "linked": false
   },
   {
@@ -300,7 +300,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-10", "A4a-79", "A4a-87", "P-A-110"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1443076,
+    "internal_id": 656003,
     "linked": false
   },
   {
@@ -330,7 +330,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-11"],
     "artist": "5ban Graphics",
-    "internal_id": 1443201,
+    "internal_id": 656064,
     "linked": false
   },
   {
@@ -360,7 +360,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-12"],
     "artist": "5ban Graphics",
-    "internal_id": 1443330,
+    "internal_id": 656129,
     "linked": false
   },
   {
@@ -390,7 +390,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-13"],
     "artist": "Yuka Morii",
-    "internal_id": 1443457,
+    "internal_id": 656192,
     "linked": false
   },
   {
@@ -420,7 +420,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-14"],
     "artist": "Kanako Eo",
-    "internal_id": 1443586,
+    "internal_id": 656257,
     "linked": false
   },
   {
@@ -450,7 +450,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-15"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1443713,
+    "internal_id": 656320,
     "linked": false
   },
   {
@@ -480,7 +480,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-16"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1443842,
+    "internal_id": 656385,
     "linked": false
   },
   {
@@ -510,7 +510,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-17"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1443969,
+    "internal_id": 656448,
     "linked": false
   },
   {
@@ -540,7 +540,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-18"],
     "artist": "Aya Kusube",
-    "internal_id": 1444098,
+    "internal_id": 656513,
     "linked": false
   },
   {
@@ -570,7 +570,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-19"],
     "artist": "Yukiko Baba",
-    "internal_id": 1444225,
+    "internal_id": 656576,
     "linked": false
   },
   {
@@ -604,7 +604,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-20", "A4a-80", "A4a-90"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1444356,
+    "internal_id": 656643,
     "linked": false
   },
   {
@@ -634,7 +634,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-21"],
     "artist": "Suwama Chiaki",
-    "internal_id": 1444481,
+    "internal_id": 656704,
     "linked": false
   },
   {
@@ -668,7 +668,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-22", "A4a-72", "P-A-104"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1444611,
+    "internal_id": 656770,
     "linked": false
   },
   {
@@ -698,7 +698,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-23", "A4a-105"],
     "artist": "Shibuzoh.",
-    "internal_id": 1444739,
+    "internal_id": 656834,
     "linked": false
   },
   {
@@ -728,7 +728,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-24"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1444865,
+    "internal_id": 656896,
     "linked": false
   },
   {
@@ -762,7 +762,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-25", "A4a-81", "A4a-88"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1444996,
+    "internal_id": 656963,
     "linked": false
   },
   {
@@ -792,7 +792,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-26"],
     "artist": "Naoki Saito",
-    "internal_id": 1445121,
+    "internal_id": 657024,
     "linked": false
   },
   {
@@ -822,7 +822,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-27"],
     "artist": "Suwama Chiaki",
-    "internal_id": 1445249,
+    "internal_id": 657088,
     "linked": false
   },
   {
@@ -852,7 +852,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-28"],
     "artist": "tetsuya koizumi",
-    "internal_id": 1445378,
+    "internal_id": 657153,
     "linked": false
   },
   {
@@ -882,7 +882,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-29", "A4a-73"],
     "artist": "Naoki Saito",
-    "internal_id": 1445505,
+    "internal_id": 657216,
     "linked": false
   },
   {
@@ -912,7 +912,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-30", "A4a-74"],
     "artist": "Akira Komayama",
-    "internal_id": 1445633,
+    "internal_id": 657280,
     "linked": false
   },
   {
@@ -942,7 +942,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-31"],
     "artist": "Tomomi Ozaki",
-    "internal_id": 1445763,
+    "internal_id": 657346,
     "linked": false
   },
   {
@@ -976,7 +976,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-32"],
     "artist": "Suwama Chiaki",
-    "internal_id": 1445889,
+    "internal_id": 657408,
     "linked": false
   },
   {
@@ -1006,7 +1006,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-33"],
     "artist": "tono",
-    "internal_id": 1446018,
+    "internal_id": 657473,
     "linked": false
   },
   {
@@ -1036,7 +1036,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-34"],
     "artist": "Kouki Saitou",
-    "internal_id": 1446145,
+    "internal_id": 657536,
     "linked": false
   },
   {
@@ -1070,7 +1070,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-35"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1446275,
+    "internal_id": 657602,
     "linked": false
   },
   {
@@ -1100,7 +1100,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-36", "P-A-101"],
     "artist": "rika",
-    "internal_id": 1446403,
+    "internal_id": 657666,
     "linked": false
   },
   {
@@ -1134,7 +1134,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-37", "A4a-75"],
     "artist": "rika",
-    "internal_id": 1446531,
+    "internal_id": 657730,
     "linked": false
   },
   {
@@ -1164,7 +1164,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-38"],
     "artist": "Akira Komayama",
-    "internal_id": 1446657,
+    "internal_id": 657792,
     "linked": false
   },
   {
@@ -1194,7 +1194,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-39"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1446786,
+    "internal_id": 657857,
     "linked": false
   },
   {
@@ -1224,7 +1224,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-40"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1446913,
+    "internal_id": 657920,
     "linked": false
   },
   {
@@ -1254,7 +1254,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-41"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1447042,
+    "internal_id": 657985,
     "linked": false
   },
   {
@@ -1284,7 +1284,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-42", "A4a-82", "A4a-89"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1447172,
+    "internal_id": 658051,
     "linked": false
   },
   {
@@ -1314,7 +1314,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-43", "A4a-76", "P-A-108"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1447297,
+    "internal_id": 658112,
     "linked": false
   },
   {
@@ -1348,7 +1348,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-44"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1447426,
+    "internal_id": 658177,
     "linked": false
   },
   {
@@ -1378,7 +1378,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-45"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1447553,
+    "internal_id": 658240,
     "linked": false
   },
   {
@@ -1408,7 +1408,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-46"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1447681,
+    "internal_id": 658304,
     "linked": false
   },
   {
@@ -1438,7 +1438,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-47"],
     "artist": "Naoki Saito",
-    "internal_id": 1447810,
+    "internal_id": 658369,
     "linked": false
   },
   {
@@ -1468,7 +1468,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-48"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1447937,
+    "internal_id": 658432,
     "linked": false
   },
   {
@@ -1498,7 +1498,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-49", "P-A-105"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1448065,
+    "internal_id": 658496,
     "linked": false
   },
   {
@@ -1532,7 +1532,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-50", "P-A-106"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1448195,
+    "internal_id": 658562,
     "linked": false
   },
   {
@@ -1562,7 +1562,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-51"],
     "artist": "miki kudo",
-    "internal_id": 1448321,
+    "internal_id": 658624,
     "linked": false
   },
   {
@@ -1592,7 +1592,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-52"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1448450,
+    "internal_id": 658689,
     "linked": false
   },
   {
@@ -1622,7 +1622,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-53"],
     "artist": "Yukiko Baba",
-    "internal_id": 1448577,
+    "internal_id": 658752,
     "linked": false
   },
   {
@@ -1652,7 +1652,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-54"],
     "artist": "5ban Graphics",
-    "internal_id": 1448705,
+    "internal_id": 658816,
     "linked": false
   },
   {
@@ -1682,7 +1682,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-55"],
     "artist": "miki kudo",
-    "internal_id": 1448835,
+    "internal_id": 658882,
     "linked": false
   },
   {
@@ -1712,7 +1712,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-56"],
     "artist": "Midori Harada",
-    "internal_id": 1448961,
+    "internal_id": 658944,
     "linked": false
   },
   {
@@ -1742,7 +1742,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-57"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1449089,
+    "internal_id": 659008,
     "linked": false
   },
   {
@@ -1772,7 +1772,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-58"],
     "artist": "Mina Nakai",
-    "internal_id": 1449218,
+    "internal_id": 659073,
     "linked": false
   },
   {
@@ -1802,7 +1802,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-59"],
     "artist": "Miki Tanaka",
-    "internal_id": 1449347,
+    "internal_id": 659138,
     "linked": false
   },
   {
@@ -1832,7 +1832,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-60"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1449473,
+    "internal_id": 659200,
     "linked": false
   },
   {
@@ -1862,7 +1862,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-61"],
     "artist": "Uta",
-    "internal_id": 1449602,
+    "internal_id": 659265,
     "linked": false
   },
   {
@@ -1892,7 +1892,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-62", "P-A-107"],
     "artist": "Kouki Saitou",
-    "internal_id": 1449730,
+    "internal_id": 659329,
     "linked": false
   },
   {
@@ -1922,7 +1922,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-63", "A4a-77"],
     "artist": "Rond",
-    "internal_id": 1449859,
+    "internal_id": 659394,
     "linked": false
   },
   {
@@ -1952,7 +1952,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-64"],
     "artist": "0313",
-    "internal_id": 1449985,
+    "internal_id": 659456,
     "linked": false
   },
   {
@@ -1986,7 +1986,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-65"],
     "artist": "Misa Tsutsui",
-    "internal_id": 1450114,
+    "internal_id": 659521,
     "linked": false
   },
   {
@@ -2016,7 +2016,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-66"],
     "artist": "Shibuzoh.",
-    "internal_id": 1450241,
+    "internal_id": 659584,
     "linked": false
   },
   {
@@ -2043,7 +2043,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-67"],
     "artist": "Toyste Beach",
-    "internal_id": 1450370,
+    "internal_id": 659649,
     "linked": false
   },
   {
@@ -2070,7 +2070,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-68"],
     "artist": "Studio Bora Inc.",
-    "internal_id": 1450498,
+    "internal_id": 659713,
     "linked": false
   },
   {
@@ -2097,7 +2097,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-69", "A4a-83"],
     "artist": "Yuu Nishida",
-    "internal_id": 1450626,
+    "internal_id": 659777,
     "linked": false
   },
   {
@@ -2124,7 +2124,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-70", "A4a-84"],
     "artist": "GOSSAN",
-    "internal_id": 1450754,
+    "internal_id": 659841,
     "linked": false
   },
   {
@@ -2151,7 +2151,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-71", "A4a-85"],
     "artist": "Teeziro",
-    "internal_id": 1450882,
+    "internal_id": 659905,
     "linked": false
   },
   {
@@ -2185,7 +2185,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-22", "A4a-72", "P-A-104"],
     "artist": "YASHIRO Nanaco",
-    "internal_id": 1451013,
+    "internal_id": 659972,
     "linked": false
   },
   {
@@ -2215,7 +2215,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-29", "A4a-73"],
     "artist": "Akira Komayama",
-    "internal_id": 1451141,
+    "internal_id": 660036,
     "linked": false
   },
   {
@@ -2245,7 +2245,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-30", "A4a-74"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1451269,
+    "internal_id": 660100,
     "linked": false
   },
   {
@@ -2279,7 +2279,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-37", "A4a-75"],
     "artist": "kodama",
-    "internal_id": 1451397,
+    "internal_id": 660164,
     "linked": false
   },
   {
@@ -2309,7 +2309,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-43", "A4a-76", "P-A-108"],
     "artist": "OKACHEKE",
-    "internal_id": 1451525,
+    "internal_id": 660228,
     "linked": false
   },
   {
@@ -2339,7 +2339,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-63", "A4a-77"],
     "artist": "ryoma uratsuka",
-    "internal_id": 1451653,
+    "internal_id": 660292,
     "linked": false
   },
   {
@@ -2369,7 +2369,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-3", "A4a-78", "A4a-86"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1451782,
+    "internal_id": 660357,
     "linked": false
   },
   {
@@ -2403,7 +2403,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-10", "A4a-79", "A4a-87", "P-A-110"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1451910,
+    "internal_id": 660421,
     "linked": false
   },
   {
@@ -2437,7 +2437,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-20", "A4a-80", "A4a-90"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1452038,
+    "internal_id": 660485,
     "linked": false
   },
   {
@@ -2471,7 +2471,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-25", "A4a-81", "A4a-88"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1452166,
+    "internal_id": 660549,
     "linked": false
   },
   {
@@ -2501,7 +2501,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-42", "A4a-82", "A4a-89"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1452294,
+    "internal_id": 660613,
     "linked": false
   },
   {
@@ -2528,7 +2528,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-69", "A4a-83"],
     "artist": "Yuu Nishida",
-    "internal_id": 1452422,
+    "internal_id": 660677,
     "linked": false
   },
   {
@@ -2555,7 +2555,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-70", "A4a-84"],
     "artist": "GOSSAN",
-    "internal_id": 1452550,
+    "internal_id": 660741,
     "linked": false
   },
   {
@@ -2582,7 +2582,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-71", "A4a-85"],
     "artist": "Teeziro",
-    "internal_id": 1452678,
+    "internal_id": 660805,
     "linked": false
   },
   {
@@ -2612,7 +2612,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-3", "A4a-78", "A4a-86"],
     "artist": "takashi shiraishi",
-    "internal_id": 1452806,
+    "internal_id": 660869,
     "linked": false
   },
   {
@@ -2646,7 +2646,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-10", "A4a-79", "A4a-87", "P-A-110"],
     "artist": "Tsuyoshi Nagano",
-    "internal_id": 1452934,
+    "internal_id": 660933,
     "linked": false
   },
   {
@@ -2680,7 +2680,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-25", "A4a-81", "A4a-88"],
     "artist": "Tsuyoshi Nagano",
-    "internal_id": 1453062,
+    "internal_id": 660997,
     "linked": false
   },
   {
@@ -2710,7 +2710,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-42", "A4a-82", "A4a-89"],
     "artist": "Teeziro",
-    "internal_id": 1453190,
+    "internal_id": 661061,
     "linked": false
   },
   {
@@ -2744,7 +2744,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-20", "A4a-80", "A4a-90"],
     "artist": "mele",
-    "internal_id": 1453319,
+    "internal_id": 661126,
     "linked": false
   },
   {
@@ -2774,7 +2774,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-27", "P-A-40", "A4a-91", "A4b-71", "A4b-72"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1453448,
+    "internal_id": 661192,
     "linked": false
   },
   {
@@ -2804,7 +2804,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-28", "A4a-92", "A4b-73", "A4b-74"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1453576,
+    "internal_id": 661256,
     "linked": false
   },
   {
@@ -2834,7 +2834,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-57", "A4a-93"],
     "artist": "Scav",
-    "internal_id": 1453704,
+    "internal_id": 661320,
     "linked": false
   },
   {
@@ -2864,7 +2864,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-58", "A4a-94"],
     "artist": "Scav",
-    "internal_id": 1453832,
+    "internal_id": 661384,
     "linked": false
   },
   {
@@ -2894,7 +2894,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-68", "A4a-95"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1453960,
+    "internal_id": 661448,
     "linked": false
   },
   {
@@ -2924,7 +2924,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-69", "A4a-96"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1454088,
+    "internal_id": 661512,
     "linked": false
   },
   {
@@ -2958,7 +2958,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-54", "A3-163", "A4a-97"],
     "artist": "Nisota Niso",
-    "internal_id": 1454216,
+    "internal_id": 661576,
     "linked": false
   },
   {
@@ -2988,7 +2988,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-45", "P-A-46", "A4a-98", "A4b-205", "A4b-206"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1454344,
+    "internal_id": 661640,
     "linked": false
   },
   {
@@ -3018,7 +3018,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-46", "A4a-99", "A4b-207", "A4b-208"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 1454472,
+    "internal_id": 661704,
     "linked": false
   },
   {
@@ -3048,7 +3048,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-47", "A4a-100", "A4b-236", "A4b-237"],
     "artist": "MAHOU",
-    "internal_id": 1454600,
+    "internal_id": 661768,
     "linked": false
   },
   {
@@ -3078,7 +3078,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-29", "A2-181", "A2-197", "A4a-101", "A4b-75"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1454729,
+    "internal_id": 661833,
     "linked": false
   },
   {
@@ -3114,7 +3114,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-32", "A1a-77", "A1a-83", "A1a-86", "A4a-102", "A4b-159", "A4b-366"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1454857,
+    "internal_id": 661897,
     "linked": false
   },
   {
@@ -3150,7 +3150,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-47", "A2a-84", "A2a-93", "A4a-103", "A4b-209"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1454985,
+    "internal_id": 661961,
     "linked": false
   },
   {
@@ -3180,7 +3180,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-48", "A2b-85", "A2b-93", "A4a-104", "A4b-238"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1455113,
+    "internal_id": 662025,
     "linked": false
   },
   {
@@ -3210,7 +3210,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-23", "A4a-105"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1455242,
+    "internal_id": 662092,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/A4b.json
+++ b/frontend/assets/cards/A4b.json
@@ -26,7 +26,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-1", "A1-227", "P-A-23", "A3-210", "A4b-1", "A4b-2"],
     "artist": "Narumi Sato",
-    "internal_id": 262273,
+    "internal_id": 65600,
     "linked": true
   },
   {
@@ -56,7 +56,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-1", "A1-227", "P-A-23", "A3-210", "A4b-1", "A4b-2"],
     "artist": "Narumi Sato",
-    "internal_id": 1573121,
+    "internal_id": 721024,
     "linked": false
   },
   {
@@ -86,7 +86,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-2", "A3-211", "A4b-3", "A4b-4"],
     "artist": "Kurata So",
-    "internal_id": 262402,
+    "internal_id": 65665,
     "linked": true
   },
   {
@@ -116,7 +116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-2", "A3-211", "A4b-3", "A4b-4"],
     "artist": "Kurata So",
-    "internal_id": 1573378,
+    "internal_id": 721153,
     "linked": false
   },
   {
@@ -152,7 +152,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-4", "A1-251", "A3-230", "A4b-5"],
     "artist": "PLANETA CG Works",
-    "internal_id": 262660,
+    "internal_id": 65795,
     "linked": true
   },
   {
@@ -182,7 +182,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-1", "A2b-97", "A4b-6", "A4b-7"],
     "artist": "Akira Komayama",
-    "internal_id": 786561,
+    "internal_id": 327744,
     "linked": true
   },
   {
@@ -212,7 +212,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-1", "A2b-97", "A4b-6", "A4b-7"],
     "artist": "Akira Komayama",
-    "internal_id": 1573761,
+    "internal_id": 721344,
     "linked": false
   },
   {
@@ -242,7 +242,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-2", "A2b-98", "A4b-8", "A4b-9"],
     "artist": "Yuka Morii",
-    "internal_id": 786690,
+    "internal_id": 327809,
     "linked": true
   },
   {
@@ -272,7 +272,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-2", "A2b-98", "A4b-8", "A4b-9"],
     "artist": "Yuka Morii",
-    "internal_id": 1574018,
+    "internal_id": 721473,
     "linked": false
   },
   {
@@ -302,7 +302,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-3", "A2b-79", "A2b-107", "A4b-10"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 786820,
+    "internal_id": 327875,
     "linked": true
   },
   {
@@ -332,7 +332,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-21", "A4b-11", "A4b-12"],
     "artist": "kawayoo",
-    "internal_id": 264833,
+    "internal_id": 66880,
     "linked": true
   },
   {
@@ -362,7 +362,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-21", "A4b-11", "A4b-12"],
     "artist": "kawayoo",
-    "internal_id": 1574401,
+    "internal_id": 721664,
     "linked": false
   },
   {
@@ -392,7 +392,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-23", "A1-252", "A3-231", "A4b-13"],
     "artist": "PLANETA CG Works",
-    "internal_id": 265092,
+    "internal_id": 67011,
     "linked": true
   },
   {
@@ -422,7 +422,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-13", "A4b-14", "A4b-15"],
     "artist": "Mékayu",
-    "internal_id": 1312385,
+    "internal_id": 590656,
     "linked": true
   },
   {
@@ -452,7 +452,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-13", "A4b-14", "A4b-15"],
     "artist": "Mékayu",
-    "internal_id": 1574785,
+    "internal_id": 721856,
     "linked": false
   },
   {
@@ -482,7 +482,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-14", "A4b-16", "A4b-17"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1312514,
+    "internal_id": 590721,
     "linked": true
   },
   {
@@ -512,7 +512,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-14", "A4b-16", "A4b-17"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1575042,
+    "internal_id": 721985,
     "linked": false
   },
   {
@@ -546,7 +546,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-15", "A4b-18", "A4b-19"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1312643,
+    "internal_id": 590786,
     "linked": true
   },
   {
@@ -580,7 +580,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-15", "A4b-18", "A4b-19"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1575299,
+    "internal_id": 722114,
     "linked": false
   },
   {
@@ -610,7 +610,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-6", "A4b-20", "A4b-21"],
     "artist": "Eri Yamaki",
-    "internal_id": 525057,
+    "internal_id": 196992,
     "linked": true
   },
   {
@@ -640,7 +640,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-6", "A4b-20", "A4b-21"],
     "artist": "Eri Yamaki",
-    "internal_id": 1575553,
+    "internal_id": 722240,
     "linked": false
   },
   {
@@ -670,7 +670,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-7", "A2-180", "A2-196", "A4-232", "A4b-22"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 525188,
+    "internal_id": 197059,
     "linked": true
   },
   {
@@ -704,7 +704,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-21", "A4-186", "A4-202", "A4b-23"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1313412,
+    "internal_id": 591171,
     "linked": true
   },
   {
@@ -734,7 +734,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-3", "A1a-75", "A1a-85", "A3a-99", "A4b-24"],
     "artist": "PLANETA CG Works",
-    "internal_id": 393604,
+    "internal_id": 131267,
     "linked": true
   },
   {
@@ -768,7 +768,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-23", "A4b-25", "A4b-26"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1313665,
+    "internal_id": 591296,
     "linked": true
   },
   {
@@ -802,7 +802,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-23", "A4b-25", "A4b-26"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1576193,
+    "internal_id": 722560,
     "linked": false
   },
   {
@@ -832,7 +832,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-24", "A4b-27", "A4b-28"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1313794,
+    "internal_id": 591361,
     "linked": true
   },
   {
@@ -862,7 +862,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-24", "A4b-27", "A4b-28"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1576450,
+    "internal_id": 722689,
     "linked": false
   },
   {
@@ -896,7 +896,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-10", "A2a-82", "A2a-91", "A4-233", "A4b-29"],
     "artist": "PLANETA CG Works",
-    "internal_id": 656644,
+    "internal_id": 262787,
     "linked": true
   },
   {
@@ -930,7 +930,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-22", "A2-159", "A4b-30", "A4b-31", "P-A-116"],
     "artist": "Narumi Sato",
-    "internal_id": 527107,
+    "internal_id": 198018,
     "linked": true
   },
   {
@@ -964,7 +964,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-22", "A2-159", "A4b-30", "A4b-31", "P-A-116"],
     "artist": "Narumi Sato",
-    "internal_id": 1576835,
+    "internal_id": 722882,
     "linked": false
   },
   {
@@ -994,7 +994,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-4", "A4b-32", "A4b-33"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 393729,
+    "internal_id": 131328,
     "linked": true
   },
   {
@@ -1024,7 +1024,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-4", "A4b-32", "A4b-33"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1577089,
+    "internal_id": 723008,
     "linked": false
   },
   {
@@ -1054,7 +1054,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-5", "A4b-34", "A4b-35"],
     "artist": "Shigenori Negishi",
-    "internal_id": 393858,
+    "internal_id": 131393,
     "linked": true
   },
   {
@@ -1084,7 +1084,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-5", "A4b-34", "A4b-35"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1577346,
+    "internal_id": 723137,
     "linked": false
   },
   {
@@ -1118,7 +1118,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-6", "A1a-70", "A4b-36", "A4b-37"],
     "artist": "Yoshioka",
-    "internal_id": 393987,
+    "internal_id": 131458,
     "linked": true
   },
   {
@@ -1152,7 +1152,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-6", "A1a-70", "A4b-36", "A4b-37"],
     "artist": "Yoshioka",
-    "internal_id": 1577603,
+    "internal_id": 723266,
     "linked": false
   },
   {
@@ -1182,7 +1182,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-10", "A4b-38", "A4b-39"],
     "artist": "Saya Tsuruta",
-    "internal_id": 918785,
+    "internal_id": 393856,
     "linked": true
   },
   {
@@ -1212,7 +1212,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-10", "A4b-38", "A4b-39"],
     "artist": "Saya Tsuruta",
-    "internal_id": 1577857,
+    "internal_id": 723392,
     "linked": false
   },
   {
@@ -1242,7 +1242,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-11", "A4b-40", "A4b-41"],
     "artist": "Mizue",
-    "internal_id": 918914,
+    "internal_id": 393921,
     "linked": true
   },
   {
@@ -1272,7 +1272,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-11", "A4b-40", "A4b-41"],
     "artist": "Mizue",
-    "internal_id": 1578114,
+    "internal_id": 723521,
     "linked": false
   },
   {
@@ -1308,7 +1308,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-12", "A3-180", "A3-198", "A4b-42"],
     "artist": "PLANETA CG Works",
-    "internal_id": 919044,
+    "internal_id": 393987,
     "linked": true
   },
   {
@@ -1338,7 +1338,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-23", "A3-181", "A3-199", "A4b-43"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 920452,
+    "internal_id": 394691,
     "linked": true
   },
   {
@@ -1374,7 +1374,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-6", "A3a-76", "A3a-88", "A4b-44", "A4b-360"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 1049348,
+    "internal_id": 459139,
     "linked": true
   },
   {
@@ -1404,7 +1404,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-7", "A3a-71", "A4b-45", "A4b-46"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1049474,
+    "internal_id": 459201,
     "linked": true
   },
   {
@@ -1434,7 +1434,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-7", "A3a-71", "A4b-45", "A4b-46"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1578754,
+    "internal_id": 723841,
     "linked": false
   },
   {
@@ -1464,7 +1464,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-8", "P-A-75", "A4b-47", "A4b-48"],
     "artist": "nagimiso",
-    "internal_id": 1049601,
+    "internal_id": 459264,
     "linked": true
   },
   {
@@ -1494,7 +1494,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-8", "P-A-75", "A4b-47", "A4b-48"],
     "artist": "nagimiso",
-    "internal_id": 1579009,
+    "internal_id": 723968,
     "linked": false
   },
   {
@@ -1524,7 +1524,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-5", "P-A-52", "A4b-49", "A4b-50"],
     "artist": "mashu",
-    "internal_id": 787073,
+    "internal_id": 328000,
     "linked": true
   },
   {
@@ -1554,7 +1554,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-5", "P-A-52", "A4b-49", "A4b-50"],
     "artist": "mashu",
-    "internal_id": 1579265,
+    "internal_id": 724096,
     "linked": false
   },
   {
@@ -1584,7 +1584,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-6", "A4b-51", "A4b-52", "A4b-354"],
     "artist": "mashu",
-    "internal_id": 787202,
+    "internal_id": 328065,
     "linked": true
   },
   {
@@ -1614,7 +1614,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-6", "A4b-51", "A4b-52", "A4b-354"],
     "artist": "mashu",
-    "internal_id": 1579522,
+    "internal_id": 724225,
     "linked": false
   },
   {
@@ -1644,7 +1644,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-7", "A2b-73", "A4b-53", "A4b-54"],
     "artist": "mashu",
-    "internal_id": 787331,
+    "internal_id": 328130,
     "linked": true
   },
   {
@@ -1674,7 +1674,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-7", "A2b-73", "A4b-53", "A4b-54"],
     "artist": "mashu",
-    "internal_id": 1579779,
+    "internal_id": 724354,
     "linked": false
   },
   {
@@ -1704,7 +1704,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-33", "A1-230", "P-A-32", "A4b-55", "A4b-56"],
     "artist": "Teeziro",
-    "internal_id": 266369,
+    "internal_id": 67648,
     "linked": true
   },
   {
@@ -1734,7 +1734,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-33", "A1-230", "P-A-32", "A4b-55", "A4b-56"],
     "artist": "Teeziro",
-    "internal_id": 1580033,
+    "internal_id": 724480,
     "linked": false
   },
   {
@@ -1764,7 +1764,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-34", "A4b-57", "A4b-58"],
     "artist": "kantaro",
-    "internal_id": 266498,
+    "internal_id": 67713,
     "linked": true
   },
   {
@@ -1794,7 +1794,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-34", "A4b-57", "A4b-58"],
     "artist": "kantaro",
-    "internal_id": 1580290,
+    "internal_id": 724609,
     "linked": false
   },
   {
@@ -1830,7 +1830,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-36", "A1-253", "A1-280", "A1-284", "A4b-59", "A4b-361"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 266756,
+    "internal_id": 67843,
     "linked": true
   },
   {
@@ -1866,7 +1866,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-10", "A2b-80", "A2b-108", "A4b-60"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 787716,
+    "internal_id": 328323,
     "linked": true
   },
   {
@@ -1896,7 +1896,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-39", "A3a-89", "A4b-61", "A4b-62"],
     "artist": "Mizue",
-    "internal_id": 267137,
+    "internal_id": 68032,
     "linked": true
   },
   {
@@ -1926,7 +1926,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-39", "A3a-89", "A4b-61", "A4b-62"],
     "artist": "Mizue",
-    "internal_id": 1580801,
+    "internal_id": 724864,
     "linked": false
   },
   {
@@ -1956,7 +1956,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-41", "A1-254", "A3a-100", "A4b-63"],
     "artist": "PLANETA Saito",
-    "internal_id": 267396,
+    "internal_id": 68163,
     "linked": true
   },
   {
@@ -1986,7 +1986,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-8", "A3b-71", "A4-213", "A4b-64", "A4b-65"],
     "artist": "Eri Yamaki",
-    "internal_id": 1180675,
+    "internal_id": 524802,
     "linked": true
   },
   {
@@ -2016,7 +2016,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-8", "A3b-71", "A4-213", "A4b-64", "A4b-65"],
     "artist": "Eri Yamaki",
-    "internal_id": 1581187,
+    "internal_id": 725058,
     "linked": false
   },
   {
@@ -2050,7 +2050,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-9", "A3b-79", "A3b-87", "A4b-66"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1180804,
+    "internal_id": 524867,
     "linked": true
   },
   {
@@ -2086,7 +2086,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-47", "A1-255", "A1-274", "P-A-25", "A3b-103", "A4b-67"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 268164,
+    "internal_id": 68547,
     "linked": true
   },
   {
@@ -2116,7 +2116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-34", "A4-187", "A4-210", "A4-240", "A4b-68", "A4b-362"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1315076,
+    "internal_id": 592003,
     "linked": true
   },
   {
@@ -2146,7 +2146,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-10", "A4b-69", "A4b-70"],
     "artist": "sui",
-    "internal_id": 1180929,
+    "internal_id": 524928,
     "linked": true
   },
   {
@@ -2176,7 +2176,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-10", "A4b-69", "A4b-70"],
     "artist": "sui",
-    "internal_id": 1581825,
+    "internal_id": 725376,
     "linked": false
   },
   {
@@ -2206,7 +2206,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-27", "P-A-40", "A4a-91", "A4b-71", "A4b-72"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 527745,
+    "internal_id": 198336,
     "linked": true
   },
   {
@@ -2236,7 +2236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-27", "P-A-40", "A4a-91", "A4b-71", "A4b-72"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 1582081,
+    "internal_id": 725504,
     "linked": false
   },
   {
@@ -2266,7 +2266,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-28", "A4a-92", "A4b-73", "A4b-74"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 527874,
+    "internal_id": 198401,
     "linked": true
   },
   {
@@ -2296,7 +2296,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-28", "A4a-92", "A4b-73", "A4b-74"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 1582338,
+    "internal_id": 725633,
     "linked": false
   },
   {
@@ -2326,7 +2326,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-29", "A2-181", "A2-197", "A4a-101", "A4b-75"],
     "artist": "PLANETA CG Works",
-    "internal_id": 528004,
+    "internal_id": 198467,
     "linked": true
   },
   {
@@ -2360,7 +2360,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-13", "A4b-76", "A4b-77"],
     "artist": "Kazumasa Yasukuni",
-    "internal_id": 657027,
+    "internal_id": 262978,
     "linked": true
   },
   {
@@ -2394,7 +2394,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-13", "A4b-76", "A4b-77"],
     "artist": "Kazumasa Yasukuni",
-    "internal_id": 1582723,
+    "internal_id": 725826,
     "linked": false
   },
   {
@@ -2424,7 +2424,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-30", "A4b-78", "A4b-79"],
     "artist": "Akira Komayama",
-    "internal_id": 921345,
+    "internal_id": 395136,
     "linked": true
   },
   {
@@ -2454,7 +2454,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-30", "A4b-78", "A4b-79"],
     "artist": "Akira Komayama",
-    "internal_id": 1582977,
+    "internal_id": 725952,
     "linked": false
   },
   {
@@ -2484,7 +2484,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-32", "A4b-80", "A4b-81"],
     "artist": "tetsuya koizumi",
-    "internal_id": 921602,
+    "internal_id": 395265,
     "linked": true
   },
   {
@@ -2514,7 +2514,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-32", "A4b-80", "A4b-81"],
     "artist": "tetsuya koizumi",
-    "internal_id": 1583234,
+    "internal_id": 726081,
     "linked": false
   },
   {
@@ -2550,7 +2550,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-33", "A3-182", "A3-200", "A4b-82"],
     "artist": "PLANETA CG Works",
-    "internal_id": 921732,
+    "internal_id": 395331,
     "linked": true
   },
   {
@@ -2580,7 +2580,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-53", "A1-232", "P-A-33", "A3-215", "A4b-83", "A4b-84"],
     "artist": "Mizue",
-    "internal_id": 268929,
+    "internal_id": 68928,
     "linked": true
   },
   {
@@ -2610,7 +2610,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-53", "A1-232", "P-A-33", "A3-215", "A4b-83", "A4b-84"],
     "artist": "Mizue",
-    "internal_id": 1583617,
+    "internal_id": 726272,
     "linked": false
   },
   {
@@ -2640,7 +2640,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-54", "A3-216", "A4b-85", "A4b-86"],
     "artist": "Nelnal",
-    "internal_id": 269058,
+    "internal_id": 68993,
     "linked": true
   },
   {
@@ -2670,7 +2670,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-54", "A3-216", "A4b-85", "A4b-86"],
     "artist": "Nelnal",
-    "internal_id": 1583874,
+    "internal_id": 726401,
     "linked": false
   },
   {
@@ -2706,7 +2706,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-56", "A1-256", "A3-232", "A4b-87"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 269316,
+    "internal_id": 69123,
     "linked": true
   },
   {
@@ -2736,7 +2736,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-41", "A4b-88", "A4b-89"],
     "artist": "Yukiko Baba",
-    "internal_id": 1315969,
+    "internal_id": 592448,
     "linked": true
   },
   {
@@ -2766,7 +2766,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-41", "A4b-88", "A4b-89"],
     "artist": "Yukiko Baba",
-    "internal_id": 1584257,
+    "internal_id": 726592,
     "linked": false
   },
   {
@@ -2796,7 +2796,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-42", "A4b-90", "A4b-91"],
     "artist": "sui",
-    "internal_id": 1316098,
+    "internal_id": 592513,
     "linked": true
   },
   {
@@ -2826,7 +2826,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-42", "A4b-90", "A4b-91"],
     "artist": "sui",
-    "internal_id": 1584514,
+    "internal_id": 726721,
     "linked": false
   },
   {
@@ -2856,7 +2856,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-43", "A4-188", "A4-203", "A4b-92"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1316228,
+    "internal_id": 592579,
     "linked": true
   },
   {
@@ -2886,7 +2886,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-74", "A3-218", "A4b-93", "A4b-94"],
     "artist": "Hiroki Asanuma",
-    "internal_id": 271617,
+    "internal_id": 70272,
     "linked": true
   },
   {
@@ -2916,7 +2916,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-74", "A3-218", "A4b-93", "A4b-94"],
     "artist": "Hiroki Asanuma",
-    "internal_id": 1584897,
+    "internal_id": 726912,
     "linked": false
   },
   {
@@ -2946,7 +2946,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-76", "A1-257", "A3-233", "A4b-95"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 271876,
+    "internal_id": 70403,
     "linked": true
   },
   {
@@ -2976,7 +2976,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-17", "A4-214", "A4b-96", "A4b-97"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 395393,
+    "internal_id": 132160,
     "linked": true
   },
   {
@@ -3006,7 +3006,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-17", "A4-214", "A4b-96", "A4b-97"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 1585281,
+    "internal_id": 727104,
     "linked": false
   },
   {
@@ -3036,7 +3036,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-18", "A1a-76", "A4-234", "A4b-98"],
     "artist": "PLANETA CG Works",
-    "internal_id": 395524,
+    "internal_id": 132227,
     "linked": true
   },
   {
@@ -3070,7 +3070,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-19", "A1a-72", "A4b-99", "A4b-100"],
     "artist": "LINNE",
-    "internal_id": 395651,
+    "internal_id": 132290,
     "linked": true
   },
   {
@@ -3104,7 +3104,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-19", "A1a-72", "A4b-99", "A4b-100"],
     "artist": "LINNE",
-    "internal_id": 1585667,
+    "internal_id": 727298,
     "linked": false
   },
   {
@@ -3140,7 +3140,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-84", "A1-258", "A1-275", "A3b-104", "A4b-101"],
     "artist": "PLANETA Saito",
-    "internal_id": 272900,
+    "internal_id": 70915,
     "linked": true
   },
   {
@@ -3170,7 +3170,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-60", "A4b-102", "A4b-103"],
     "artist": "chibi",
-    "internal_id": 1318401,
+    "internal_id": 593664,
     "linked": true
   },
   {
@@ -3200,7 +3200,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-60", "A4b-102", "A4b-103"],
     "artist": "chibi",
-    "internal_id": 1586049,
+    "internal_id": 727488,
     "linked": false
   },
   {
@@ -3234,7 +3234,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-61", "A4b-104", "A4b-105", "A4b-355"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1318531,
+    "internal_id": 593730,
     "linked": true
   },
   {
@@ -3268,7 +3268,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-61", "A4b-104", "A4b-105", "A4b-355"],
     "artist": "Hajime Kusajima",
-    "internal_id": 1586307,
+    "internal_id": 727618,
     "linked": false
   },
   {
@@ -3302,7 +3302,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-22", "A2a-83", "A2a-92", "A4-235", "A4b-106"],
     "artist": "PLANETA CG Works",
-    "internal_id": 658180,
+    "internal_id": 263555,
     "linked": true
   },
   {
@@ -3338,7 +3338,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-49", "A2-182", "A2-204", "A2-206", "A4b-107", "A4b-363"],
     "artist": "PLANETA CG Works",
-    "internal_id": 530564,
+    "internal_id": 199747,
     "linked": true
   },
   {
@@ -3368,7 +3368,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-50", "A2-162", "P-A-48", "A4b-108", "A4b-109"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 530690,
+    "internal_id": 199809,
     "linked": true
   },
   {
@@ -3398,7 +3398,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-50", "A2-162", "P-A-48", "A4b-108", "A4b-109"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 1586818,
+    "internal_id": 727873,
     "linked": false
   },
   {
@@ -3428,7 +3428,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-87", "P-A-61", "A3a-91", "A4b-110", "A4b-111"],
     "artist": "Aya Kusube",
-    "internal_id": 273281,
+    "internal_id": 71104,
     "linked": true
   },
   {
@@ -3458,7 +3458,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-87", "P-A-61", "A3a-91", "A4b-110", "A4b-111"],
     "artist": "Aya Kusube",
-    "internal_id": 1587073,
+    "internal_id": 728000,
     "linked": false
   },
   {
@@ -3488,7 +3488,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-88", "A3a-92", "A4b-112", "A4b-113"],
     "artist": "Akira Komayama",
-    "internal_id": 273410,
+    "internal_id": 71169,
     "linked": true
   },
   {
@@ -3518,7 +3518,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-88", "A3a-92", "A4b-112", "A4b-113"],
     "artist": "Akira Komayama",
-    "internal_id": 1587330,
+    "internal_id": 728129,
     "linked": false
   },
   {
@@ -3552,7 +3552,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-89", "P-A-19", "A3a-93", "A4b-114", "A4b-115", "A4b-356"],
     "artist": "5ban Graphics",
-    "internal_id": 273539,
+    "internal_id": 71234,
     "linked": true
   },
   {
@@ -3586,7 +3586,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-89", "P-A-19", "A3a-93", "A4b-114", "A4b-115", "A4b-356"],
     "artist": "5ban Graphics",
-    "internal_id": 1587587,
+    "internal_id": 728258,
     "linked": false
   },
   {
@@ -3616,7 +3616,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-22", "A4b-116", "A4b-117"],
     "artist": "match",
-    "internal_id": 1182465,
+    "internal_id": 525696,
     "linked": true
   },
   {
@@ -3646,7 +3646,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-22", "A4b-116", "A4b-117"],
     "artist": "match",
-    "internal_id": 1587841,
+    "internal_id": 728384,
     "linked": false
   },
   {
@@ -3676,7 +3676,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-23", "A4b-118", "A4b-119"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1182593,
+    "internal_id": 525760,
     "linked": true
   },
   {
@@ -3706,7 +3706,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-23", "A4b-118", "A4b-119"],
     "artist": "Atsuko Nishida",
-    "internal_id": 1588097,
+    "internal_id": 728512,
     "linked": false
   },
   {
@@ -3742,7 +3742,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-24", "A3b-80", "A3b-88", "A4b-120"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1182724,
+    "internal_id": 525827,
     "linked": true
   },
   {
@@ -3772,7 +3772,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-49", "A3-183", "A3-201", "A4b-121"],
     "artist": "PLANETA CG Works",
-    "internal_id": 923780,
+    "internal_id": 396355,
     "linked": true
   },
   {
@@ -3802,7 +3802,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-50", "A4b-122", "A4b-123"],
     "artist": "Kouki Saitou",
-    "internal_id": 923905,
+    "internal_id": 396416,
     "linked": true
   },
   {
@@ -3832,7 +3832,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-50", "A4b-122", "A4b-123"],
     "artist": "Kouki Saitou",
-    "internal_id": 1588609,
+    "internal_id": 728768,
     "linked": false
   },
   {
@@ -3862,7 +3862,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-51", "A3-184", "A3-202", "A4b-124"],
     "artist": "PLANETA CG Works",
-    "internal_id": 924036,
+    "internal_id": 396483,
     "linked": true
   },
   {
@@ -3892,7 +3892,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-18", "A2b-101", "A4b-125", "A4b-126"],
     "artist": "miki kudo",
-    "internal_id": 788737,
+    "internal_id": 328832,
     "linked": true
   },
   {
@@ -3922,7 +3922,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-18", "A2b-101", "A4b-125", "A4b-126"],
     "artist": "miki kudo",
-    "internal_id": 1588993,
+    "internal_id": 728960,
     "linked": false
   },
   {
@@ -3952,7 +3952,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-19", "A2b-81", "A2b-109", "A4b-127"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 788868,
+    "internal_id": 328899,
     "linked": true
   },
   {
@@ -3982,7 +3982,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-94", "P-A-9", "P-A-15", "P-A-26", "A4b-128", "A4b-129"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 274177,
+    "internal_id": 71552,
     "linked": true
   },
   {
@@ -4012,7 +4012,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-94", "P-A-9", "P-A-15", "P-A-26", "A4b-128", "A4b-129"],
     "artist": "Mitsuhiro Arita",
-    "internal_id": 1589377,
+    "internal_id": 729152,
     "linked": false
   },
   {
@@ -4042,7 +4042,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-58", "A3-185", "A3-203", "A4b-130"],
     "artist": "PLANETA CG Works",
-    "internal_id": 924932,
+    "internal_id": 396931,
     "linked": true
   },
   {
@@ -4072,7 +4072,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-96", "A1-259", "A1-281", "A1-285", "A4b-131", "A4b-364", "A4b-376"],
     "artist": "PLANETA CG Works",
-    "internal_id": 274436,
+    "internal_id": 71683,
     "linked": true
   },
   {
@@ -4102,7 +4102,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-22", "A2b-82", "A2b-92", "A4b-132"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 789252,
+    "internal_id": 329091,
     "linked": true
   },
   {
@@ -4132,7 +4132,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-97", "P-A-24", "A4-217", "A4b-133", "A4b-134"],
     "artist": "sowsow",
-    "internal_id": 274561,
+    "internal_id": 71744,
     "linked": true
   },
   {
@@ -4162,7 +4162,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-97", "P-A-24", "A4-217", "A4b-133", "A4b-134"],
     "artist": "sowsow",
-    "internal_id": 1590017,
+    "internal_id": 729472,
     "linked": false
   },
   {
@@ -4196,7 +4196,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-98", "A4-218", "A4b-135", "A4b-136"],
     "artist": "kirisAki",
-    "internal_id": 274691,
+    "internal_id": 71810,
     "linked": true
   },
   {
@@ -4230,7 +4230,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-98", "A4-218", "A4b-135", "A4b-136"],
     "artist": "kirisAki",
-    "internal_id": 1590275,
+    "internal_id": 729602,
     "linked": false
   },
   {
@@ -4260,7 +4260,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-53", "A4b-137", "A4b-138"],
     "artist": "Yoshinobu Saito",
-    "internal_id": 531075,
+    "internal_id": 200002,
     "linked": true
   },
   {
@@ -4290,7 +4290,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-53", "A4b-137", "A4b-138"],
     "artist": "Yoshinobu Saito",
-    "internal_id": 1590531,
+    "internal_id": 729730,
     "linked": false
   },
   {
@@ -4326,7 +4326,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-104", "A1-260", "A1-276", "A3b-105", "A4b-139"],
     "artist": "PLANETA CG Works",
-    "internal_id": 275460,
+    "internal_id": 72195,
     "linked": true
   },
   {
@@ -4356,7 +4356,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-64", "A4b-140", "A4b-141"],
     "artist": "Miki Tanaka",
-    "internal_id": 1318913,
+    "internal_id": 593920,
     "linked": true
   },
   {
@@ -4386,7 +4386,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-64", "A4b-140", "A4b-141"],
     "artist": "Miki Tanaka",
-    "internal_id": 1590913,
+    "internal_id": 729920,
     "linked": false
   },
   {
@@ -4416,7 +4416,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-65", "A4-189", "A4-204", "A4b-142"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1319044,
+    "internal_id": 593987,
     "linked": true
   },
   {
@@ -4446,7 +4446,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-25", "A2b-103", "P-A-58", "A4b-143", "A4b-144"],
     "artist": "imoniii",
-    "internal_id": 789634,
+    "internal_id": 329281,
     "linked": true
   },
   {
@@ -4476,7 +4476,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-25", "A2b-103", "P-A-58", "A4b-143", "A4b-144"],
     "artist": "imoniii",
-    "internal_id": 1591298,
+    "internal_id": 730113,
     "linked": false
   },
   {
@@ -4506,7 +4506,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-61", "A2-183", "A2-198", "A4-236", "A4b-145"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 532100,
+    "internal_id": 200515,
     "linked": true
   },
   {
@@ -4540,7 +4540,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-66", "A3-165", "A4b-146", "A4b-147"],
     "artist": "Jerky",
-    "internal_id": 925955,
+    "internal_id": 397442,
     "linked": true
   },
   {
@@ -4574,7 +4574,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-66", "A3-165", "A4b-146", "A4b-147"],
     "artist": "Jerky",
-    "internal_id": 1591683,
+    "internal_id": 730306,
     "linked": false
   },
   {
@@ -4610,7 +4610,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-19", "A3a-77", "A3a-84", "P-A-84", "A4b-148"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1051012,
+    "internal_id": 459971,
     "linked": true
   },
   {
@@ -4644,7 +4644,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-21", "P-A-74", "A4b-149", "A4b-150"],
     "artist": "kawayoo",
-    "internal_id": 1051267,
+    "internal_id": 460098,
     "linked": true
   },
   {
@@ -4678,7 +4678,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-21", "P-A-74", "A4b-149", "A4b-150"],
     "artist": "kawayoo",
-    "internal_id": 1592067,
+    "internal_id": 730498,
     "linked": false
   },
   {
@@ -4708,7 +4708,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-120", "A4b-151", "A4b-152"],
     "artist": "Masako Yamashita",
-    "internal_id": 277505,
+    "internal_id": 73216,
     "linked": true
   },
   {
@@ -4738,7 +4738,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-120", "A4b-151", "A4b-152"],
     "artist": "Masako Yamashita",
-    "internal_id": 1592321,
+    "internal_id": 730624,
     "linked": false
   },
   {
@@ -4768,7 +4768,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-121", "A3-221", "A4b-153", "A4b-154"],
     "artist": "Nisota Niso",
-    "internal_id": 277634,
+    "internal_id": 73281,
     "linked": true
   },
   {
@@ -4798,7 +4798,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-121", "A3-221", "A4b-153", "A4b-154"],
     "artist": "Nisota Niso",
-    "internal_id": 1592578,
+    "internal_id": 730753,
     "linked": false
   },
   {
@@ -4832,7 +4832,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-123", "A1-261", "A1-277", "A3-234", "A4b-155"],
     "artist": "PLANETA CG Works",
-    "internal_id": 277892,
+    "internal_id": 73411,
     "linked": true
   },
   {
@@ -4862,7 +4862,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-127", "A3a-94", "A4b-156", "A4b-157"],
     "artist": "Oswaldo KATO",
-    "internal_id": 278401,
+    "internal_id": 73664,
     "linked": true
   },
   {
@@ -4892,7 +4892,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-127", "A3a-94", "A4b-156", "A4b-157"],
     "artist": "Oswaldo KATO",
-    "internal_id": 1592961,
+    "internal_id": 730944,
     "linked": false
   },
   {
@@ -4928,7 +4928,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-129", "A1-262", "A1-282", "A1-286", "P-A-50", "A4b-158", "A4b-365"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 278660,
+    "internal_id": 73795,
     "linked": true
   },
   {
@@ -4964,7 +4964,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-32", "A1a-77", "A1a-83", "A1a-86", "A4a-102", "A4b-159", "A4b-366"],
     "artist": "PLANETA CG Works",
-    "internal_id": 397316,
+    "internal_id": 133123,
     "linked": true
   },
   {
@@ -4998,7 +4998,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-83", "A4-190", "A4-205", "A4b-160"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1321348,
+    "internal_id": 595139,
     "linked": true
   },
   {
@@ -5028,7 +5028,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-66", "A4-220", "A4b-161", "A4b-162"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 532737,
+    "internal_id": 200832,
     "linked": true
   },
   {
@@ -5058,7 +5058,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-66", "A4-220", "A4b-161", "A4b-162"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1593601,
+    "internal_id": 731264,
     "linked": false
   },
   {
@@ -5088,7 +5088,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-67", "A2-184", "A2-199", "A4-237", "A4b-163"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 532868,
+    "internal_id": 200899,
     "linked": true
   },
   {
@@ -5118,7 +5118,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-68", "A3b-97", "A4b-164", "A4b-165"],
     "artist": "Miki Tanaka",
-    "internal_id": 532993,
+    "internal_id": 200960,
     "linked": true
   },
   {
@@ -5148,7 +5148,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-68", "A3b-97", "A4b-164", "A4b-165"],
     "artist": "Miki Tanaka",
-    "internal_id": 1593985,
+    "internal_id": 731456,
     "linked": false
   },
   {
@@ -5178,7 +5178,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-69", "A3b-98", "A4b-166", "A4b-167"],
     "artist": "Yukiko Baba",
-    "internal_id": 533121,
+    "internal_id": 201024,
     "linked": true
   },
   {
@@ -5208,7 +5208,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-69", "A3b-98", "A4b-166", "A4b-167"],
     "artist": "Yukiko Baba",
-    "internal_id": 1594241,
+    "internal_id": 731584,
     "linked": false
   },
   {
@@ -5242,7 +5242,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-132", "A3b-99", "A4b-168", "A4b-169", "A4b-357"],
     "artist": "Yuu Nishida",
-    "internal_id": 279043,
+    "internal_id": 73986,
     "linked": true
   },
   {
@@ -5276,7 +5276,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-132", "A3b-99", "A4b-168", "A4b-169", "A4b-357"],
     "artist": "Yuu Nishida",
-    "internal_id": 1594499,
+    "internal_id": 731714,
     "linked": false
   },
   {
@@ -5310,7 +5310,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-78", "A2-167", "A4b-170", "A4b-171"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 534275,
+    "internal_id": 201602,
     "linked": true
   },
   {
@@ -5344,7 +5344,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-78", "A2-167", "A4b-170", "A4b-171"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1594755,
+    "internal_id": 731842,
     "linked": false
   },
   {
@@ -5378,7 +5378,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-35", "A2b-83", "A2b-96", "A4b-172", "A4b-377"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 790916,
+    "internal_id": 329923,
     "linked": true
   },
   {
@@ -5408,7 +5408,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-31", "A4b-173", "A4b-174"],
     "artist": "MAHOU",
-    "internal_id": 1183617,
+    "internal_id": 526272,
     "linked": true
   },
   {
@@ -5438,7 +5438,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-31", "A4b-173", "A4b-174"],
     "artist": "MAHOU",
-    "internal_id": 1595137,
+    "internal_id": 732032,
     "linked": false
   },
   {
@@ -5468,7 +5468,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-32", "A4b-175", "A4b-176", "A4b-358"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1183746,
+    "internal_id": 526337,
     "linked": true
   },
   {
@@ -5498,7 +5498,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-32", "A4b-175", "A4b-176", "A4b-358"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1595394,
+    "internal_id": 732161,
     "linked": false
   },
   {
@@ -5532,7 +5532,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-34", "A3b-81", "A3b-89", "A4b-177"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1184004,
+    "internal_id": 526467,
     "linked": true
   },
   {
@@ -5562,7 +5562,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-77", "A4b-178", "A4b-179"],
     "artist": "Jerky",
-    "internal_id": 927362,
+    "internal_id": 398145,
     "linked": true
   },
   {
@@ -5592,7 +5592,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-77", "A4b-178", "A4b-179"],
     "artist": "Jerky",
-    "internal_id": 1595778,
+    "internal_id": 732353,
     "linked": false
   },
   {
@@ -5622,7 +5622,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-85", "A3-171", "P-A-67", "A4b-180", "A4b-181"],
     "artist": "sui",
-    "internal_id": 928385,
+    "internal_id": 398656,
     "linked": true
   },
   {
@@ -5652,7 +5652,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-85", "A3-171", "P-A-67", "A4b-180", "A4b-181"],
     "artist": "sui",
-    "internal_id": 1596033,
+    "internal_id": 732480,
     "linked": false
   },
   {
@@ -5682,7 +5682,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-86", "A4b-182", "A4b-183"],
     "artist": "Aya Kusube",
-    "internal_id": 928514,
+    "internal_id": 398721,
     "linked": true
   },
   {
@@ -5712,7 +5712,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-86", "A4b-182", "A4b-183"],
     "artist": "Aya Kusube",
-    "internal_id": 1596290,
+    "internal_id": 732609,
     "linked": false
   },
   {
@@ -5746,7 +5746,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-87", "A3-186", "A3-204", "A3-238", "A4b-184", "A4b-367"],
     "artist": "PLANETA CG Works",
-    "internal_id": 928644,
+    "internal_id": 398787,
     "linked": true
   },
   {
@@ -5776,7 +5776,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-36", "A4b-185", "A4b-186"],
     "artist": "Mina Nakai",
-    "internal_id": 1184257,
+    "internal_id": 526592,
     "linked": true
   },
   {
@@ -5806,7 +5806,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-36", "A4b-185", "A4b-186"],
     "artist": "Mina Nakai",
-    "internal_id": 1596673,
+    "internal_id": 732800,
     "linked": false
   },
   {
@@ -5836,7 +5836,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-37", "P-A-87", "A4b-187", "A4b-188"],
     "artist": "Mizue",
-    "internal_id": 1184386,
+    "internal_id": 526657,
     "linked": true
   },
   {
@@ -5866,7 +5866,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-37", "P-A-87", "A4b-187", "A4b-188"],
     "artist": "Mizue",
-    "internal_id": 1596930,
+    "internal_id": 732929,
     "linked": false
   },
   {
@@ -5896,7 +5896,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-143", "A3-223", "A4b-189", "A4b-190"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 280449,
+    "internal_id": 74688,
     "linked": true
   },
   {
@@ -5926,7 +5926,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-143", "A3-223", "A4b-189", "A4b-190"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1597185,
+    "internal_id": 733056,
     "linked": false
   },
   {
@@ -5956,7 +5956,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-144", "A3-224", "A4b-191", "A4b-192"],
     "artist": "match",
-    "internal_id": 280578,
+    "internal_id": 74753,
     "linked": true
   },
   {
@@ -5986,7 +5986,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-144", "A3-224", "A4b-191", "A4b-192"],
     "artist": "match",
-    "internal_id": 1597442,
+    "internal_id": 733185,
     "linked": false
   },
   {
@@ -6016,7 +6016,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-146", "A1-263", "A1-278", "A3-235", "A4b-193"],
     "artist": "PLANETA CG Works",
-    "internal_id": 280836,
+    "internal_id": 74883,
     "linked": true
   },
   {
@@ -6046,7 +6046,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-151", "A1-239", "A3-226", "A4b-194", "A4b-195"],
     "artist": "sowsow",
-    "internal_id": 281473,
+    "internal_id": 75200,
     "linked": true
   },
   {
@@ -6076,7 +6076,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-151", "A1-239", "A3-226", "A4b-194", "A4b-195"],
     "artist": "sowsow",
-    "internal_id": 1597825,
+    "internal_id": 733376,
     "linked": false
   },
   {
@@ -6106,7 +6106,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-153", "A1-264", "A3-236", "A4b-196"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 281732,
+    "internal_id": 75331,
     "linked": true
   },
   {
@@ -6140,7 +6140,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-46", "A1a-78", "A1a-84", "A3a-101", "A4b-197"],
     "artist": "PLANETA CG Works",
-    "internal_id": 399108,
+    "internal_id": 134019,
     "linked": true
   },
   {
@@ -6170,7 +6170,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-36", "A2a-79", "A4b-198", "A4b-199"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 659970,
+    "internal_id": 264449,
     "linked": true
   },
   {
@@ -6200,7 +6200,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-36", "A2a-79", "A4b-198", "A4b-199"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1598338,
+    "internal_id": 733633,
     "linked": false
   },
   {
@@ -6230,7 +6230,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-99", "A4b-200", "A4b-201"],
     "artist": "Midori Harada",
-    "internal_id": 1323393,
+    "internal_id": 596160,
     "linked": true
   },
   {
@@ -6260,7 +6260,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-99", "A4b-200", "A4b-201"],
     "artist": "Midori Harada",
-    "internal_id": 1598593,
+    "internal_id": 733760,
     "linked": false
   },
   {
@@ -6290,7 +6290,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-100", "A4-191", "A4-206", "A4b-202"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1323524,
+    "internal_id": 596227,
     "linked": true
   },
   {
@@ -6320,7 +6320,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-42", "A4b-203", "A4b-204"],
     "artist": "Satoshi Shirai",
-    "internal_id": 660737,
+    "internal_id": 264832,
     "linked": true
   },
   {
@@ -6350,7 +6350,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-42", "A4b-203", "A4b-204"],
     "artist": "Satoshi Shirai",
-    "internal_id": 1598977,
+    "internal_id": 733952,
     "linked": false
   },
   {
@@ -6380,7 +6380,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-45", "P-A-46", "A4a-98", "A4b-205", "A4b-206"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 661121,
+    "internal_id": 265024,
     "linked": true
   },
   {
@@ -6410,7 +6410,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-45", "P-A-46", "A4a-98", "A4b-205", "A4b-206"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1599233,
+    "internal_id": 734080,
     "linked": false
   },
   {
@@ -6440,7 +6440,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-46", "A4a-99", "A4b-207", "A4b-208"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 661249,
+    "internal_id": 265088,
     "linked": true
   },
   {
@@ -6470,7 +6470,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-46", "A4a-99", "A4b-207", "A4b-208"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1599489,
+    "internal_id": 734208,
     "linked": false
   },
   {
@@ -6506,7 +6506,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-47", "A2a-84", "A2a-93", "A4a-103", "A4b-209"],
     "artist": "PLANETA CG Works",
-    "internal_id": 661380,
+    "internal_id": 265155,
     "linked": true
   },
   {
@@ -6536,7 +6536,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-42", "A2b-104", "P-A-59", "A4b-210", "A4b-211"],
     "artist": "You Iribi",
-    "internal_id": 791809,
+    "internal_id": 330368,
     "linked": true
   },
   {
@@ -6566,7 +6566,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-42", "A2b-104", "P-A-59", "A4b-210", "A4b-211"],
     "artist": "You Iribi",
-    "internal_id": 1599873,
+    "internal_id": 734400,
     "linked": false
   },
   {
@@ -6600,7 +6600,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-92", "A2-170", "A4b-212", "A4b-213"],
     "artist": "nagimiso",
-    "internal_id": 536067,
+    "internal_id": 202498,
     "linked": true
   },
   {
@@ -6634,7 +6634,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-92", "A2-170", "A4b-212", "A4b-213"],
     "artist": "nagimiso",
-    "internal_id": 1600131,
+    "internal_id": 734530,
     "linked": false
   },
   {
@@ -6664,7 +6664,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-43", "A2b-84", "A2b-110", "A4b-214"],
     "artist": "PLANETA CG Works",
-    "internal_id": 791940,
+    "internal_id": 330435,
     "linked": true
   },
   {
@@ -6694,7 +6694,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-95", "A2-185", "A2-200", "A3b-106", "A4b-215"],
     "artist": "PLANETA CG Works",
-    "internal_id": 536452,
+    "internal_id": 202691,
     "linked": true
   },
   {
@@ -6724,7 +6724,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-93", "A4b-216", "A4b-217"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 929409,
+    "internal_id": 399168,
     "linked": true
   },
   {
@@ -6754,7 +6754,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-93", "A4b-216", "A4b-217"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 1600641,
+    "internal_id": 734784,
     "linked": false
   },
   {
@@ -6784,7 +6784,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-97", "P-A-71", "A4b-218", "A4b-219"],
     "artist": "kirisAki",
-    "internal_id": 929921,
+    "internal_id": 399424,
     "linked": true
   },
   {
@@ -6814,7 +6814,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-97", "P-A-71", "A4b-218", "A4b-219"],
     "artist": "kirisAki",
-    "internal_id": 1600897,
+    "internal_id": 734912,
     "linked": false
   },
   {
@@ -6844,7 +6844,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-32", "A4b-220", "A4b-221"],
     "artist": "match",
-    "internal_id": 1052673,
+    "internal_id": 460800,
     "linked": true
   },
   {
@@ -6874,7 +6874,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-32", "A4b-220", "A4b-221"],
     "artist": "match",
-    "internal_id": 1601153,
+    "internal_id": 735040,
     "linked": false
   },
   {
@@ -6904,7 +6904,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-33", "A3a-78", "A3a-85", "A4b-222"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1052804,
+    "internal_id": 460867,
     "linked": true
   },
   {
@@ -6938,7 +6938,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-104", "A3-187", "A3-205", "A4b-223"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 930820,
+    "internal_id": 399875,
     "linked": true
   },
   {
@@ -6968,7 +6968,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-47", "A1a-74", "A4b-224", "A4b-225"],
     "artist": "kantaro",
-    "internal_id": 399235,
+    "internal_id": 134082,
     "linked": true
   },
   {
@@ -6998,7 +6998,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-47", "A1a-74", "A4b-224", "A4b-225"],
     "artist": "kantaro",
-    "internal_id": 1601667,
+    "internal_id": 735298,
     "linked": false
   },
   {
@@ -7028,7 +7028,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-48", "A4b-226", "A4b-227"],
     "artist": "Sekio",
-    "internal_id": 661505,
+    "internal_id": 265216,
     "linked": true
   },
   {
@@ -7058,7 +7058,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-48", "A4b-226", "A4b-227"],
     "artist": "Sekio",
-    "internal_id": 1601921,
+    "internal_id": 735424,
     "linked": false
   },
   {
@@ -7088,7 +7088,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-49", "A4b-228", "A4b-229"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 661633,
+    "internal_id": 265280,
     "linked": true
   },
   {
@@ -7118,7 +7118,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-49", "A4b-228", "A4b-229"],
     "artist": "Kyoko Umemoto",
-    "internal_id": 1602177,
+    "internal_id": 735552,
     "linked": false
   },
   {
@@ -7152,7 +7152,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-50", "A4b-230", "A4b-231"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 661763,
+    "internal_id": 265346,
     "linked": true
   },
   {
@@ -7186,7 +7186,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-50", "A4b-230", "A4b-231"],
     "artist": "AKIRA EGAWA",
-    "internal_id": 1602435,
+    "internal_id": 735682,
     "linked": false
   },
   {
@@ -7216,7 +7216,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-109", "A4-192", "A4-207", "A4b-232"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1324676,
+    "internal_id": 596803,
     "linked": true
   },
   {
@@ -7246,7 +7246,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-110", "A4b-233", "A4b-234"],
     "artist": "Akira Komayama",
-    "internal_id": 931585,
+    "internal_id": 400256,
     "linked": true
   },
   {
@@ -7276,7 +7276,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-110", "A4b-233", "A4b-234"],
     "artist": "Akira Komayama",
-    "internal_id": 1602817,
+    "internal_id": 735872,
     "linked": false
   },
   {
@@ -7306,7 +7306,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-111", "A3-188", "A3-206", "A4b-235"],
     "artist": "PLANETA CG Works",
-    "internal_id": 931716,
+    "internal_id": 400323,
     "linked": true
   },
   {
@@ -7336,7 +7336,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-47", "A4a-100", "A4b-236", "A4b-237"],
     "artist": "Mori Yuu",
-    "internal_id": 792449,
+    "internal_id": 330688,
     "linked": true
   },
   {
@@ -7366,7 +7366,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-47", "A4a-100", "A4b-236", "A4b-237"],
     "artist": "Mori Yuu",
-    "internal_id": 1603201,
+    "internal_id": 736064,
     "linked": false
   },
   {
@@ -7396,7 +7396,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-48", "A2b-85", "A2b-93", "A4a-104", "A4b-238"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 792580,
+    "internal_id": 330755,
     "linked": true
   },
   {
@@ -7426,7 +7426,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-43", "A3b-77", "A4b-239", "A4b-240"],
     "artist": "Ryota Murayama",
-    "internal_id": 1185155,
+    "internal_id": 527042,
     "linked": true
   },
   {
@@ -7456,7 +7456,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-43", "A3b-77", "A4b-239", "A4b-240"],
     "artist": "Ryota Murayama",
-    "internal_id": 1603587,
+    "internal_id": 736258,
     "linked": false
   },
   {
@@ -7490,7 +7490,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-112", "A4-193", "A4-208", "A4b-241"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1325060,
+    "internal_id": 596995,
     "linked": true
   },
   {
@@ -7520,7 +7520,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-98", "A4b-242", "A4b-243"],
     "artist": "Hasuno",
-    "internal_id": 536833,
+    "internal_id": 202880,
     "linked": true
   },
   {
@@ -7550,7 +7550,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-98", "A4b-242", "A4b-243"],
     "artist": "Hasuno",
-    "internal_id": 1603969,
+    "internal_id": 736448,
     "linked": false
   },
   {
@@ -7580,7 +7580,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-99", "A2-186", "A2-201", "A4-238", "A4b-244"],
     "artist": "PLANETA CG Works",
-    "internal_id": 536964,
+    "internal_id": 202947,
     "linked": true
   },
   {
@@ -7614,7 +7614,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-110", "A2-187", "A2-202", "P-A-42", "A4b-245", "A4b-378"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 538372,
+    "internal_id": 203651,
     "linked": true
   },
   {
@@ -7648,7 +7648,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-42", "A3a-103", "A4b-246", "A4b-247"],
     "artist": "nagimiso",
-    "internal_id": 1053955,
+    "internal_id": 461442,
     "linked": true
   },
   {
@@ -7682,7 +7682,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-42", "A3a-103", "A4b-246", "A4b-247"],
     "artist": "nagimiso",
-    "internal_id": 1604483,
+    "internal_id": 736706,
     "linked": false
   },
   {
@@ -7718,7 +7718,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-43", "A3a-79", "A3a-86", "A4b-248"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1054084,
+    "internal_id": 461507,
     "linked": true
   },
   {
@@ -7748,7 +7748,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-46", "A4b-249", "A4b-250"],
     "artist": "Megumi Mizutani",
-    "internal_id": 1054465,
+    "internal_id": 461696,
     "linked": true
   },
   {
@@ -7778,7 +7778,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-46", "A4b-249", "A4b-250"],
     "artist": "Megumi Mizutani",
-    "internal_id": 1604865,
+    "internal_id": 736896,
     "linked": false
   },
   {
@@ -7808,7 +7808,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-47", "A3a-80", "A3a-87", "A4b-251"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1054596,
+    "internal_id": 461763,
     "linked": true
   },
   {
@@ -7838,7 +7838,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-124", "A4-194", "A4-209", "A4b-252"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1326596,
+    "internal_id": 597763,
     "linked": true
   },
   {
@@ -7868,7 +7868,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-57", "A2a-85", "A2a-94", "A4b-253"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 662660,
+    "internal_id": 265795,
     "linked": true
   },
   {
@@ -7904,7 +7904,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-119", "A2-188", "A2-205", "A2-207", "A4b-254", "A4b-368"],
     "artist": "PLANETA CG Works",
-    "internal_id": 539524,
+    "internal_id": 204227,
     "linked": true
   },
   {
@@ -7934,7 +7934,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-119", "A4b-255", "A4b-256"],
     "artist": "SATOSHI NAKAI",
-    "internal_id": 932738,
+    "internal_id": 400833,
     "linked": true
   },
   {
@@ -7964,7 +7964,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-119", "A4b-255", "A4b-256"],
     "artist": "SATOSHI NAKAI",
-    "internal_id": 1605634,
+    "internal_id": 737281,
     "linked": false
   },
   {
@@ -7994,7 +7994,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-121", "A4b-257", "A4b-258"],
     "artist": "Shin Nagasawa",
-    "internal_id": 932995,
+    "internal_id": 400962,
     "linked": true
   },
   {
@@ -8024,7 +8024,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-121", "A4b-257", "A4b-258"],
     "artist": "Shin Nagasawa",
-    "internal_id": 1605891,
+    "internal_id": 737410,
     "linked": false
   },
   {
@@ -8058,7 +8058,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-122", "A3-189", "A3-207", "A3-239", "A4b-259", "A4b-369"],
     "artist": "PLANETA CG Works",
-    "internal_id": 933124,
+    "internal_id": 401027,
     "linked": true
   },
   {
@@ -8088,7 +8088,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-123", "A3-175", "A4b-260", "A4b-261"],
     "artist": "kawayoo",
-    "internal_id": 933251,
+    "internal_id": 401090,
     "linked": true
   },
   {
@@ -8118,7 +8118,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-123", "A3-175", "A4b-260", "A4b-261"],
     "artist": "kawayoo",
-    "internal_id": 1606275,
+    "internal_id": 737602,
     "linked": false
   },
   {
@@ -8148,7 +8148,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-52", "A4b-262", "A4b-263"],
     "artist": "miki kudo",
-    "internal_id": 793089,
+    "internal_id": 331008,
     "linked": true
   },
   {
@@ -8178,7 +8178,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-52", "A4b-262", "A4b-263"],
     "artist": "miki kudo",
-    "internal_id": 1606529,
+    "internal_id": 737728,
     "linked": false
   },
   {
@@ -8208,7 +8208,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-53", "A4b-264", "A4b-265"],
     "artist": "miki kudo",
-    "internal_id": 793218,
+    "internal_id": 331073,
     "linked": true
   },
   {
@@ -8238,7 +8238,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-53", "A4b-264", "A4b-265"],
     "artist": "miki kudo",
-    "internal_id": 1606786,
+    "internal_id": 737857,
     "linked": false
   },
   {
@@ -8268,7 +8268,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-54", "A2b-86", "A2b-94", "A4b-266"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 793348,
+    "internal_id": 331139,
     "linked": true
   },
   {
@@ -8298,7 +8298,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-51", "A4b-267", "A4b-268"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1186177,
+    "internal_id": 527552,
     "linked": true
   },
   {
@@ -8328,7 +8328,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-51", "A4b-267", "A4b-268"],
     "artist": "Naoyo Kimura",
-    "internal_id": 1607169,
+    "internal_id": 738048,
     "linked": false
   },
   {
@@ -8358,7 +8358,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-52", "A4b-269", "A4b-270"],
     "artist": "sui",
-    "internal_id": 1186305,
+    "internal_id": 527616,
     "linked": true
   },
   {
@@ -8388,7 +8388,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-52", "A4b-269", "A4b-270"],
     "artist": "sui",
-    "internal_id": 1607425,
+    "internal_id": 738176,
     "linked": false
   },
   {
@@ -8418,7 +8418,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-53", "A3b-82", "A3b-90", "A4b-271"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 1186436,
+    "internal_id": 527683,
     "linked": true
   },
   {
@@ -8448,7 +8448,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-57", "A4b-272", "A4b-273"],
     "artist": "Shigenori Negishi",
-    "internal_id": 400513,
+    "internal_id": 134720,
     "linked": true
   },
   {
@@ -8478,7 +8478,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-57", "A4b-272", "A4b-273"],
     "artist": "Shigenori Negishi",
-    "internal_id": 1607809,
+    "internal_id": 738368,
     "linked": false
   },
   {
@@ -8508,7 +8508,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-58", "A4b-274", "A4b-275"],
     "artist": "Taiga Kayama",
-    "internal_id": 400641,
+    "internal_id": 134784,
     "linked": true
   },
   {
@@ -8538,7 +8538,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-58", "A4b-274", "A4b-275"],
     "artist": "Taiga Kayama",
-    "internal_id": 1608065,
+    "internal_id": 738496,
     "linked": false
   },
   {
@@ -8568,7 +8568,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-59", "A1a-79", "A3a-102", "A4b-276"],
     "artist": "PLANETA CG Works",
-    "internal_id": 400772,
+    "internal_id": 134851,
     "linked": true
   },
   {
@@ -8598,7 +8598,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-193", "A4b-277", "A4b-278"],
     "artist": "Mizue",
-    "internal_id": 286849,
+    "internal_id": 77888,
     "linked": true
   },
   {
@@ -8628,7 +8628,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-193", "A4b-277", "A4b-278"],
     "artist": "Mizue",
-    "internal_id": 1608449,
+    "internal_id": 738688,
     "linked": false
   },
   {
@@ -8658,7 +8658,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-195", "A1-265", "A1-279", "A3-237", "A4b-279"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 287108,
+    "internal_id": 78019,
     "linked": true
   },
   {
@@ -8688,7 +8688,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-198", "P-A-62", "A3b-102", "A4b-280", "A4b-281", "A4b-359"],
     "artist": "Miki Tanaka",
-    "internal_id": 287489,
+    "internal_id": 78208,
     "linked": true
   },
   {
@@ -8718,7 +8718,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-198", "P-A-62", "A3b-102", "A4b-280", "A4b-281", "A4b-359"],
     "artist": "Miki Tanaka",
-    "internal_id": 1608833,
+    "internal_id": 738880,
     "linked": false
   },
   {
@@ -8748,7 +8748,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-124", "A4-230", "A4b-282", "A4b-283"],
     "artist": "Yukiko Baba",
-    "internal_id": 540161,
+    "internal_id": 204544,
     "linked": true
   },
   {
@@ -8778,7 +8778,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-124", "A4-230", "A4b-282", "A4b-283"],
     "artist": "Yukiko Baba",
-    "internal_id": 1609089,
+    "internal_id": 739008,
     "linked": false
   },
   {
@@ -8808,7 +8808,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-125", "A2-189", "A2-203", "A4-239", "A4b-284"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 540292,
+    "internal_id": 204611,
     "linked": true
   },
   {
@@ -8838,7 +8838,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-55", "A3b-78", "A4b-285", "A4b-286"],
     "artist": "Naoki Saito",
-    "internal_id": 1186689,
+    "internal_id": 527808,
     "linked": true
   },
   {
@@ -8868,7 +8868,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-55", "A3b-78", "A4b-285", "A4b-286"],
     "artist": "Naoki Saito",
-    "internal_id": 1609473,
+    "internal_id": 739200,
     "linked": false
   },
   {
@@ -8902,7 +8902,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-56", "A3b-83", "A3b-92", "A4b-287", "A4b-370", "P-A-109"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1186820,
+    "internal_id": 527875,
     "linked": true
   },
   {
@@ -8936,7 +8936,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-57", "A3b-84", "A3b-91", "A4b-288"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 1186948,
+    "internal_id": 527939,
     "linked": true
   },
   {
@@ -8966,7 +8966,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-149", "A4-195", "A4-211", "A4-241", "A4b-289", "A4b-371"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1329796,
+    "internal_id": 599363,
     "linked": true
   },
   {
@@ -8996,7 +8996,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-129", "A4b-290", "A4b-291"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 934017,
+    "internal_id": 401472,
     "linked": true
   },
   {
@@ -9026,7 +9026,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-129", "A4b-290", "A4b-291"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 1610113,
+    "internal_id": 739520,
     "linked": false
   },
   {
@@ -9056,7 +9056,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-130", "A4b-292", "A4b-293"],
     "artist": "0313",
-    "internal_id": 934146,
+    "internal_id": 401537,
     "linked": true
   },
   {
@@ -9086,7 +9086,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-130", "A4b-292", "A4b-293"],
     "artist": "0313",
-    "internal_id": 1610370,
+    "internal_id": 739649,
     "linked": false
   },
   {
@@ -9116,7 +9116,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-64", "P-A-57", "A4b-294", "A4b-295"],
     "artist": "Sekio",
-    "internal_id": 794625,
+    "internal_id": 331776,
     "linked": true
   },
   {
@@ -9146,7 +9146,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-64", "P-A-57", "A4b-294", "A4b-295"],
     "artist": "Sekio",
-    "internal_id": 1610625,
+    "internal_id": 739776,
     "linked": false
   },
   {
@@ -9176,7 +9176,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-65", "A2b-87", "A2b-95", "A4b-296"],
     "artist": "PLANETA CG Works",
-    "internal_id": 794756,
+    "internal_id": 331843,
     "linked": true
   },
   {
@@ -9210,7 +9210,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-69", "A2a-81", "A4b-297", "A4b-298"],
     "artist": "Mizue",
-    "internal_id": 664195,
+    "internal_id": 266562,
     "linked": true
   },
   {
@@ -9244,7 +9244,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-69", "A2a-81", "A4b-297", "A4b-298"],
     "artist": "Mizue",
-    "internal_id": 1611011,
+    "internal_id": 739970,
     "linked": false
   },
   {
@@ -9278,7 +9278,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-71", "A2a-86", "A2a-95", "A2a-96", "A4b-299", "A4b-372"],
     "artist": "PLANETA CG Works",
-    "internal_id": 664452,
+    "internal_id": 266691,
     "linked": true
   },
   {
@@ -9308,7 +9308,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-60", "A4b-300", "A4b-301"],
     "artist": "match",
-    "internal_id": 1056258,
+    "internal_id": 462593,
     "linked": true
   },
   {
@@ -9338,7 +9338,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-60", "A4b-300", "A4b-301"],
     "artist": "match",
-    "internal_id": 1611394,
+    "internal_id": 740161,
     "linked": false
   },
   {
@@ -9368,7 +9368,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-61", "A3a-74", "A4b-302", "A4b-303"],
     "artist": "Eske Yoshinob",
-    "internal_id": 1056387,
+    "internal_id": 462658,
     "linked": true
   },
   {
@@ -9398,7 +9398,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-61", "A3a-74", "A4b-302", "A4b-303"],
     "artist": "Eske Yoshinob",
-    "internal_id": 1611651,
+    "internal_id": 740290,
     "linked": false
   },
   {
@@ -9432,7 +9432,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-62", "A3a-75", "A4b-304", "A4b-305"],
     "artist": "kawayoo",
-    "internal_id": 1056515,
+    "internal_id": 462722,
     "linked": true
   },
   {
@@ -9466,7 +9466,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-62", "A3a-75", "A4b-304", "A4b-305"],
     "artist": "kawayoo",
-    "internal_id": 1611907,
+    "internal_id": 740418,
     "linked": false
   },
   {
@@ -9496,7 +9496,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-68", "P-A-51", "A4b-306", "A4b-307"],
     "artist": "HAGIYA Kaoru",
-    "internal_id": 795138,
+    "internal_id": 332033,
     "linked": true
   },
   {
@@ -9526,7 +9526,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-68", "P-A-51", "A4b-306", "A4b-307"],
     "artist": "HAGIYA Kaoru",
-    "internal_id": 1612162,
+    "internal_id": 740545,
     "linked": false
   },
   {
@@ -9553,7 +9553,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-66", "A3b-107", "A4b-308", "A4b-309"],
     "artist": "AYUMI ODASHIMA",
-    "internal_id": 1188098,
+    "internal_id": 528513,
     "linked": true
   },
   {
@@ -9580,7 +9580,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-66", "A3b-107", "A4b-308", "A4b-309"],
     "artist": "AYUMI ODASHIMA",
-    "internal_id": 1612418,
+    "internal_id": 740673,
     "linked": false
   },
   {
@@ -9607,7 +9607,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-151", "A4b-310", "A4b-311"],
     "artist": "Toyste Beach",
-    "internal_id": 1330050,
+    "internal_id": 599489,
     "linked": true
   },
   {
@@ -9634,7 +9634,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-151", "A4b-310", "A4b-311"],
     "artist": "Toyste Beach",
-    "internal_id": 1612674,
+    "internal_id": 740801,
     "linked": false
   },
   {
@@ -9661,7 +9661,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-218", "A1a-63", "A4b-312", "A4b-313"],
     "artist": "Toyste Beach",
-    "internal_id": 290049,
+    "internal_id": 79488,
     "linked": true
   },
   {
@@ -9688,7 +9688,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-218", "A1a-63", "A4b-312", "A4b-313"],
     "artist": "Toyste Beach",
-    "internal_id": 1612929,
+    "internal_id": 740928,
     "linked": false
   },
   {
@@ -9715,7 +9715,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-144", "A4b-314", "A4b-315", "A4b-379"],
     "artist": "Toyste Beach",
-    "internal_id": 935938,
+    "internal_id": 402433,
     "linked": true
   },
   {
@@ -9742,7 +9742,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-144", "A4b-314", "A4b-315", "A4b-379"],
     "artist": "Toyste Beach",
-    "internal_id": 1613186,
+    "internal_id": 741057,
     "linked": false
   },
   {
@@ -9769,7 +9769,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-146", "A4b-316", "A4b-317"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 542978,
+    "internal_id": 205953,
     "linked": true
   },
   {
@@ -9796,7 +9796,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-146", "A4b-316", "A4b-317"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 1613442,
+    "internal_id": 741185,
     "linked": false
   },
   {
@@ -9823,7 +9823,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-65", "A4b-318", "A4b-319"],
     "artist": "Toyste Beach",
-    "internal_id": 1056898,
+    "internal_id": 462913,
     "linked": true
   },
   {
@@ -9850,7 +9850,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-65", "A4b-318", "A4b-319"],
     "artist": "Toyste Beach",
-    "internal_id": 1613698,
+    "internal_id": 741313,
     "linked": false
   },
   {
@@ -9877,7 +9877,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-147", "A4b-320", "A4b-321"],
     "artist": "Ryo Ueda",
-    "internal_id": 543106,
+    "internal_id": 206017,
     "linked": true
   },
   {
@@ -9904,7 +9904,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-147", "A4b-320", "A4b-321"],
     "artist": "Ryo Ueda",
-    "internal_id": 1613954,
+    "internal_id": 741441,
     "linked": false
   },
   {
@@ -9931,7 +9931,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-148", "A4b-322", "A4b-323"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 543234,
+    "internal_id": 206081,
     "linked": true
   },
   {
@@ -9958,7 +9958,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-148", "A4b-322", "A4b-323"],
     "artist": "Ayaka Yoshida",
-    "internal_id": 1614210,
+    "internal_id": 741569,
     "linked": false
   },
   {
@@ -9985,7 +9985,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-147", "A4b-324", "A4b-325"],
     "artist": "Toyste Beach",
-    "internal_id": 936322,
+    "internal_id": 402625,
     "linked": true
   },
   {
@@ -10012,7 +10012,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-147", "A4b-324", "A4b-325"],
     "artist": "Toyste Beach",
-    "internal_id": 1614466,
+    "internal_id": 741697,
     "linked": false
   },
   {
@@ -10039,7 +10039,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-150", "A2-190", "A4b-326", "A4b-327"],
     "artist": "akagi",
-    "internal_id": 543490,
+    "internal_id": 206209,
     "linked": true
   },
   {
@@ -10066,7 +10066,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-150", "A2-190", "A4b-326", "A4b-327"],
     "artist": "akagi",
-    "internal_id": 1614722,
+    "internal_id": 741825,
     "linked": false
   },
   {
@@ -10093,7 +10093,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-219", "A1-266", "A4b-328", "A4b-329"],
     "artist": "kirisAki",
-    "internal_id": 290178,
+    "internal_id": 79553,
     "linked": true
   },
   {
@@ -10120,7 +10120,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-219", "A1-266", "A4b-328", "A4b-329"],
     "artist": "kirisAki",
-    "internal_id": 1614978,
+    "internal_id": 741953,
     "linked": false
   },
   {
@@ -10147,7 +10147,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-72", "A2a-87", "A4b-330", "A4b-331"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 664578,
+    "internal_id": 266753,
     "linked": true
   },
   {
@@ -10174,7 +10174,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-72", "A2a-87", "A4b-330", "A4b-331"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 1615234,
+    "internal_id": 742081,
     "linked": false
   },
   {
@@ -10201,7 +10201,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-157", "A4-197", "A4b-332", "A4b-333"],
     "artist": "yuu",
-    "internal_id": 1330818,
+    "internal_id": 599873,
     "linked": true
   },
   {
@@ -10228,7 +10228,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-157", "A4-197", "A4b-332", "A4b-333"],
     "artist": "yuu",
-    "internal_id": 1615490,
+    "internal_id": 742209,
     "linked": false
   },
   {
@@ -10255,7 +10255,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-223", "A1-270", "A4b-334", "A4b-335"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 290690,
+    "internal_id": 79809,
     "linked": true
   },
   {
@@ -10282,7 +10282,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-223", "A1-270", "A4b-334", "A4b-335"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1615746,
+    "internal_id": 742337,
     "linked": false
   },
   {
@@ -10309,7 +10309,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-158", "A4-198", "A4b-336", "A4b-337"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1330946,
+    "internal_id": 599937,
     "linked": true
   },
   {
@@ -10336,7 +10336,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-158", "A4-198", "A4b-336", "A4b-337"],
     "artist": "Hideki Ishikawa",
-    "internal_id": 1616002,
+    "internal_id": 742465,
     "linked": false
   },
   {
@@ -10363,7 +10363,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-225", "A1-272", "A4b-338", "A4b-339"],
     "artist": "Yuu Nishida",
-    "internal_id": 290946,
+    "internal_id": 79937,
     "linked": true
   },
   {
@@ -10390,7 +10390,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-225", "A1-272", "A4b-338", "A4b-339"],
     "artist": "Yuu Nishida",
-    "internal_id": 1616258,
+    "internal_id": 742593,
     "linked": false
   },
   {
@@ -10417,7 +10417,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-69", "A2b-88", "A4b-340", "A4b-341"],
     "artist": "saino misaki",
-    "internal_id": 795266,
+    "internal_id": 332097,
     "linked": true
   },
   {
@@ -10444,7 +10444,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-69", "A2b-88", "A4b-340", "A4b-341"],
     "artist": "saino misaki",
-    "internal_id": 1616514,
+    "internal_id": 742721,
     "linked": false
   },
   {
@@ -10471,7 +10471,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-154", "A2-194", "A4b-342", "A4b-343"],
     "artist": "saino misaki",
-    "internal_id": 544002,
+    "internal_id": 206465,
     "linked": true
   },
   {
@@ -10498,7 +10498,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-154", "A2-194", "A4b-342", "A4b-343"],
     "artist": "saino misaki",
-    "internal_id": 1616770,
+    "internal_id": 742849,
     "linked": false
   },
   {
@@ -10525,7 +10525,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-155", "A2-195", "A4b-344", "A4b-345"],
     "artist": "Yuu Nishida",
-    "internal_id": 544130,
+    "internal_id": 206529,
     "linked": true
   },
   {
@@ -10552,7 +10552,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-155", "A2-195", "A4b-344", "A4b-345"],
     "artist": "Yuu Nishida",
-    "internal_id": 1617026,
+    "internal_id": 742977,
     "linked": false
   },
   {
@@ -10579,7 +10579,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-68", "A1a-82", "A4b-346", "A4b-347"],
     "artist": "En Morikura",
-    "internal_id": 401922,
+    "internal_id": 135425,
     "linked": true
   },
   {
@@ -10606,7 +10606,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-68", "A1a-82", "A4b-346", "A4b-347"],
     "artist": "En Morikura",
-    "internal_id": 1617282,
+    "internal_id": 743105,
     "linked": false
   },
   {
@@ -10633,7 +10633,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-155", "A3-197", "A3-209", "A4b-348", "A4b-349", "A4b-374"],
     "artist": "hechima",
-    "internal_id": 937346,
+    "internal_id": 403137,
     "linked": true
   },
   {
@@ -10660,7 +10660,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-155", "A3-197", "A3-209", "A4b-348", "A4b-349", "A4b-374"],
     "artist": "hechima",
-    "internal_id": 1617538,
+    "internal_id": 743233,
     "linked": false
   },
   {
@@ -10687,7 +10687,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-69", "A3a-83", "A4b-350", "A4b-351", "A4b-375"],
     "artist": "Taira Akitsu",
-    "internal_id": 1057410,
+    "internal_id": 463169,
     "linked": true
   },
   {
@@ -10714,7 +10714,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-69", "A3a-83", "A4b-350", "A4b-351", "A4b-375"],
     "artist": "Taira Akitsu",
-    "internal_id": 1617794,
+    "internal_id": 743361,
     "linked": false
   },
   {
@@ -10741,7 +10741,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-71", "A2b-90", "A4b-352", "A4b-353"],
     "artist": "Teeziro",
-    "internal_id": 795522,
+    "internal_id": 332225,
     "linked": true
   },
   {
@@ -10768,7 +10768,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-71", "A2b-90", "A4b-352", "A4b-353"],
     "artist": "Teeziro",
-    "internal_id": 1618050,
+    "internal_id": 743489,
     "linked": false
   },
   {
@@ -10798,7 +10798,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-6", "A4b-51", "A4b-52", "A4b-354"],
     "artist": "Kariya",
-    "internal_id": 1618181,
+    "internal_id": 743556,
     "linked": false
   },
   {
@@ -10832,7 +10832,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-61", "A4b-104", "A4b-105", "A4b-355"],
     "artist": "REND",
-    "internal_id": 1618309,
+    "internal_id": 743620,
     "linked": false
   },
   {
@@ -10866,7 +10866,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-89", "P-A-19", "A3a-93", "A4b-114", "A4b-115", "A4b-356"],
     "artist": "Noriaki Tanimura",
-    "internal_id": 1618437,
+    "internal_id": 743684,
     "linked": false
   },
   {
@@ -10900,7 +10900,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-132", "A3b-99", "A4b-168", "A4b-169", "A4b-357"],
     "artist": "Tomomi Ozaki",
-    "internal_id": 1618565,
+    "internal_id": 743748,
     "linked": false
   },
   {
@@ -10930,7 +10930,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-32", "A4b-175", "A4b-176", "A4b-358"],
     "artist": "Orca",
-    "internal_id": 1618693,
+    "internal_id": 743812,
     "linked": false
   },
   {
@@ -10960,7 +10960,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-198", "P-A-62", "A3b-102", "A4b-280", "A4b-281", "A4b-359"],
     "artist": "Uninori",
-    "internal_id": 1618821,
+    "internal_id": 743876,
     "linked": false
   },
   {
@@ -10996,7 +10996,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-6", "A3a-76", "A3a-88", "A4b-44", "A4b-360"],
     "artist": "5ban Graphics",
-    "internal_id": 1618950,
+    "internal_id": 743941,
     "linked": false
   },
   {
@@ -11032,7 +11032,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-36", "A1-253", "A1-280", "A1-284", "A4b-59", "A4b-361"],
     "artist": "5ban Graphics",
-    "internal_id": 1619078,
+    "internal_id": 744005,
     "linked": false
   },
   {
@@ -11062,7 +11062,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-34", "A4-187", "A4-210", "A4-240", "A4b-68", "A4b-362"],
     "artist": "5ban Graphics",
-    "internal_id": 1619206,
+    "internal_id": 744069,
     "linked": false
   },
   {
@@ -11098,7 +11098,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-49", "A2-182", "A2-204", "A2-206", "A4b-107", "A4b-363"],
     "artist": "5ban Graphics",
-    "internal_id": 1619334,
+    "internal_id": 744133,
     "linked": false
   },
   {
@@ -11128,7 +11128,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-96", "A1-259", "A1-281", "A1-285", "A4b-131", "A4b-364", "A4b-376"],
     "artist": "5ban Graphics",
-    "internal_id": 1619462,
+    "internal_id": 744197,
     "linked": false
   },
   {
@@ -11164,7 +11164,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-129", "A1-262", "A1-282", "A1-286", "P-A-50", "A4b-158", "A4b-365"],
     "artist": "5ban Graphics",
-    "internal_id": 1619590,
+    "internal_id": 744261,
     "linked": false
   },
   {
@@ -11200,7 +11200,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-32", "A1a-77", "A1a-83", "A1a-86", "A4a-102", "A4b-159", "A4b-366"],
     "artist": "5ban Graphics",
-    "internal_id": 1619718,
+    "internal_id": 744325,
     "linked": false
   },
   {
@@ -11234,7 +11234,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-87", "A3-186", "A3-204", "A3-238", "A4b-184", "A4b-367"],
     "artist": "5ban Graphics",
-    "internal_id": 1619846,
+    "internal_id": 744389,
     "linked": false
   },
   {
@@ -11270,7 +11270,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-119", "A2-188", "A2-205", "A2-207", "A4b-254", "A4b-368"],
     "artist": "5ban Graphics",
-    "internal_id": 1619974,
+    "internal_id": 744453,
     "linked": false
   },
   {
@@ -11304,7 +11304,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-122", "A3-189", "A3-207", "A3-239", "A4b-259", "A4b-369"],
     "artist": "5ban Graphics",
-    "internal_id": 1620102,
+    "internal_id": 744517,
     "linked": false
   },
   {
@@ -11338,7 +11338,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-56", "A3b-83", "A3b-92", "A4b-287", "A4b-370", "P-A-109"],
     "artist": "5ban Graphics",
-    "internal_id": 1620230,
+    "internal_id": 744581,
     "linked": false
   },
   {
@@ -11368,7 +11368,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-149", "A4-195", "A4-211", "A4-241", "A4b-289", "A4b-371"],
     "artist": "5ban Graphics",
-    "internal_id": 1620358,
+    "internal_id": 744645,
     "linked": false
   },
   {
@@ -11402,7 +11402,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-71", "A2a-86", "A2a-95", "A2a-96", "A4b-299", "A4b-372"],
     "artist": "5ban Graphics",
-    "internal_id": 1620486,
+    "internal_id": 744709,
     "linked": false
   },
   {
@@ -11429,7 +11429,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-7", "A4b-373"],
     "artist": "Akira Komayama",
-    "internal_id": 1620614,
+    "internal_id": 744773,
     "linked": false
   },
   {
@@ -11456,7 +11456,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-155", "A3-197", "A3-209", "A4b-348", "A4b-349", "A4b-374"],
     "artist": "yuu",
-    "internal_id": 1620742,
+    "internal_id": 744837,
     "linked": false
   },
   {
@@ -11483,7 +11483,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-69", "A3a-83", "A4b-350", "A4b-351", "A4b-375"],
     "artist": "Taira Akitsu",
-    "internal_id": 1620870,
+    "internal_id": 744901,
     "linked": false
   },
   {
@@ -11513,7 +11513,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-96", "A1-259", "A1-281", "A1-285", "A4b-131", "A4b-364", "A4b-376"],
     "artist": "kantaro",
-    "internal_id": 1620999,
+    "internal_id": 744966,
     "linked": false
   },
   {
@@ -11547,7 +11547,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-35", "A2b-83", "A2b-96", "A4b-172", "A4b-377"],
     "artist": "PLANETA Yamashita",
-    "internal_id": 1621129,
+    "internal_id": 745033,
     "linked": false
   },
   {
@@ -11581,7 +11581,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-110", "A2-187", "A2-202", "P-A-42", "A4b-245", "A4b-378"],
     "artist": "PLANETA CG Works",
-    "internal_id": 1621257,
+    "internal_id": 745097,
     "linked": false
   },
   {
@@ -11608,7 +11608,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-144", "A4b-314", "A4b-315", "A4b-379"],
     "artist": "Toyste Beach",
-    "internal_id": 1621386,
+    "internal_id": 745164,
     "linked": false
   }
 ]

--- a/frontend/assets/cards/P-A.json
+++ b/frontend/assets/cards/P-A.json
@@ -23,7 +23,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-1"],
     "artist": "5ban Graphics",
-    "internal_id": 131211,
+    "internal_id": 12582992,
     "linked": false
   },
   {
@@ -50,7 +50,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-2"],
     "artist": "Toyste Beach",
-    "internal_id": 131339,
+    "internal_id": 12583056,
     "linked": false
   },
   {
@@ -77,7 +77,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-3"],
     "artist": "Toyste Beach",
-    "internal_id": 131467,
+    "internal_id": 12583120,
     "linked": false
   },
   {
@@ -104,7 +104,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-4", "P-A-8"],
     "artist": "Ryo Ueda",
-    "internal_id": 131595,
+    "internal_id": 12583184,
     "linked": false
   },
   {
@@ -131,7 +131,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-5", "A2b-111"],
     "artist": "Ryo Ueda",
-    "internal_id": 131723,
+    "internal_id": 12583248,
     "linked": false
   },
   {
@@ -158,7 +158,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-6"],
     "artist": "5ban Graphics",
-    "internal_id": 131851,
+    "internal_id": 12583312,
     "linked": false
   },
   {
@@ -185,7 +185,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-7", "A4b-373"],
     "artist": "Naoki Saito",
-    "internal_id": 131979,
+    "internal_id": 12583376,
     "linked": false
   },
   {
@@ -212,7 +212,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-4", "P-A-8"],
     "artist": "Yuu Nishida",
-    "internal_id": 132107,
+    "internal_id": 12583440,
     "linked": false
   },
   {
@@ -242,7 +242,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-94", "P-A-9", "P-A-15", "P-A-26", "A4b-128", "A4b-129"],
     "artist": "Atsushi Furusawa",
-    "internal_id": 132235,
+    "internal_id": 12583504,
     "linked": false
   },
   {
@@ -272,7 +272,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-128", "P-A-10"],
     "artist": "Krgc",
-    "internal_id": 132363,
+    "internal_id": 12583568,
     "linked": false
   },
   {
@@ -302,7 +302,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-202", "P-A-11"],
     "artist": "sowsow",
-    "internal_id": 132491,
+    "internal_id": 12583632,
     "linked": false
   },
   {
@@ -332,7 +332,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-196", "A1-246", "P-A-12"],
     "artist": "Shigenori Negishi",
-    "internal_id": 132619,
+    "internal_id": 12583696,
     "linked": false
   },
   {
@@ -366,7 +366,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-7", "P-A-13"],
     "artist": "miki kudo",
-    "internal_id": 132747,
+    "internal_id": 12583760,
     "linked": false
   },
   {
@@ -396,7 +396,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-14"],
     "artist": "PLANETA CG Works",
-    "internal_id": 132875,
+    "internal_id": 12583824,
     "linked": false
   },
   {
@@ -426,7 +426,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-94", "P-A-9", "P-A-15", "P-A-26", "A4b-128", "A4b-129"],
     "artist": "Kouki Saitou",
-    "internal_id": 133003,
+    "internal_id": 12583888,
     "linked": false
   },
   {
@@ -456,7 +456,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-113", "P-A-16"],
     "artist": "Shibuzoh.",
-    "internal_id": 133131,
+    "internal_id": 12583952,
     "linked": false
   },
   {
@@ -486,7 +486,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-17"],
     "artist": "Souichirou Gunjima",
-    "internal_id": 133259,
+    "internal_id": 12584016,
     "linked": false
   },
   {
@@ -516,7 +516,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-3", "P-A-18", "A3-212"],
     "artist": "Kuroimori",
-    "internal_id": 133387,
+    "internal_id": 12584080,
     "linked": false
   },
   {
@@ -550,7 +550,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-89", "P-A-19", "A3a-93", "A4b-114", "A4b-115", "A4b-356"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 133515,
+    "internal_id": 12584144,
     "linked": false
   },
   {
@@ -580,7 +580,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-20"],
     "artist": "Mékayu",
-    "internal_id": 133643,
+    "internal_id": 12584208,
     "linked": false
   },
   {
@@ -610,7 +610,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-150", "P-A-21"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 133771,
+    "internal_id": 12584272,
     "linked": false
   },
   {
@@ -640,7 +640,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-22"],
     "artist": "Kurata So",
-    "internal_id": 133899,
+    "internal_id": 12584336,
     "linked": false
   },
   {
@@ -670,7 +670,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-1", "A1-227", "P-A-23", "A3-210", "A4b-1", "A4b-2"],
     "artist": "Kouki Saitou",
-    "internal_id": 134027,
+    "internal_id": 12584400,
     "linked": false
   },
   {
@@ -700,7 +700,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-97", "P-A-24", "A4-217", "A4b-133", "A4b-134"],
     "artist": "Miki Tanaka",
-    "internal_id": 134155,
+    "internal_id": 12584464,
     "linked": false
   },
   {
@@ -736,7 +736,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-47", "A1-255", "A1-274", "P-A-25", "A3b-103", "A4b-67"],
     "artist": "PLANETA Igarashi",
-    "internal_id": 134283,
+    "internal_id": 12584528,
     "linked": false
   },
   {
@@ -766,7 +766,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-94", "P-A-9", "P-A-15", "P-A-26", "A4b-128", "A4b-129"],
     "artist": "Kouki Saitou",
-    "internal_id": 134411,
+    "internal_id": 12584592,
     "linked": false
   },
   {
@@ -796,7 +796,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-27"],
     "artist": "Yoriyuki Ikegami",
-    "internal_id": 134539,
+    "internal_id": 12584656,
     "linked": false
   },
   {
@@ -826,7 +826,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-14", "P-A-28"],
     "artist": "Shin Nagasawa",
-    "internal_id": 134667,
+    "internal_id": 12584720,
     "linked": false
   },
   {
@@ -856,7 +856,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-55", "P-A-29", "A3-217"],
     "artist": "danciao",
-    "internal_id": 134795,
+    "internal_id": 12584784,
     "linked": false
   },
   {
@@ -886,7 +886,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-30"],
     "artist": "En Morikura",
-    "internal_id": 134923,
+    "internal_id": 12584848,
     "linked": false
   },
   {
@@ -916,7 +916,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-213", "P-A-31"],
     "artist": "MAHOU",
-    "internal_id": 135051,
+    "internal_id": 12584912,
     "linked": false
   },
   {
@@ -946,7 +946,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-33", "A1-230", "P-A-32", "A4b-55", "A4b-56"],
     "artist": "Naoyo Kimura",
-    "internal_id": 135179,
+    "internal_id": 12584976,
     "linked": false
   },
   {
@@ -976,7 +976,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-53", "A1-232", "P-A-33", "A3-215", "A4b-83", "A4b-84"],
     "artist": "Kanako Eo",
-    "internal_id": 135307,
+    "internal_id": 12585040,
     "linked": false
   },
   {
@@ -1006,7 +1006,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-35", "P-A-34"],
     "artist": "Kariya",
-    "internal_id": 135435,
+    "internal_id": 12585104,
     "linked": false
   },
   {
@@ -1036,7 +1036,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-10", "P-A-35"],
     "artist": "Atsuko Nishida",
-    "internal_id": 135563,
+    "internal_id": 12585168,
     "linked": false
   },
   {
@@ -1066,7 +1066,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-57", "P-A-36"],
     "artist": "Sumiyoshi Kizuki",
-    "internal_id": 135691,
+    "internal_id": 12585232,
     "linked": false
   },
   {
@@ -1100,7 +1100,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-37"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 135819,
+    "internal_id": 12585296,
     "linked": false
   },
   {
@@ -1130,7 +1130,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-38"],
     "artist": "Miki Tanaka",
-    "internal_id": 135947,
+    "internal_id": 12585360,
     "linked": false
   },
   {
@@ -1160,7 +1160,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-111", "P-A-39"],
     "artist": "Anesaki Dynamic",
-    "internal_id": 136075,
+    "internal_id": 12585424,
     "linked": false
   },
   {
@@ -1190,7 +1190,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-27", "P-A-40", "A4a-91", "A4b-71", "A4b-72"],
     "artist": "sui",
-    "internal_id": 136203,
+    "internal_id": 12585488,
     "linked": false
   },
   {
@@ -1220,7 +1220,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-63", "P-A-41"],
     "artist": "Naoyo Kimura",
-    "internal_id": 136331,
+    "internal_id": 12585552,
     "linked": false
   },
   {
@@ -1254,7 +1254,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-110", "A2-187", "A2-202", "P-A-42", "A4b-245", "A4b-378"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 136459,
+    "internal_id": 12585616,
     "linked": false
   },
   {
@@ -1284,7 +1284,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-8", "P-A-43"],
     "artist": "MAHOU",
-    "internal_id": 136587,
+    "internal_id": 12585680,
     "linked": false
   },
   {
@@ -1318,7 +1318,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-26", "P-A-44"],
     "artist": "Kazumasa Yasukuni",
-    "internal_id": 136715,
+    "internal_id": 12585744,
     "linked": false
   },
   {
@@ -1348,7 +1348,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-45"],
     "artist": "Tomokazu Komiya",
-    "internal_id": 136843,
+    "internal_id": 12585808,
     "linked": false
   },
   {
@@ -1378,7 +1378,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-45", "P-A-46", "A4a-98", "A4b-205", "A4b-206"],
     "artist": "Uninori",
-    "internal_id": 136971,
+    "internal_id": 12585872,
     "linked": false
   },
   {
@@ -1412,7 +1412,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-47"],
     "artist": "Hasuno",
-    "internal_id": 137099,
+    "internal_id": 12585936,
     "linked": false
   },
   {
@@ -1442,7 +1442,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-50", "A2-162", "P-A-48", "A4b-108", "A4b-109"],
     "artist": "sui",
-    "internal_id": 137227,
+    "internal_id": 12586000,
     "linked": false
   },
   {
@@ -1472,7 +1472,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2a-63", "P-A-49"],
     "artist": "okayamatakatoshi",
-    "internal_id": 137355,
+    "internal_id": 12586064,
     "linked": false
   },
   {
@@ -1508,7 +1508,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-129", "A1-262", "A1-282", "A1-286", "P-A-50", "A4b-158", "A4b-365"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 137483,
+    "internal_id": 12586128,
     "linked": false
   },
   {
@@ -1538,7 +1538,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-68", "P-A-51", "A4b-306", "A4b-307"],
     "artist": "Shigenori Negishi",
-    "internal_id": 137611,
+    "internal_id": 12586192,
     "linked": false
   },
   {
@@ -1568,7 +1568,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-5", "P-A-52", "A4b-49", "A4b-50"],
     "artist": "MINAMINAMI Take",
-    "internal_id": 137739,
+    "internal_id": 12586256,
     "linked": false
   },
   {
@@ -1598,7 +1598,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-53"],
     "artist": "Shin Nagasawa",
-    "internal_id": 137867,
+    "internal_id": 12586320,
     "linked": false
   },
   {
@@ -1632,7 +1632,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-28", "P-A-54"],
     "artist": "REND",
-    "internal_id": 137995,
+    "internal_id": 12586384,
     "linked": false
   },
   {
@@ -1662,7 +1662,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-39", "P-A-55", "A3-225"],
     "artist": "Masakazu Fukuda",
-    "internal_id": 138123,
+    "internal_id": 12586448,
     "linked": false
   },
   {
@@ -1692,7 +1692,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-56"],
     "artist": "Krgc",
-    "internal_id": 138251,
+    "internal_id": 12586512,
     "linked": false
   },
   {
@@ -1722,7 +1722,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-64", "P-A-57", "A4b-294", "A4b-295"],
     "artist": "Kouki Saitou",
-    "internal_id": 138379,
+    "internal_id": 12586576,
     "linked": false
   },
   {
@@ -1752,7 +1752,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-25", "A2b-103", "P-A-58", "A4b-143", "A4b-144"],
     "artist": "OOYAMA",
-    "internal_id": 138507,
+    "internal_id": 12586640,
     "linked": false
   },
   {
@@ -1782,7 +1782,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2b-42", "A2b-104", "P-A-59", "A4b-210", "A4b-211"],
     "artist": "Akira Komayama",
-    "internal_id": 138635,
+    "internal_id": 12586704,
     "linked": false
   },
   {
@@ -1812,7 +1812,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1a-1", "P-A-60"],
     "artist": "0313",
-    "internal_id": 138763,
+    "internal_id": 12586768,
     "linked": false
   },
   {
@@ -1842,7 +1842,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-87", "P-A-61", "A3a-91", "A4b-110", "A4b-111"],
     "artist": "Sanosuke Sakuma",
-    "internal_id": 138891,
+    "internal_id": 12586832,
     "linked": false
   },
   {
@@ -1872,7 +1872,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-198", "P-A-62", "A3b-102", "A4b-280", "A4b-281", "A4b-359"],
     "artist": "Eri Yamaki",
-    "internal_id": 139019,
+    "internal_id": 12586896,
     "linked": false
   },
   {
@@ -1902,7 +1902,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-63"],
     "artist": "Yoshinobu Saito",
-    "internal_id": 139147,
+    "internal_id": 12586960,
     "linked": false
   },
   {
@@ -1932,7 +1932,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-64", "P-A-65"],
     "artist": "PLANETA CG Works",
-    "internal_id": 139275,
+    "internal_id": 12587024,
     "linked": false
   },
   {
@@ -1962,7 +1962,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-64", "P-A-65"],
     "artist": "PLANETA CG Works",
-    "internal_id": 139403,
+    "internal_id": 12587088,
     "linked": false
   },
   {
@@ -1992,7 +1992,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-83", "P-A-66"],
     "artist": "Amelicart",
-    "internal_id": 139531,
+    "internal_id": 12587152,
     "linked": false
   },
   {
@@ -2022,7 +2022,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-85", "A3-171", "P-A-67", "A4b-180", "A4b-181"],
     "artist": "Mizue",
-    "internal_id": 139659,
+    "internal_id": 12587216,
     "linked": false
   },
   {
@@ -2052,7 +2052,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-100", "P-A-68"],
     "artist": "Ryuta Fuse",
-    "internal_id": 139787,
+    "internal_id": 12587280,
     "linked": false
   },
   {
@@ -2082,7 +2082,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-2", "A3-156", "P-A-69"],
     "artist": "Satoshi Shirai",
-    "internal_id": 139915,
+    "internal_id": 12587344,
     "linked": false
   },
   {
@@ -2112,7 +2112,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-41", "P-A-70"],
     "artist": "tono",
-    "internal_id": 140043,
+    "internal_id": 12587408,
     "linked": false
   },
   {
@@ -2142,7 +2142,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3-97", "P-A-71", "A4b-218", "A4b-219"],
     "artist": "Miki Tanaka",
-    "internal_id": 140171,
+    "internal_id": 12587472,
     "linked": false
   },
   {
@@ -2172,7 +2172,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-72"],
     "artist": "Naoki Saito",
-    "internal_id": 140299,
+    "internal_id": 12587536,
     "linked": false
   },
   {
@@ -2202,7 +2202,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-73"],
     "artist": "Sekio",
-    "internal_id": 140427,
+    "internal_id": 12587600,
     "linked": false
   },
   {
@@ -2236,7 +2236,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-21", "P-A-74", "A4b-149", "A4b-150"],
     "artist": "GIDORA",
-    "internal_id": 140555,
+    "internal_id": 12587664,
     "linked": false
   },
   {
@@ -2266,7 +2266,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-8", "P-A-75", "A4b-47", "A4b-48"],
     "artist": "Hasuno",
-    "internal_id": 140683,
+    "internal_id": 12587728,
     "linked": false
   },
   {
@@ -2296,7 +2296,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-9", "A3a-72", "P-A-76"],
     "artist": "Hasuno",
-    "internal_id": 140811,
+    "internal_id": 12587792,
     "linked": false
   },
   {
@@ -2326,7 +2326,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-20", "P-A-77"],
     "artist": "Shin Nagasawa",
-    "internal_id": 140939,
+    "internal_id": 12587856,
     "linked": false
   },
   {
@@ -2356,7 +2356,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-78"],
     "artist": "nagimiso",
-    "internal_id": 141067,
+    "internal_id": 12587920,
     "linked": false
   },
   {
@@ -2386,7 +2386,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-79"],
     "artist": "nagimiso",
-    "internal_id": 141195,
+    "internal_id": 12587984,
     "linked": false
   },
   {
@@ -2416,7 +2416,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-53", "P-A-80"],
     "artist": "Shin Nagasawa",
-    "internal_id": 141323,
+    "internal_id": 12588048,
     "linked": false
   },
   {
@@ -2452,7 +2452,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-81"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 141451,
+    "internal_id": 12588112,
     "linked": false
   },
   {
@@ -2482,7 +2482,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-44", "P-A-82"],
     "artist": "Megumi Mizutani",
-    "internal_id": 141579,
+    "internal_id": 12588176,
     "linked": false
   },
   {
@@ -2512,7 +2512,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-57", "P-A-83"],
     "artist": "Kanako Eo",
-    "internal_id": 141707,
+    "internal_id": 12588240,
     "linked": false
   },
   {
@@ -2548,7 +2548,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3a-19", "A3a-77", "A3a-84", "P-A-84", "A4b-148"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 141835,
+    "internal_id": 12588304,
     "linked": false
   },
   {
@@ -2578,7 +2578,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-18", "P-A-85"],
     "artist": "OOYAMA",
-    "internal_id": 141963,
+    "internal_id": 12588368,
     "linked": false
   },
   {
@@ -2608,7 +2608,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-25", "A3b-74", "P-A-86", "A4-219"],
     "artist": "Mizue",
-    "internal_id": 142091,
+    "internal_id": 12588432,
     "linked": false
   },
   {
@@ -2638,7 +2638,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-37", "P-A-87", "A4b-187", "A4b-188"],
     "artist": "Tika Matsuno",
-    "internal_id": 142219,
+    "internal_id": 12588496,
     "linked": false
   },
   {
@@ -2668,7 +2668,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-88"],
     "artist": "Shinya Komatsu",
-    "internal_id": 142347,
+    "internal_id": 12588560,
     "linked": false
   },
   {
@@ -2698,7 +2698,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-89"],
     "artist": "MAHOU",
-    "internal_id": 142475,
+    "internal_id": 12588624,
     "linked": false
   },
   {
@@ -2728,7 +2728,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-48", "P-A-90"],
     "artist": "sowsow",
-    "internal_id": 142603,
+    "internal_id": 12588688,
     "linked": false
   },
   {
@@ -2758,7 +2758,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-65", "P-A-91"],
     "artist": "HYOGONOSUKE",
-    "internal_id": 142731,
+    "internal_id": 12588752,
     "linked": false
   },
   {
@@ -2788,7 +2788,7 @@
     "pack": "everypack",
     "alternate_versions": ["A1-206", "A1-207", "A1-208", "A1-248", "P-A-92"],
     "artist": "nisimono",
-    "internal_id": 142859,
+    "internal_id": 12588816,
     "linked": false
   },
   {
@@ -2818,7 +2818,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-77", "P-A-93"],
     "artist": "Tika Matsuno",
-    "internal_id": 142987,
+    "internal_id": 12588880,
     "linked": false
   },
   {
@@ -2848,7 +2848,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-94"],
     "artist": "Taira Akitsu",
-    "internal_id": 143115,
+    "internal_id": 12588944,
     "linked": false
   },
   {
@@ -2878,7 +2878,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-95"],
     "artist": "Aya Kusube",
-    "internal_id": 143243,
+    "internal_id": 12589008,
     "linked": false
   },
   {
@@ -2908,7 +2908,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-118", "P-A-96"],
     "artist": "Kagemaru Himeno",
-    "internal_id": 143371,
+    "internal_id": 12589072,
     "linked": false
   },
   {
@@ -2938,7 +2938,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-133", "P-A-97"],
     "artist": "Kouki Saitou",
-    "internal_id": 143499,
+    "internal_id": 12589136,
     "linked": false
   },
   {
@@ -2968,7 +2968,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-98"],
     "artist": "PLANETA CG Works",
-    "internal_id": 143627,
+    "internal_id": 12589200,
     "linked": false
   },
   {
@@ -2998,7 +2998,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-49", "P-A-99"],
     "artist": "Shibuzoh.",
-    "internal_id": 143755,
+    "internal_id": 12589264,
     "linked": false
   },
   {
@@ -3028,7 +3028,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-116", "P-A-100"],
     "artist": "Satoshi Shirai",
-    "internal_id": 143883,
+    "internal_id": 12589328,
     "linked": false
   },
   {
@@ -3058,7 +3058,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-36", "P-A-101"],
     "artist": "Yuu Nishida",
-    "internal_id": 144011,
+    "internal_id": 12589392,
     "linked": false
   },
   {
@@ -3088,7 +3088,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-102"],
     "artist": "sowsow",
-    "internal_id": 144139,
+    "internal_id": 12589456,
     "linked": false
   },
   {
@@ -3118,7 +3118,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-103"],
     "artist": "MAHOU",
-    "internal_id": 144267,
+    "internal_id": 12589520,
     "linked": false
   },
   {
@@ -3152,7 +3152,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-22", "A4a-72", "P-A-104"],
     "artist": "Hajime Kusajima",
-    "internal_id": 144395,
+    "internal_id": 12589584,
     "linked": false
   },
   {
@@ -3182,7 +3182,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-49", "P-A-105"],
     "artist": "Naoyo Kimura",
-    "internal_id": 144523,
+    "internal_id": 12589648,
     "linked": false
   },
   {
@@ -3216,7 +3216,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-50", "P-A-106"],
     "artist": "matazo",
-    "internal_id": 144651,
+    "internal_id": 12589712,
     "linked": false
   },
   {
@@ -3246,7 +3246,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-62", "P-A-107"],
     "artist": "Kanako Eo",
-    "internal_id": 144779,
+    "internal_id": 12589776,
     "linked": false
   },
   {
@@ -3276,7 +3276,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-43", "A4a-76", "P-A-108"],
     "artist": "Asako Ito",
-    "internal_id": 144907,
+    "internal_id": 12589840,
     "linked": false
   },
   {
@@ -3310,7 +3310,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-56", "A3b-83", "A3b-92", "A4b-287", "A4b-370", "P-A-109"],
     "artist": "Kanami Ogata",
-    "internal_id": 145035,
+    "internal_id": 12589904,
     "linked": false
   },
   {
@@ -3344,7 +3344,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4a-10", "A4a-79", "A4a-87", "P-A-110"],
     "artist": "PLANETA Tsuji",
-    "internal_id": 145163,
+    "internal_id": 12589968,
     "linked": false
   },
   {
@@ -3374,7 +3374,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-111"],
     "artist": "sui",
-    "internal_id": 145291,
+    "internal_id": 12590032,
     "linked": false
   },
   {
@@ -3404,7 +3404,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-112"],
     "artist": "PLANETA Mochizuki",
-    "internal_id": 145419,
+    "internal_id": 12590096,
     "linked": false
   },
   {
@@ -3434,7 +3434,7 @@
     "pack": "everypack",
     "alternate_versions": ["A3b-35", "P-A-113"],
     "artist": "Yuka Morii",
-    "internal_id": 145547,
+    "internal_id": 12590160,
     "linked": false
   },
   {
@@ -3464,7 +3464,7 @@
     "pack": "everypack",
     "alternate_versions": ["P-A-114"],
     "artist": "Naoki Saito",
-    "internal_id": 145675,
+    "internal_id": 12590224,
     "linked": false
   },
   {
@@ -3494,7 +3494,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-143", "A2-179", "P-A-115"],
     "artist": "Ryuta Fuse",
-    "internal_id": 145803,
+    "internal_id": 12590288,
     "linked": false
   },
   {
@@ -3528,7 +3528,7 @@
     "pack": "everypack",
     "alternate_versions": ["A2-22", "A2-159", "A4b-30", "A4b-31", "P-A-116"],
     "artist": "Sekio",
-    "internal_id": 145931,
+    "internal_id": 12590352,
     "linked": false
   },
   {
@@ -3558,7 +3558,7 @@
     "pack": "everypack",
     "alternate_versions": ["A4-120", "P-A-117"],
     "artist": "Eri Yamaki",
-    "internal_id": 146059,
+    "internal_id": 12590416,
     "linked": false
   }
 ]

--- a/frontend/src/components/BatchUpdateDialog.tsx
+++ b/frontend/src/components/BatchUpdateDialog.tsx
@@ -26,12 +26,15 @@ export function BatchUpdateDialog({ filteredCards }: BatchUpdateDialogProps) {
 
   const onBatchUpdate = async (cardIds: string[], amount: number) => {
     updateCardsMutation.mutate({
-      updates: cardIds.map((card_id) => ({
-        card_id,
-        rarity: getCardById(card_id)?.rarity || '',
-        internal_id: getInteralIdByCardId(card_id),
-        amount_owned: amount,
-      })),
+      updates: cardIds
+        .map(getCardById)
+        .filter((card): card is Card => Boolean(card))
+        .map((card) => ({
+          card_id: card.card_id,
+          rarity: card.rarity,
+          internal_id: getInteralIdByCardId(card.card_id),
+          amount_owned: amount,
+        })),
     })
   }
 

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -98,7 +98,7 @@ const FilterPanel: FC<Props> = ({ cards, filters, setFilters, onFiltersChanged, 
     let filteredCards = allCards
 
     if (filters.deckbuildingMode) {
-      filteredCards = filteredCards.filter((c) => basicRarities.includes(c.rarity) || c.rarity === '' || c.rarity === 'P')
+      filteredCards = filteredCards.filter((c) => basicRarities.includes(c.rarity) || c.rarity === 'P')
     }
 
     if (filters.expansion !== 'all') {
@@ -146,7 +146,7 @@ const FilterPanel: FC<Props> = ({ cards, filters, setFilters, onFiltersChanged, 
       if (filters.rarity.length === 0) {
         return true
       }
-      return c.rarity !== '' && filters.rarity.includes(c.rarity)
+      return filters.rarity.includes(c.rarity)
     })
     filteredCards = filteredCards.filter((c: Card) => {
       if (filters.cardType.length === 0) {

--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -79,10 +79,11 @@ const a4aMissions: Mission[] = A4aMissions as unknown as Mission[]
 const a4bMissions: Mission[] = A4bMissions as unknown as Mission[]
 
 export const expansions: Expansion[] = [
+  // internalId=0 skipped for error states
   {
     name: 'promo-a',
     id: 'P-A',
-    internalId: 1, // IMPORTANT note: these should NEVER EVER change. The internals of the DB depend on it.
+    internalId: 192, // IMPORTANT note: these should NEVER EVER change. The internals of the DB depend on it.
     cards: paCards,
     packs: [{ name: 'everypack', color: '#CCCCCC' }],
     tradeable: false,
@@ -91,7 +92,7 @@ export const expansions: Expansion[] = [
   {
     name: 'geneticapex',
     id: 'A1',
-    internalId: 2,
+    internalId: 1,
     cards: a1Cards,
     packs: [
       { name: 'mewtwopack', color: '#986C88' },
@@ -105,7 +106,7 @@ export const expansions: Expansion[] = [
   {
     name: 'mythicalisland',
     id: 'A1a',
-    internalId: 3,
+    internalId: 2,
     cards: a1aCards,
     packs: [{ name: 'mewpack', color: '#FFC1EA' }],
     missions: a1aMissions,
@@ -114,7 +115,7 @@ export const expansions: Expansion[] = [
   {
     name: 'space-timesmackdown',
     id: 'A2',
-    internalId: 4,
+    internalId: 3,
     cards: a2Cards,
     packs: [
       { name: 'dialgapack', color: '#A0C5E8' },
@@ -127,7 +128,7 @@ export const expansions: Expansion[] = [
   {
     name: 'triumphantlight',
     id: 'A2a',
-    internalId: 5,
+    internalId: 4,
     cards: a2aCards,
     packs: [{ name: 'arceuspack', color: '#E4D7CA' }],
     missions: a2aMissions,
@@ -136,7 +137,7 @@ export const expansions: Expansion[] = [
   {
     name: 'shiningrevelry',
     id: 'A2b',
-    internalId: 6,
+    internalId: 5,
     cards: a2bCards,
     packs: [{ name: 'shiningrevelrypack', color: '#99F6E4' }],
     missions: a2bMissions,
@@ -146,7 +147,7 @@ export const expansions: Expansion[] = [
   {
     name: 'celestialguardians',
     id: 'A3',
-    internalId: 7,
+    internalId: 6,
     cards: a3Cards,
     packs: [
       { name: 'lunalapack', color: '#A0ABE0' },
@@ -160,7 +161,7 @@ export const expansions: Expansion[] = [
   {
     name: 'extradimensionalcrisis',
     id: 'A3a',
-    internalId: 8,
+    internalId: 7,
     cards: a3aCards,
     packs: [{ name: 'buzzwolepack', color: '#ef4444' }],
     missions: a3aMissions,
@@ -170,7 +171,7 @@ export const expansions: Expansion[] = [
   {
     name: 'eeveegrove',
     id: 'A3b',
-    internalId: 9,
+    internalId: 8,
     cards: a3bCards,
     packs: [{ name: 'eeveegrovepack', color: '#b45309' }],
     missions: a3bMissions,
@@ -180,7 +181,7 @@ export const expansions: Expansion[] = [
   {
     name: 'wisdomofseaandsky',
     id: 'A4',
-    internalId: 10,
+    internalId: 9,
     cards: a4Cards,
     packs: [
       { name: 'ho-ohpack', color: '#FE3A2B' },
@@ -194,7 +195,7 @@ export const expansions: Expansion[] = [
   {
     name: 'secludedsprings',
     id: 'A4a',
-    internalId: 11,
+    internalId: 10,
     cards: a4aCards,
     packs: [{ name: 'suicunepack', color: '#E9B00D' }],
     missions: a4aMissions,
@@ -205,7 +206,7 @@ export const expansions: Expansion[] = [
   {
     name: 'deluxepackex',
     id: 'A4b',
-    internalId: 12,
+    internalId: 11,
     cards: a4bCards,
     packs: [{ name: 'deluxepack', color: '#CCA331' }],
     missions: a4bMissions,
@@ -332,7 +333,6 @@ const createRarityProbability = (probabilities: Partial<Record<Rarity, number>>)
   '✵✵': 0,
   'Crown Rare': 0,
   P: 0,
-  '': 0,
   ...probabilities,
 })
 
@@ -473,13 +473,8 @@ export const pullRate = ({ ownedCards, expansion, pack, rarityFilter = [], numbe
   let missingCards = cardsInPackWithAmounts.filter((c) => c.amount_owned <= numberFilter - 1)
 
   if (rarityFilter.length > 0) {
-    //filter out cards that are not in the rarity filter
-    missingCards = missingCards.filter((c) => {
-      if (c.rarity === '') {
-        return false
-      }
-      return rarityFilter.includes(c.rarity)
-    })
+    // filter out cards that are not in the rarity filter
+    missingCards = missingCards.filter((c) => rarityFilter.includes(c.rarity))
   }
 
   return pullRateForCardSubset(missingCards, expansion, cardsInPack, deckbuildingMode)
@@ -530,7 +525,7 @@ const pullRateForCardSubset = (missingCards: Card[], expansion: Expansion, cards
   for (const card of missingCardsFromPack) {
     const rarityList = [card.rarity]
     // Skip cards that cannot be picked
-    if (rarityList[0] === 'P' || rarityList[0] === '') {
+    if (rarityList[0] === 'P') {
       continue
     }
 

--- a/frontend/src/pages/scan/Scan.tsx
+++ b/frontend/src/pages/scan/Scan.tsx
@@ -12,7 +12,7 @@ import { calculatePerceptualHash, calculateSimilarity, imageToBuffers } from '@/
 import { getCardNameByLang } from '@/lib/utils'
 import { useCollection, useUpdateCards } from '@/services/collection/useCollection'
 import CardDetectorService, { type DetectionResult } from '@/services/scanner/CardDetectionService'
-import type { Card, CollectionRow } from '@/types'
+import type { Card, CollectionRow, Rarity } from '@/types'
 
 interface ExtractedCard {
   imageUrl: string
@@ -332,7 +332,7 @@ const Scan = () => {
       updateCardsMutation.mutate({
         updates: updates.map((x) => ({
           card_id: x.card_id,
-          rarity: getCardById(x.card_id)?.rarity ?? '',
+          rarity: getCardById(x.card_id)?.rarity as Rarity,
           internal_id: getInteralIdByCardId(x.card_id),
           amount_owned: x.previous_amount + x.increment,
         })),

--- a/frontend/src/pages/trade/components/TradeList.tsx
+++ b/frontend/src/pages/trade/components/TradeList.tsx
@@ -36,7 +36,10 @@ function TradeList({ trades, viewHistory }: Props) {
 
   const getAndIncrement = (card_id: string, increment: number): CardAmountUpdate => {
     const internal_id = getInteralIdByCardId(card_id)
-    const rarity = getCardById(card_id)?.rarity || ''
+    const rarity = getCardById(card_id)?.rarity
+    if (rarity === undefined) {
+      throw new Error(`Could not find card: ${card_id}`)
+    }
     return { card_id, internal_id, rarity, amount_owned: (ownedCards.get(internal_id)?.amount_owned ?? 0) + increment }
   }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,7 +5,7 @@ export type User = Session
 export const expansionIds = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'A3a', 'A3b', 'A4', 'A4a', 'A4b', 'P-A'] as const
 export type ExpansionId = (typeof expansionIds)[number]
 
-export const rarities = ['◊', '◊◊', '◊◊◊', '◊◊◊◊', '☆', '☆☆', '☆☆☆', '✵', '✵✵', 'Crown Rare', 'P', ''] as const
+export const rarities = ['◊', '◊◊', '◊◊◊', '◊◊◊◊', '☆', '☆☆', '☆☆☆', '✵', '✵✵', 'Crown Rare', 'P'] as const
 export const tradableRarities = ['◊', '◊◊', '◊◊◊', '◊◊◊◊', '☆'] as const
 
 export const cardTypes = ['grass', 'fire', 'water', 'lightning', 'psychic', 'fighting', 'darkness', 'metal', 'dragon', 'colorless', 'trainer', ''] as const

--- a/scripts/encoder.ts
+++ b/scripts/encoder.ts
@@ -1,26 +1,27 @@
 import { expansions } from '../frontend/src/lib/CardsDB'
-import type { Expansion } from '../frontend/src/types'
+import type { Expansion, ExpansionId, Rarity } from '../frontend/src/types'
 
-const MASK_7 = 0x7f // 127 - for expansion and rarity (up to 99)
+const MASK_6 = 0x3f // 63 - for rarity
+const MASK_8 = 0xff // 255 - for expansion and rarity (up to 199)
 const MASK_10 = 0x3ff // 1023 - for card number (up to 999)
 
 export function encode(expansion: Expansion, cardNr: number, rarity: Rarity): number {
   console.log('encoding', expansion.id, cardNr, rarity)
-  const expansionId = expansion.internalId ?? 0
-  const rarityId = rarityToId[rarity] ?? 0
+  const expansionId = expansion.internalId
+  const rarityId = rarityToId[rarity]
 
-  if (expansionId < 1 || expansionId > 99) {
-    throw new Error('Expansion ID must be 1-99')
+  if (expansionId < 1 || expansionId > 199) {
+    throw new Error('Expansion ID must be 1-199')
   }
   if (cardNr < 1 || cardNr > 999) {
     throw new Error('Card number must be 1-999')
   }
-  if (rarityId < 1 || rarityId > 99) {
-    throw new Error('Rarity ID must be 1-99')
+  if (rarityId < 0 || rarityId > 63) {
+    throw new Error('Rarity ID must be 0-63')
   }
 
-  // Layout: [7 bits expansion][10 bits cardNr][7 bits rarity] = 24 bits total
-  const encoded = (expansionId << 17) | (cardNr << 7) | rarityId
+  // Layout: [8 bits expansion][10 bits cardNr][6 bits rarity] = 24 bits total
+  const encoded = (expansionId << 16) | (cardNr << 6) | rarityId
   const x = encoded >>> 0 // unsigned 32-bit
 
   console.log('encoded', x)
@@ -30,31 +31,35 @@ export function encode(expansion: Expansion, cardNr: number, rarity: Rarity): nu
 }
 
 export function decode(id: number) {
-  const rarityId = id & MASK_7
-  const card = (id >>> 7) & MASK_10
-  const expansionId = (id >>> 17) & MASK_7
-  return {
-    expansion: expansions.find((e) => e.internalId === expansionId)?.id ?? '',
-    card,
-    rarity: rarities[rarityId] ?? '',
+  const rarityId = id & MASK_6
+  const card = (id >>> 6) & MASK_10
+  const expansionId = (id >>> 16) & MASK_8
+
+  const rarity = rarityIdToRarity.get(rarityId)
+  const expansion = expansions.find((e) => e.internalId === expansionId)
+  if (rarity === undefined || expansion === undefined) {
+    throw new Error(`Cannot decode ${id}: rarity=${rarityId.toString(2)}, expansion=${expansionId}`)
   }
+  return { expansion: expansion.id as ExpansionId, card, rarity }
 }
 
-export const rarities = [
-  '', //0
-  '◊', // 1
-  '◊◊', // 2
-  '◊◊◊', // 3
-  '◊◊◊◊', // 4
-  '☆', // 5
-  '☆☆', // 6
-  '☆☆☆', // 7
-  '✵', // 8
-  '✵✵', // 9
-  'Crown Rare', // 10
-  'P', // 11
-] as const
+const rarityToId: Record<Rarity, number> = {
+  '◊': 0,
+  '◊◊': 1,
+  '◊◊◊': 2,
+  '◊◊◊◊': 3,
+  '☆': 4,
+  '☆☆': 5,
+  '☆☆☆': 6,
+  // '☆☆☆☆': 7,
+  '✵': 8,
+  '✵✵': 9,
+  // '✵✵✵': 10,
+  // '✵✵✵✵': 11,
+  'Crown Rare': 12,
+  // 13-15
+  P: 16,
+  // 17-63
+} as const
 
-export type Rarity = (typeof rarities)[number]
-
-const rarityToId = Object.fromEntries(rarities.map((r, i) => [r, i])) as Record<Rarity, number>
+const rarityIdToRarity: Map<number, Rarity> = new Map(Object.entries(rarityToId).map(([r, i]) => [i, r as Rarity]))


### PR DESCRIPTION
- Changed the schema to have 8 expansion bits and 6 rarity bits, from 7-7.
- Removed `''` from the `Rarity` type and added proper error checks instead of partially broken states
- Changed the rarity encodings in order to:
  - Be able to check the bits 3rd and 4th bit for the rarity "class": `00` is diamond, `01` is star, `10` is shiny, `11` is Crown
  - Reserve the in-between space for rarities that could be introduced in the future, like ✵✵✵. Just to be extra safe that some unexpected actions from the game publisher don't mess up the order.
- Changed `Promo` expansion to `internalId=192` so:
  - There is space after it if they introduce `Promo2` or something. Again, just to be extra safe.
  - Chose 192, to have space to launch parallel lines from 128 and 64 in case the published releases some strange expansion that doesn't blend well into the normal `[A-Z][1-9][a-z]?` line and needs to be sorted separately.