### PR TITLE
Fix null search validation in collection page (fixes #883)

### DIFF
--- a/frontend/src/hooks/use-search-state.ts
+++ b/frontend/src/hooks/use-search-state.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 
 function safeJson(val: string) {
   try {
-    return JSON.parse(val)
+    const parsed = JSON.parse(val)
+    return parsed === null ? val : parsed
   } catch {
     return val
   }


### PR DESCRIPTION
`JSON.parse("null")` returns `null`, which would cause the Zod schema parse to fail and reset the search state unexpectedly when `null` appeared as a URL param value.

Added a null-check in `safeJson` so it falls back to returning the raw string instead.

Fixes #883