### PR TITLE
feat: add all missing translations for Mega-Rising pokemon, tools and trainers

### DIFF
--- a/frontend/assets/pokemon_translations.json
+++ b/frontend/assets/pokemon_translations.json
@@ -8462,5 +8462,53 @@
     "fr-FR": "Corayôme de Galar",
     "it-IT": null,
     "de-DE": "Galar-Gorgasonn"
+  },
+  "mega pinsir": {
+    "en-US": "Mega Pinsir",
+    "es-ES": "Mega-Pinsir",
+    "pt-BR": "Mega Pinsir",
+    "fr-FR": "Méga-Scarabrute",
+    "it-IT": "Mega Pinsir",
+    "de-DE": "Mega-Pinsir"
+  },
+  "mega blaziken": {
+    "en-US": "Mega Blaziken",
+    "es-ES": "Mega-Blaziken",
+    "pt-BR": "Mega Blaziken",
+    "fr-FR": "Méga-Braségali",
+    "it-IT": "Mega Blaziken",
+    "de-DE": "Mega-Lohgock"
+  },
+  "mega gyarados": {
+    "en-US": "Mega Gyarados",
+    "es-ES": "Mega-Gyarados",
+    "pt-BR": "Mega Gyarados",
+    "fr-FR": "Méga-Léviator",
+    "it-IT": "Mega Gyarados",
+    "de-DE": "Mega-Garados"
+  },
+  "mega ampharos": {
+    "en-US": "Mega Ampharos",
+    "es-ES": "Mega-Ampharos",
+    "pt-BR": "Mega Ampharos",
+    "fr-FR": "Méga-Pharamp",
+    "it-IT": "Mega Ampharos",
+    "de-DE": "Mega-Ampharos"
+  },
+  "mega altaria": {
+    "en-US": "Mega Altaria",
+    "es-ES": "Mega-Altaria",
+    "pt-BR": "Mega Altaria",
+    "fr-FR": "Méga-Altaria",
+    "it-IT": "Mega Altaria",
+    "de-DE": "Mega-Altaria"
+  },
+  "mega absol": {
+    "en-US": "Mega Absol",
+    "es-ES": "Mega-Absol",
+    "pt-BR": "Mega Absol",
+    "fr-FR": "Méga-Absol",
+    "it-IT": "Mega Absol",
+    "de-DE": "Mega-Absol"
   }
 }

--- a/frontend/assets/tools_translations.json
+++ b/frontend/assets/tools_translations.json
@@ -289,58 +289,66 @@
   },
   "prank spinner": {
     "en-US": "Prank Spinner",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Ruleta Jugarreta",
+    "pt-BR": "Roleta Travessa",
     "fr-FR": "Roue Farceuse",
-    "it-IT": null
+    "it-IT": "Ruota della Sfortuna",
+    "de-DE": "Rad des Zufalls"
   },
   "plume fossil": {
     "en-US": "Plume Fossil",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Fósil Pluma",
+    "pt-BR": "Fóssil Pluma",
     "fr-FR": "Fossile Plume",
-    "it-IT": null
+    "it-IT": "Fossilpiuma",
+    "de-DE": "Federfossil"
   },
   "hitting hammer": {
     "en-US": "Hitting Hammer",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Mazo Golpeador",
+    "pt-BR": "Martelo Batedor",
     "fr-FR": "Maillet Cognant",
-    "it-IT": null
+    "it-IT": "Martello Debilitante",
+    "de-DE": "Schlagender Hammer"
   },
   "cover fossil": {
     "en-US": "Cover Fossil",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Fósil Tapa",
+    "pt-BR": "Fóssil Casca",
     "fr-FR": "Fossile Plaque",
-    "it-IT": null
+    "it-IT": "Fossiltappo",
+    "de-DE": "Schildfossil"
   },
   "flame patch": {
     "en-US": "Flame Patch",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Refuerzo Fuego",
+    "pt-BR": "Fragmento Incendiário",
     "fr-FR": "Fortifiant Flamboyant",
-    "it-IT": null
+    "it-IT": "Distintivo Fiamma",
+    "de-DE": "Flammenpflaster"
   },
   "sitrus berry": {
     "en-US": "Sitrus Berry",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Baya Zidra",
+    "pt-BR": "Fruta Sitrus",
     "fr-FR": "Baie Sitrus",
-    "it-IT": null
+    "it-IT": "Baccacedro",
+    "de-DE": "Tsitrubeere"
   },
   "heavy helmet": {
     "en-US": "Heavy Helmet",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Casco Pesado",
+    "pt-BR": "Capacete Compacto",
     "fr-FR": "Casque Lourd",
-    "it-IT": null
+    "it-IT": "Casco Pesante",
+    "de-DE": "Schwerer Helm"
   },
   "lucky mittens": {
     "en-US": "Lucky Mittens",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Manoplas Suerte",
+    "pt-BR": "Luvas Sortudas",
     "fr-FR": "Moufles Chance",
-    "it-IT": null
+    "it-IT": "Fortunguanti",
+    "de-DE": "Glückshandschuhe"
   }
 }

--- a/frontend/assets/trainers_translations.json
+++ b/frontend/assets/trainers_translations.json
@@ -385,44 +385,50 @@
   },
   "marlon": {
     "en-US": "Marlon",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Ciprián",
+    "pt-BR": "Marlon",
     "fr-FR": "Amana",
-    "it-IT": null
+    "it-IT": "Ciprian",
+    "de-DE": "Benson"
   },
   "hala": {
     "en-US": "Hala",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Kaudan",
+    "pt-BR": "Pandam",
     "fr-FR": "Pectorius",
-    "it-IT": null
+    "it-IT": "Hala",
+    "de-DE": "Hala"
   },
   "may": {
     "en-US": "May",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Aura",
+    "pt-BR": "May",
     "fr-FR": "Flora",
-    "it-IT": null
+    "it-IT": "Vera",
+    "de-DE": "Maike"
   },
   "fantina": {
     "en-US": "Fantina",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Fantina",
+    "pt-BR": "Fantina",
     "fr-FR": "Kiméra",
-    "it-IT": null
+    "it-IT": "Fannie",
+    "de-DE": "Lamina"
   },
   "copycat": {
     "en-US": "Copycat",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Copiona",
+    "pt-BR": "Imitadora",
     "fr-FR": "Copieuse",
-    "it-IT": null
+    "it-IT": "Copiona",
+    "de-DE": "Nachahmerin"
   },
   "lisia": {
     "en-US": "Lisia",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Ariana",
+    "pt-BR": "Elisia",
     "fr-FR": "Atalante",
-    "it-IT": null
+    "it-IT": "Orthilla",
+    "de-DE": "Xenia"
   }
 }


### PR DESCRIPTION
Adds translations for German, Italian, Portuguese, Spanish for tools and trainers cards of Mega Rising
Also adds translations for mega pokemons of this extension, in all languages.

Fixes  #772 