### PR TITLE
Faster deckbuilding in overview

### DIFF
--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -256,7 +256,7 @@ export const getNrOfCardsOwned = ({ ownedCards, rarityFilter, numberFilter, expa
   })
   if (deckbuildingMode) {
     //deduplicate allCardsWithAmounts by c.internal_id
-    allCardsWithAmounts = allCardsWithAmounts.filter((c, i, a) => a.findIndex((t) => t.internal_id === c.internal_id) === i)
+    allCardsWithAmounts = [...new Map(allCardsWithAmounts.map((c) => [c.internal_id, c])).values()]
 
     allCardsWithAmounts = allCardsWithAmounts
       .map((ac) => {
@@ -317,8 +317,8 @@ export const getTotalNrOfCards = ({ rarityFilter, expansion, packName, deckbuild
   if (deckbuildingMode) {
     filteredCards = filteredCards.filter((c) => basicRarities.includes(c.rarity))
 
-    //deduplicate filteredCards by c.internal_id
-    filteredCards = filteredCards.filter((c, i, a) => a.findIndex((t) => t.internal_id === c.internal_id) === i)
+    // deduplicate filteredCards by c.internal_id
+    filteredCards = [...new Map(filteredCards.map((c) => [c.internal_id, c])).values()]
   }
 
   return filteredCards.length


### PR DESCRIPTION
Please don't do $O(n^2)$ loops, they make the UI load for like 2 seconds ☹️
This $O(n \log n)$ approach takes a fraction on a second