### PR TITLE
Default to earliest expansion

### DIFF
--- a/frontend/src/lib/CardsDB.ts
+++ b/frontend/src/lib/CardsDB.ts
@@ -19,7 +19,7 @@ const B1aMissions = await import('../../assets/themed-collections/B1a-missions.j
 export const allCards: Card[] = AllCardsJson.default as Card[]
 
 const allCardsDict: Map<string, Card> = new Map(allCards.map((card) => [card.card_id, card]))
-const allCardsByInternalId: Map<number, Card> = new Map(allCards.map((card) => [card.internal_id, card]))
+const allCardsByInternalId: Map<number, Card> = new Map(allCards.toReversed().map((card) => [card.internal_id, card]))
 const allCardsByInternalIdList: Partial<Record<number, Card[]>> = Object.groupBy(allCards, (c) => c.internal_id)
 
 export const getCardById = (cardId: string): Card | undefined => {


### PR DESCRIPTION
The `getCardByInternalId` gives you a card object that has an `expansion`. For cards that appear in multiple ones (mainly those reprinted in deluxe pack), it picks the latest one. It would be more natural if it was the earliest one. Another benefit is that you now know that 1-3 diamond cards from A4b are foil ones, which is currently hard to tell (you need to click on the card to see that).

<img width="333" height="382" alt="image" src="https://github.com/user-attachments/assets/b45cae5f-ed3b-4b61-a6fd-5cb5b466ffaa" />

<img width="339" height="436" alt="image" src="https://github.com/user-attachments/assets/e25cebe8-3745-4bb0-a3c8-3a1a94895294" />
