### PR TITLE
Use Lucide icons for trade status

### DIFF
--- a/frontend/src/pages/trade/TradeOffers.tsx
+++ b/frontend/src/pages/trade/TradeOffers.tsx
@@ -5,13 +5,17 @@ import { useTrades } from '@/services/trade/useTrade.ts'
 import type { TradeRow } from '@/types'
 
 function TradeOffers() {
-  const { t } = useTranslation('trade-matches')
+  const { t } = useTranslation(['trade-matches', 'common'])
 
-  const { data: account } = useAccount()
-  const { data: trades } = useTrades()
+  const { data: account, isLoading: isLoadingAccount } = useAccount()
+  const { data: trades, isLoading: isLoadingTrades } = useTrades()
+
+  if (isLoadingAccount || isLoadingTrades) {
+    return <div className="mx-auto mt-12 animate-spin rounded-full size-12 border-4 border-white border-t-transparent" />
+  }
 
   if (!trades || !account) {
-    return null
+    return <p className="text-xl text-center py-8">{t('common:error')}</p>
   }
 
   if (trades.length === 0) {

--- a/frontend/src/pages/trade/components/TradeList.tsx
+++ b/frontend/src/pages/trade/components/TradeList.tsx
@@ -145,13 +145,12 @@ function TradeList({ trades, viewHistory }: Props) {
   }
 
   return (
-    <div className="rounded-lg border-1 border-neutral-700 border-solid p-1 sm:p-2">
-      <div className="hidden sm:flex px-1">
-        <div className="w-9" />
+    <div className="rounded-lg border-1 border-neutral-700 border-solid p-1 md:p-2">
+      <div className="hidden md:flex pr-1">
         <h4 className="text-lg font-medium w-1/2 ml-8">{t('youGive')}</h4>
         <h4 className="text-lg font-medium w-1/2 ml-8">{t('youReceive')}</h4>
       </div>
-      <ul className="flex flex-col gap-2 sm:gap-0">
+      <ul className="flex flex-col gap-2 md:gap-0">
         {filteredTrades
           .toSorted((a, b) => (a.created_at > b.created_at ? -1 : 1))
           .map((x) => (

--- a/frontend/src/pages/trade/components/TradeListRow.tsx
+++ b/frontend/src/pages/trade/components/TradeListRow.tsx
@@ -1,3 +1,5 @@
+import { Slot } from '@radix-ui/react-slot'
+import { ArrowLeft, ArrowRight, ArrowRightLeft, Check, X } from 'lucide-react'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Tooltip } from 'react-tooltip'
@@ -14,10 +16,14 @@ interface Props {
 export const TradeListRow: FC<Props> = ({ row, selectedTradeId, setSelectedTradeId }) => {
   const { t } = useTranslation('trade-matches')
 
-  const { data: account } = useAccount()
+  const { data: account, isLoading } = useAccount()
+
+  if (isLoading) {
+    return null
+  }
 
   if (!account) {
-    return null
+    return <p className="text-xl text-center py-8">{t('common:error')}</p>
   }
 
   const yourCard = row.offering_friend_id === account.friend_id ? row.offer_card_id : row.receiver_card_id
@@ -33,34 +39,30 @@ export const TradeListRow: FC<Props> = ({ row, selectedTradeId, setSelectedTrade
 
   const status = (row: TradeRow) => {
     const style = {
-      offered: { icon: row.offering_friend_id === account.friend_id ? '→' : '←', color: 'bg-amber-600' },
-      accepted: { icon: '↔', color: 'bg-lime-600' },
-      declined: { icon: 'X', color: 'bg-stone-600' },
-      finished: { icon: '✓', color: 'bg-indigo-600' },
+      offered: row.offering_friend_id === account.friend_id ? <ArrowRight className="bg-amber-600" /> : <ArrowLeft className="bg-amber-600" />,
+      accepted: <ArrowRightLeft className="bg-lime-600" />,
+      declined: <X className="bg-stone-600" />,
+      finished: <Check className="bg-indigo-600" />,
     }
     return (
-      <div className="flex items-center">
-        <Tooltip id={`tooltip-${row.id}`} />
-        <span
-          className={`rounded-full text-center w-7 md:w-9 ${style[row.status].color}`}
-          data-tooltip-id={`tooltip-${row.id}`}
-          data-tooltip-content={t(`status.${row.status}`)}
-        >
-          {style[row.status].icon}
-        </span>
-      </div>
+      <>
+        <Tooltip id={`status-${row.id}`} />
+        <Slot className="rounded-full p-[3px] my-auto" data-tooltip-id={`status-${row.id}`} data-tooltip-content={t(`status.${row.status}`)}>
+          {style[row.status]}
+        </Slot>
+      </>
     )
   }
 
   return (
     <li
-      className={`flex cursor-pointer rounded gap-1 md:gap-4 p-1 ${selectedTradeId === row.id && 'bg-green-900'} hover:bg-neutral-500`}
+      className={`flex cursor-pointer rounded gap-1 md:gap-2 p-1 ${selectedTradeId === row.id && 'bg-green-900'} hover:bg-neutral-500`}
       onClick={() => onClick(row)}
     >
       {status(row)}
-      <div className="flex flex-col sm:flex-row w-full justify-between gap-1 md:gap-4">
-        <CardLine className="sm:w-1/2" card_id={yourCard} increment={-1} />
-        <CardLine className="sm:w-1/2" card_id={friendCard} increment={1} />
+      <div className="flex flex-col md:flex-row grow-1 justify-between gap-1 md:gap-2">
+        <CardLine className="md:w-1/2" card_id={yourCard} increment={-1} />
+        <CardLine className="md:w-1/2" card_id={friendCard} increment={1} />
       </div>
     </li>
   )

--- a/frontend/src/pages/trade/components/TradePartner.tsx
+++ b/frontend/src/pages/trade/components/TradePartner.tsx
@@ -14,15 +14,19 @@ interface TradePartnerProps {
 }
 
 function TradePartner({ friendId }: TradePartnerProps) {
-  const { t } = useTranslation('trade-matches')
+  const { t } = useTranslation(['trade-matches', 'common'])
 
-  const { data: trades } = useTrades()
-  const { data: friendAccount } = usePublicAccount(friendId)
+  const { data: trades, isLoading: isLoadingTrades } = useTrades()
+  const { data: friendAccount, isLoading: isLoadingAccount } = usePublicAccount(friendId)
 
   const [viewHistory, setViewHistory] = useState<boolean>(false)
 
-  if (!trades) {
+  if (isLoadingTrades || isLoadingAccount) {
     return null
+  }
+
+  if (!trades) {
+    return <p className="text-xl text-center py-8">{t('common:error')}</p>
   }
 
   const partnerTrades = trades.filter((t) => t.offering_friend_id === friendId || t.receiving_friend_id === friendId)
@@ -32,7 +36,7 @@ function TradePartner({ friendId }: TradePartnerProps) {
       <div className="flex justify-between items-center mb-1 mx-1">
         <p>
           <span className="text-md">{t('tradingWith')}</span>
-          <span className="text-md font-bold"> {friendAccount?.username || 'loading'} </span>
+          <span className="text-md font-bold"> {friendAccount?.username || 'unknown'} </span>
           {friendAccount && <FriendIdDisplay friendId={friendAccount.friend_id} showFriendId={false} className="ml-1" />}
         </p>
         <span className="flex gap-4">

--- a/frontend/src/services/trade/tradeService.ts
+++ b/frontend/src/services/trade/tradeService.ts
@@ -11,7 +11,7 @@ export const getTrades = async () => {
 
   console.log('fetched trades', data)
 
-  return data as TradeRow[]
+  return data.map((x) => ({ ...x, created_at: new Date(x.created_at), updated_at: new Date(x.updated_at) })) as TradeRow[]
 }
 
 export const insertTrade = async (trade: TradeRow) => {


### PR DESCRIPTION
- Uses Lucide icons for trade statuses. Not much of a difference, but it's font independent. For example my phone doesn't handle the font too well (see the second pair of screenshoots)
- Adds some loading states and sanity error checks to the trades.

<img width="367" height="361" alt="image" src="https://github.com/user-attachments/assets/1b784a53-8808-472c-9cd4-8a1d923ebad4" />

<img width="372" height="361" alt="image" src="https://github.com/user-attachments/assets/cc8fcbe4-55be-476c-abe0-d3d016f28ad9" />

<img width="534" height="403" alt="image" src="https://github.com/user-attachments/assets/6c5e5715-21c9-4daa-9bbe-dac8e1b9502c" />

<img width="488" height="401" alt="image" src="https://github.com/user-attachments/assets/a5bbcc87-e09a-4956-bfaf-f41e4afad04d" />
