### PR TITLE
Don't limit trade history

### DIFF
--- a/frontend/src/pages/trade/TradeOffers.tsx
+++ b/frontend/src/pages/trade/TradeOffers.tsx
@@ -2,14 +2,14 @@ import { useTranslation } from 'react-i18next'
 import { Spinner } from '@/components/Spinner'
 import TradePartner from '@/pages/trade/components/TradePartner.tsx'
 import { useAccount } from '@/services/account/useAccount'
-import { useTrades } from '@/services/trade/useTrade.ts'
+import { useActiveTrades } from '@/services/trade/useTrade.ts'
 import type { TradeRow } from '@/types'
 
 function TradeOffers() {
   const { t } = useTranslation(['trade-matches', 'common'])
 
   const { data: account, isLoading: isLoadingAccount } = useAccount()
-  const { data: trades, isLoading: isLoadingTrades } = useTrades()
+  const { data: trades, isLoading: isLoadingTrades } = useActiveTrades()
 
   if (isLoadingAccount || isLoadingTrades) {
     return <Spinner size="lg" overlay />
@@ -25,36 +25,20 @@ function TradeOffers() {
 
   //split into two groups for finished and ongoing trades
   const friends = groupTrades(trades, account.friend_id)
-  const friendsHasTrades = Object.fromEntries(
-    Object.entries(friends).map(([key, value]) => [key, Number(activeTrades(value as TradeRow[], account.friend_id).length === 0)]),
-  )
   const friendsLastActivity = Object.fromEntries(
     Object.entries(friends).map(([key, value]) => [key, Math.max(...(value as TradeRow[]).map((row) => new Date(row.updated_at).getTime()))]),
   )
   const friendIds = Object.keys(friends).toSorted((a, b) => {
-    if (friendsHasTrades[a] !== friendsHasTrades[b]) {
-      return friendsHasTrades[a] - friendsHasTrades[b]
-    }
     return friendsLastActivity[b] - friendsLastActivity[a]
   })
 
   return (
     <div className="flex flex-col items-center mx-auto gap-6 sm:px-4 mb-12 w-full">
       {friendIds.map((friend_id) => (
-        <TradePartner key={friend_id} friendId={friend_id} />
+        <TradePartner key={friend_id} friendId={friend_id} activeTrades={friends[friend_id] as TradeRow[]} />
       ))}
     </div>
   )
-}
-
-function activeTrades(arr: TradeRow[], id: string) {
-  return arr.filter((row) => {
-    if (row.offering_friend_id === id) {
-      return !row.offerer_ended
-    } else {
-      return !row.receiver_ended
-    }
-  })
 }
 
 function groupTrades(arr: TradeRow[], id: string) {

--- a/frontend/src/pages/trade/components/TradeList.tsx
+++ b/frontend/src/pages/trade/components/TradeList.tsx
@@ -12,10 +12,9 @@ import type { CardAmountUpdate, CollectionRow, TradeRow, TradeStatus } from '@/t
 
 interface Props {
   trades: TradeRow[]
-  viewHistory: boolean
 }
 
-function TradeList({ trades, viewHistory }: Props) {
+function TradeList({ trades }: Props) {
   const { t } = useTranslation('trade-matches')
   const { toast } = useToast()
 
@@ -23,10 +22,6 @@ function TradeList({ trades, viewHistory }: Props) {
   const { data: ownedCards = new Map<number, CollectionRow>() } = useCollection()
   const updateCardsMutation = useUpdateCards()
 
-  function interesting(row: TradeRow) {
-    return (row.offering_friend_id === account?.friend_id && !row.offerer_ended) || (row.receiving_friend_id === account?.friend_id && !row.receiver_ended)
-  }
-  const filteredTrades = viewHistory ? trades.filter((x) => !interesting(x)) : trades.filter(interesting)
   const [selectedTradeId, setSelectedTradeId] = useState<number | undefined>(undefined)
   const updateTradeMutation = useUpdateTrade()
 
@@ -118,13 +113,7 @@ function TradeList({ trades, viewHistory }: Props) {
         }
         return (
           <>
-            <Button
-              type="button"
-              onClick={async () => {
-                await increment(row)
-                await end()
-              }}
-            >
+            <Button type="button" onClick={() => increment(row)}>
               {t('actionUpdate')}
             </Button>
             <Button type="button" onClick={end}>
@@ -138,9 +127,9 @@ function TradeList({ trades, viewHistory }: Props) {
     }
   }
 
-  const selectedTrade = filteredTrades.find((r) => r.id === selectedTradeId)
+  const selectedTrade = trades.find((r) => r.id === selectedTradeId)
 
-  if (filteredTrades.length === 0) {
+  if (trades.length === 0) {
     return null
   }
 
@@ -151,7 +140,7 @@ function TradeList({ trades, viewHistory }: Props) {
         <h4 className="text-lg font-medium w-1/2 ml-8">{t('youReceive')}</h4>
       </div>
       <ul className="flex flex-col gap-2 md:gap-0">
-        {filteredTrades
+        {trades
           .toSorted((a, b) => (a.created_at > b.created_at ? -1 : 1))
           .map((x) => (
             <TradeListRow key={x.id} row={x} selectedTradeId={selectedTradeId} setSelectedTradeId={setSelectedTradeId} />

--- a/frontend/src/pages/trade/components/TradeList.tsx
+++ b/frontend/src/pages/trade/components/TradeList.tsx
@@ -113,7 +113,13 @@ function TradeList({ trades }: Props) {
         }
         return (
           <>
-            <Button type="button" onClick={() => increment(row)}>
+            <Button
+              type="button"
+              onClick={async () => {
+                await increment(row)
+                await end()
+              }}
+            >
               {t('actionUpdate')}
             </Button>
             <Button type="button" onClick={end}>

--- a/frontend/src/services/auth/useAuth.ts
+++ b/frontend/src/services/auth/useAuth.ts
@@ -26,7 +26,7 @@ export function useLogout() {
       await queryClient.invalidateQueries({ queryKey: ['user'] })
       await queryClient.invalidateQueries({ queryKey: ['account'] })
       await queryClient.invalidateQueries({ queryKey: ['collection'] })
-      await queryClient.invalidateQueries({ queryKey: ['trade'] })
+      await queryClient.invalidateQueries({ queryKey: ['trades'] })
       if (email) {
         removeLocalCacheItems(email)
       }
@@ -64,7 +64,7 @@ export function useVerifyOTP() {
       await queryClient.invalidateQueries({ queryKey: ['user'] })
       await queryClient.invalidateQueries({ queryKey: ['account'] })
       await queryClient.invalidateQueries({ queryKey: ['collection'] })
-      await queryClient.invalidateQueries({ queryKey: ['trade'] })
+      await queryClient.invalidateQueries({ queryKey: ['trades'] })
     },
   })
 }

--- a/frontend/src/services/trade/useTrade.ts
+++ b/frontend/src/services/trade/useTrade.ts
@@ -1,18 +1,22 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '@/lib/supabase'
 import { useAccount } from '@/services/account/useAccount.ts'
-import { getTrades, getTradingPartners, insertTrade, updateTrade } from '@/services/trade/tradeService.ts'
+import { getActiveTrades, getTradingPartners, insertTrade, updateTrade } from '@/services/trade/tradeService.ts'
 import type { TradeRow } from '@/types'
 
-export function useTrades() {
+export function useActiveTrades() {
+  const { data: account } = useAccount()
+  const friendId = account?.friend_id
   return useQuery({
-    queryKey: ['trade'],
-    queryFn: getTrades,
+    queryKey: ['trades'],
+    queryFn: () => getActiveTrades(friendId as string),
+    enabled: Boolean(friendId),
+    throwOnError: true,
   })
 }
 
 export function useTradingPartners(enabled: boolean, cardId: number | undefined) {
   const { data: account } = useAccount()
-
   return useQuery({
     queryKey: ['trading-partners', cardId],
     queryFn: () => getTradingPartners(account?.email as string, cardId),
@@ -27,9 +31,7 @@ export function useInsertTrade() {
 
   return useMutation({
     mutationFn: (trade: TradeRow) => insertTrade(trade),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['trade'] })
-    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['trades'] }),
   })
 }
 
@@ -38,52 +40,30 @@ export function useUpdateTrade() {
 
   return useMutation({
     mutationFn: ({ id, trade }: { id: number; trade: Partial<TradeRow> }) => updateTrade(id, trade),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['trade'] })
-      await queryClient.invalidateQueries({ queryKey: ['actionableTradeCount'] })
-    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['trades'] }),
   })
 }
 
 export function useActionableTradeCount() {
-  const { data: trades } = useTrades()
   const { data: account } = useAccount()
 
   return useQuery({
-    queryKey: ['actionableTradeCount', trades, account?.friend_id],
-    queryFn: () => {
-      console.log('openTrades', trades, account)
-      if (!account || !trades) {
-        console.log('no account or trades')
-        return 0
+    queryKey: ['trades', 'new'],
+    queryFn: async () => {
+      if (!account) {
+        throw new Error('Account is needed to fetch new trades')
       }
-
-      // trades where i'm the receiver but didn't accept/decline yet
-      const sentTrades = trades?.filter((t) => t.receiving_friend_id === account?.friend_id && t.status === 'offered')
-      console.log('sentTrades', sentTrades)
-
-      const nonCompletedTrades = trades?.filter((t) => {
-        if (t.status !== 'finished') {
-          return false //trade marked as completed
-        }
-
-        if (t.offering_friend_id === account?.friend_id && t.offerer_ended) {
-          return false //I initiated and also ended
-        }
-        if (t.receiving_friend_id === account?.friend_id && t.receiver_ended) {
-          return false //I received and also ended
-        }
-
-        if (!sentTrades?.includes(t)) {
-          return false //already counted in the sentTrades array, so don't count twice
-        }
-
-        return true
-      })
-
-      console.log('nonCompletedTrades', nonCompletedTrades)
-
-      return sentTrades?.length + nonCompletedTrades?.length
+      const { count, error } = await supabase
+        .from('trades')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'offered')
+        .eq('receiving_friend_id', account?.friend_id)
+      if (error) {
+        console.log('supabase error', error)
+        throw new Error('Failed fetching new trades')
+      }
+      return count as number
     },
+    enabled: Boolean(account?.friend_id),
   })
 }


### PR DESCRIPTION
Per my suggestions from https://github.com/marcelpanse/tcg-pocket-collection-tracker/issues/789#issuecomment-3686313700 (last point):

- Solves the problem where you active trade could get out of the 35 most recent one, effectively disappearing. With this PR, it fetches all your active (not hidden) trades. If there will be issues, we can paginate it in the future.
- The new trades navbar badge now fetches only the raw number to display.
- "View history" now fetches the full history (sends the request only when you toggle it)

Additionally, fixes a bug where trades from people who switched their account back to private were inaccessible, resulting in a badge you can't get rid of. Per the request [t/trade-request-from-unknown](https://community.tcgpocketcollectiontracker.com/t/trade-request-from-unknown/7324).