### PR TITLE
Minor filters improvements

### DIFF
--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -98,7 +98,7 @@ const FilterPanel: FC<Props> = ({ className, filters, setFilters, clearFilters }
       {filters.maxNumber !== undefined && (
         <DropdownFilter
           label={t('f-number.maxNum', { ns: 'filters' })}
-          options={[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100]}
+          options={['∞', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
           value={filters.maxNumber}
           onChange={changeFilter('maxNumber')}
         />

--- a/frontend/src/lib/filters.ts
+++ b/frontend/src/lib/filters.ts
@@ -5,7 +5,7 @@ import { levenshtein } from './levenshtein'
 import { getCardNameByLang, getExtraCards, getNeededCards } from './utils'
 
 export const expansionOptions = ['all', ...expansionIds] as const
-export const sortByOptions = ['default', 'recent', 'expansion-newest'] as const
+export const sortByOptions = ['expansion-newest', 'recent'] as const
 export const cardTypeOptions = cardTypes
 export const tradingOptions = ['all', 'wanted', 'extra'] as const
 export type ExpansionOption = (typeof expansionOptions)[number]
@@ -22,7 +22,7 @@ export interface FiltersAll {
   trading: TradingOption
   sortBy: SortByOption
   minNumber: number
-  maxNumber: number
+  maxNumber: number | '∞'
   deckbuildingMode: boolean
   allTextSearch: boolean
 }
@@ -49,44 +49,14 @@ export function getFilteredCards(filters: Filters, cards: Map<number, Collection
     filteredCards = filteredCards.filter((card) => filtered.has(card.internal_id))
   }
 
-  if (filters.sortBy !== undefined) {
-    if (filters.sortBy === 'recent') {
-      filteredCards = filteredCards.toSorted((a, b) => {
-        const isUpdatedA = cards.get(a.internal_id)?.updated_at
-        const isUpdatedB = cards.get(b.internal_id)?.updated_at
-        if (isUpdatedA && isUpdatedB) {
-          return new Date(isUpdatedB).getTime() - new Date(isUpdatedA).getTime()
-        } else if (isUpdatedA && !isUpdatedB) {
-          return -1
-        } else {
-          return 1
-        }
-      })
-    } else if (filters.sortBy === 'expansion-newest') {
-      filteredCards = [...filteredCards].sort((a, b) => {
-        if (a.expansion !== b.expansion) {
-          return expansionIds.indexOf(a.expansion) - expansionIds.indexOf(b.expansion)
-        }
-        return a.card_id.localeCompare(b.card_id, i18n.language || 'en', { numeric: true })
-      })
-    }
+  if (filters.rarity !== undefined && filters.rarity.length > 0) {
+    const rarity = filters.rarity
+    filteredCards = filteredCards.filter((c) => rarity.includes(c.rarity))
   }
-
-  filteredCards = filteredCards.filter((c) => {
-    if (filters.rarity === undefined || filters.rarity.length === 0) {
-      return true
-    }
-    return filters.rarity.includes(c.rarity)
-  })
-  filteredCards = filteredCards.filter((c) => {
-    if (filters.cardType === undefined || filters.cardType.length === 0) {
-      return true
-    }
-    if (c.card_type.toLowerCase() === 'trainer') {
-      return filters.cardType.includes('trainer')
-    }
-    return filters.cardType.includes(c.energy.toLowerCase() as CardTypeOption)
-  })
+  if (filters.cardType !== undefined && filters.cardType.length > 0) {
+    const cardType = filters.cardType
+    filteredCards = filteredCards.filter((c) => (c.card_type.toLowerCase() === 'trainer' ? cardType.includes('trainer') : cardType.includes(c.energy)))
+  }
 
   if (filters.search) {
     const query = filters.search.toLowerCase()
@@ -112,6 +82,7 @@ export function getFilteredCards(filters: Filters, cards: Map<number, Collection
     })
   }
 
+  // Fill up `collected` and `updated at`
   for (const card of filteredCards) {
     if (filters.deckbuildingMode) {
       card.amount_owned = card.alternate_versions.reduce((acc, c) => {
@@ -126,13 +97,35 @@ export function getFilteredCards(filters: Filters, cards: Map<number, Collection
     card.collected = ownedCard?.collection.includes(card.card_id) ?? false
     card.updated_at = ownedCard?.updated_at
   }
+
   if (filters.minNumber !== undefined) {
     const minNumber = filters.minNumber
     filteredCards = filteredCards.filter((f) => (f.amount_owned ?? 0) >= minNumber)
   }
-  if (filters.maxNumber !== undefined && filters.maxNumber !== 100) {
+  if (filters.maxNumber !== undefined && filters.maxNumber !== '∞') {
     const maxNumber = filters.maxNumber
     filteredCards = filteredCards.filter((f) => (f.amount_owned ?? 0) <= maxNumber)
+  }
+
+  if (filters.sortBy !== undefined) {
+    if (filters.sortBy === 'recent') {
+      filteredCards.sort((a, b) => {
+        if (a.updated_at && b.updated_at) {
+          return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+        } else if (a.updated_at && !b.updated_at) {
+          return -1
+        } else {
+          return 1
+        }
+      })
+    } else if (filters.sortBy === 'expansion-newest') {
+      filteredCards.sort((a, b) => {
+        if (a.expansion !== b.expansion) {
+          return expansionIds.indexOf(a.expansion) - expansionIds.indexOf(b.expansion)
+        }
+        return a.card_id.localeCompare(b.card_id, i18n.language || 'en', { numeric: true })
+      })
+    }
   }
 
   return filteredCards

--- a/frontend/src/pages/collection/CollectionCards.tsx
+++ b/frontend/src/pages/collection/CollectionCards.tsx
@@ -63,7 +63,7 @@ const defaultFilters: Filters = {
   trading: 'all',
   sortBy: 'expansion-newest',
   minNumber: 0,
-  maxNumber: 100,
+  maxNumber: '∞',
   deckbuildingMode: false,
   allTextSearch: false,
 }


### PR DESCRIPTION
- Uses the infinity symbol instead of value of 100 to disable `maxFilter`
- Filter by rarity and card type only if filters specified (avoids unnecessary `cards.filter(c => true)` passes)
- Applies sorting at the end, by using filled `card.updatedAt` value (instead of sorting before it was filled by querying the map a second time)
- Removes sorting by card-id which was broken anyway for over two months by #695 (and no one seemed to even notice)