### PR TITLE
Increase trade count

### DIFF
--- a/frontend/src/services/trade/tradeService.ts
+++ b/frontend/src/services/trade/tradeService.ts
@@ -2,7 +2,7 @@ import { supabase } from '@/lib/supabase.ts'
 import type { TradePartners, TradeRow } from '@/types'
 
 export const getTrades = async () => {
-  const { data, error } = await supabase.from('trades').select().limit(20).order('updated_at', { ascending: false })
+  const { data, error } = await supabase.from('trades').select().limit(35).order('updated_at', { ascending: false })
 
   if (error) {
     console.log('supa error', error)


### PR DESCRIPTION
When I'm low on active trades, I go to matches page and send ~4 trades to ~4 people. This gets me to the edge of the current limit, and some of my active trades sometimes disappear.