### PR TITLE
Revert "chore: updated react-virtual package"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
-    "@tanstack/react-virtual": "^3.13.13",
+    "@tanstack/react-virtual": "^3.13.12",
     "@tensorflow/tfjs": "^4.22.0",
     "@types/recharts": "^2.0.1",
     "class-variance-authority": "^0.7.1",

--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
 import i18n from 'i18next'
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getExpansionById } from '@/lib/CardsDB.ts'
 import { chunk, cn } from '@/lib/utils.ts'
@@ -75,14 +75,10 @@ export function CardsTable({ className, children, cards, groupExpansions, render
     [cards, cardsPerRow],
   )
 
-  const getItemKey = useCallback((index: number) => {
-    return rows[index].id // critical: stable keys per logical row
-  }, [])
-
   const rowVirtualizer = useVirtualizer({
     getScrollElement: () => scrollRef.current,
     count: rows.length,
-    getItemKey,
+    getItemKey: (index) => rows[index].id, // critical: stable keys per logical row
     estimateSize: (index) => (rows[index].type === 'header' ? 52 : cardHeight + 8),
     overscan: 5,
   })
@@ -106,7 +102,7 @@ export function CardsTable({ className, children, cards, groupExpansions, render
                     <img
                       src={`/images/sets/${i18n.language}/${row.expansion.id}.webp`}
                       alt={row.expansion.name}
-                      className="max-w-15"
+                      className="max-w-[60px]"
                       onError={(e) => {
                         ;(e.target as HTMLImageElement).src = `/images/sets/en-US/${row.expansion.id}.webp`
                       }}

--- a/frontend/src/pages/trade/TradeMatches.tsx
+++ b/frontend/src/pages/trade/TradeMatches.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronRight } from 'lucide-react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 import { CardLine } from '@/components/CardLine'
@@ -22,14 +22,10 @@ function TradeMatches() {
 
   const { data: tradingPartners, isLoading, isError } = useTradingPartners(showResults, selectedCard)
 
-  const getItemKey = useCallback((index: number) => {
-    return cards[index].card_id
-  }, [])
-
   const virtualizer = useVirtualizer({
     getScrollElement: () => scrollRef.current,
     count: cards.length,
-    getItemKey,
+    getItemKey: (index) => cards[index].card_id,
     estimateSize: () => 32,
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: ^5.91.1
         version: 5.91.1(@tanstack/react-query@5.90.12(react@19.2.3))(react@19.2.3)
       '@tanstack/react-virtual':
-        specifier: ^3.13.13
-        version: 3.13.13(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^3.13.12
+        version: 3.13.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tensorflow/tfjs':
         specifier: ^4.22.0
         version: 4.22.0(seedrandom@3.0.5)
@@ -1560,14 +1560,14 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-virtual@3.13.13':
-    resolution: {integrity: sha512-4o6oPMDvQv+9gMi8rE6gWmsOjtUZUYIJHv7EB+GblyYdi8U6OqLl8rhHWIUZSL1dUU2dPwTdTgybCKf9EjIrQg==}
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/virtual-core@3.13.13':
-    resolution: {integrity: sha512-uQFoSdKKf5S8k51W5t7b2qpfkyIbdHMzAn+AMQvHPxKUPeo1SsGaA4JRISQT87jm28b7z8OEqPcg1IOZagQHcA==}
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@tensorflow/tfjs-backend-cpu@4.22.0':
     resolution: {integrity: sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==}
@@ -3775,13 +3775,13 @@ snapshots:
       '@tanstack/query-core': 5.90.12
       react: 19.2.3
 
-  '@tanstack/react-virtual@3.13.13(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-virtual@3.13.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/virtual-core': 3.13.13
+      '@tanstack/virtual-core': 3.13.12
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/virtual-core@3.13.13': {}
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@tensorflow/tfjs-backend-cpu@4.22.0(@tensorflow/tfjs-core@4.22.0)':
     dependencies:


### PR DESCRIPTION
This reverts commit ad174ce235cac2880a9829b4470976c08e04c70d.

I *think* it might be the issue with collection not loading ([link](https://community.tcgpocketcollectiontracker.com/t/collection-not-loading/7255)). Not sure how exactly, but it is linked to the virtualizer, and it is the last commit that touched it.

The logs:
<img width="608" height="67" alt="image" src="https://github.com/user-attachments/assets/15037d5b-cbf7-4de7-8891-a73aa4000309" />
<img width="876" height="77" alt="image" src="https://github.com/user-attachments/assets/aa5cefd5-fcb3-425f-ae6b-4ff45bde161e" />
