### PR TITLE
Add Spanish, Portuguese and German translations for trainer and tool cards

### DIFF
--- a/frontend/assets/tools_translations.json
+++ b/frontend/assets/tools_translations.json
@@ -1,466 +1,482 @@
 {
   "helix fossil": {
     "en-US": "Helix Fossil",
+    "fr-FR": "Fossile Nautile",
     "es-ES": "Fósil Helix",
     "pt-BR": "Fóssil Espiral",
-    "fr-FR": "Fossile Nautile",
     "it-IT": "Helixfossile",
     "de-DE": "Helixfossil"
   },
   "dome fossil": {
     "en-US": "Dome Fossil",
+    "fr-FR": "Fossile Dôme",
     "es-ES": "Fósil Domo",
     "pt-BR": "Fóssil Cúpula",
-    "fr-FR": "Fossile Dôme",
     "it-IT": "Domofossile",
     "de-DE": "Domfossil"
   },
   "old amber": {
     "en-US": "Old Amber",
+    "fr-FR": "Vieil Ambre",
     "es-ES": "Ámbar Viejo",
     "pt-BR": "Âmbar Velho",
-    "fr-FR": "Vieil Ambre",
     "it-IT": "Ambra Antica",
     "de-DE": "Altbernstein"
   },
   "pokémon flute": {
     "en-US": "Pokémon Flute",
+    "fr-FR": "Flûte Pokémon",
     "es-ES": "Pokéflauta",
     "pt-BR": "Flauta Pokémon",
-    "fr-FR": "Flûte Pokémon",
     "it-IT": "Pokéflauto",
     "de-DE": "Pokémon-Flöte"
   },
   "mythical slab": {
     "en-US": "Mythical Slab",
+    "fr-FR": "Dalle Fabuleuse",
     "es-ES": "Losa Singular",
     "pt-BR": "Placa Mística",
-    "fr-FR": "Dalle Fabuleuse",
     "it-IT": "Pietra Misteriosa",
     "de-DE": "Mythische Tafel"
   },
   "skull fossil": {
     "en-US": "Skull Fossil",
+    "fr-FR": "Fossile Crâne",
     "es-ES": "Fósil Cráneo",
     "pt-BR": "Fóssil Crânio",
-    "fr-FR": "Fossile Crâne",
     "it-IT": "Fossilcranio",
     "de-DE": "Kopffossil"
   },
   "armor fossil": {
     "en-US": "Armor Fossil",
+    "fr-FR": "Fossile Armure",
     "es-ES": "Fósil Coraza",
     "pt-BR": "Fóssil Armadura",
-    "fr-FR": "Fossile Armure",
     "it-IT": "Fossilscudo",
     "de-DE": "Panzerfossil"
   },
   "pokémon communication": {
     "en-US": "Pokémon Communication",
+    "fr-FR": "Communication Pokémon",
     "es-ES": "Comunicación Pokémon",
     "pt-BR": "Comunicação Pokémon",
-    "fr-FR": "Communication Pokémon",
     "it-IT": "Comunicazione Pokémon",
     "de-DE": "Pokémon-Kommunikation"
   },
   "giant cape": {
     "en-US": "Giant Cape",
+    "fr-FR": "Cape Géante",
     "es-ES": "Capa Gigante",
     "pt-BR": "Capa Gigante",
-    "fr-FR": "Cape Géante",
     "it-IT": "Mantello Gigante",
     "de-DE": "Riesige Robe"
   },
   "rocky helmet": {
     "en-US": "Rocky Helmet",
+    "fr-FR": "Casque Brut",
     "es-ES": "Casco Dentado",
     "pt-BR": "Capacete de Pedra",
-    "fr-FR": "Casque Brut",
     "it-IT": "Bitorzolelmo",
     "de-DE": "Beulenhelm"
   },
   "lum berry": {
     "en-US": "Lum Berry",
+    "fr-FR": "Baie Prine",
     "es-ES": "Baya Ziuela",
     "pt-BR": "Fruta Lum",
-    "fr-FR": "Baie Prine",
     "it-IT": "Baccaprugna",
     "de-DE": "Prunusbeere"
   },
   "big malasada": {
     "en-US": "Big Malasada",
+    "fr-FR": "Malasada Maxi",
     "es-ES": "Malasada Maxi",
     "pt-BR": "Sonho Recheado Grande",
-    "fr-FR": "Malasada Maxi",
     "it-IT": "Malasada maxi",
     "de-DE": "Maxi-Malasada"
   },
   "fishing net": {
     "en-US": "Fishing Net",
+    "fr-FR": "Filet de Pêche",
     "es-ES": "Red de Pesca",
     "pt-BR": "Rede de Pesca",
-    "fr-FR": "Filet de Pêche",
     "it-IT": "Rete da Pesca",
     "de-DE": "Fischernetz"
   },
   "rare candy": {
     "en-US": "Rare Candy",
+    "fr-FR": "Super Bonbon",
     "es-ES": "Caramelo Raro",
     "pt-BR": "Doce Raro",
-    "fr-FR": "Super Bonbon",
     "it-IT": "Caramella Rara",
     "de-DE": "Sonderbonbon"
   },
   "rotom dex": {
     "en-US": "Rotom Dex",
+    "fr-FR": "Motisma-Dex",
     "es-ES": "RotomDex",
     "pt-BR": "Pokédex Rotom",
-    "fr-FR": "Motisma-Dex",
     "it-IT": "Pokédex Rotom",
     "de-DE": "Rotom-Pokédex"
   },
   "poison barb": {
     "en-US": "Poison Barb",
+    "fr-FR": "Pic Venin",
     "es-ES": "Flecha Venenosa",
     "pt-BR": "Farpa Venenosa",
-    "fr-FR": "Pic Venin",
     "it-IT": "Velenaculeo",
     "de-DE": "Giftstich"
   },
   "leaf cape": {
     "en-US": "Leaf Cape",
+    "fr-FR": "Cape Sylvestre",
     "es-ES": "Capa Hoja",
     "pt-BR": "Capa de Folha",
-    "fr-FR": "Cape Sylvestre",
     "it-IT": "Mantello Silvestre",
     "de-DE": "Blätterumhang"
   },
   "beast wall": {
     "en-US": "Beast Wall",
+    "fr-FR": "Barrière Chimère",
     "es-ES": "Muro Ente",
     "pt-BR": "Muralha de Criatura",
-    "fr-FR": "Barrière Chimère",
     "it-IT": "Ultramuro",
     "de-DE": "Bestienwand"
   },
   "repel": {
     "en-US": "Repel",
+    "fr-FR": "Repousse",
     "es-ES": "Repelente",
     "pt-BR": "Repelente",
-    "fr-FR": "Repousse",
     "it-IT": "Repellente",
     "de-DE": "Schutz"
   },
   "electrical cord": {
     "en-US": "Electrical Cord",
+    "fr-FR": "Câble Électrique",
     "es-ES": "Cable Eléctrico",
     "pt-BR": "Fio Elétrico",
-    "fr-FR": "Câble Électrique",
     "it-IT": "Prolunga",
     "de-DE": "Elektrokabel"
   },
   "beastite": {
     "en-US": "Beastite",
+    "fr-FR": "Chimérite",
     "es-ES": "Entita",
     "pt-BR": "Criaturita",
-    "fr-FR": "Chimérite",
     "it-IT": "Pietra Ultracreatura",
     "de-DE": "Bestienit"
   },
   "leftovers": {
     "en-US": "Leftovers",
+    "fr-FR": "Restes",
     "es-ES": "Restos",
     "pt-BR": "Sobras",
-    "fr-FR": "Restes",
     "it-IT": "Avanzi",
     "de-DE": "Überreste"
   },
   "poké ball": {
     "en-US": "Poké Ball",
+    "fr-FR": "Poké Ball",
     "es-ES": "Poké Ball",
     "pt-BR": "Poké Ball",
-    "fr-FR": "Poké Ball",
     "it-IT": "Poké Ball",
     "de-DE": "Pokéball"
   },
   "eevee bag": {
     "en-US": "Eevee Bag",
+    "fr-FR": "Sac Évoli",
     "es-ES": "Mochila de Eevee",
     "pt-BR": "Bolsa de Eevee",
-    "fr-FR": "Sac Évoli",
     "it-IT": "Borsa Eevee",
     "de-DE": "Evoli-Rucksack"
   },
   "elemental switch": {
     "en-US": "Elemental Switch",
+    "fr-FR": "Échange Élémentaire",
     "es-ES": "Permuta Elemental",
     "pt-BR": "Substituição Elemental",
-    "fr-FR": "Échange Élémentaire",
     "it-IT": "Scambio Elementale",
     "de-DE": "Elementartausch"
   },
   "squirt bottle": {
     "en-US": "Squirt Bottle",
+    "fr-FR": "Carapuce à O",
     "es-ES": "Squirgadera",
     "pt-BR": "Regador Squirtle",
-    "fr-FR": "Carapuce à O",
     "it-IT": "Annaffiatoio",
     "de-DE": "Schiggykanne"
   },
   "steel apron": {
     "en-US": "Steel Apron",
+    "fr-FR": "Tablier d'Acier",
     "es-ES": "Peto de Acero",
     "pt-BR": "Avental de Aço",
-    "fr-FR": "Tablier d'Acier",
     "it-IT": "Corazza Metallica",
     "de-DE": "Stählerne Schürze"
   },
   "dark pendant": {
     "en-US": "Dark Pendant",
+    "fr-FR": "Pendentif des Ténèbres",
     "es-ES": "Colgante Sombrío",
     "pt-BR": "Pingente Sombrio",
-    "fr-FR": "Pendentif des Ténèbres",
     "it-IT": "Pendente Oscuro",
     "de-DE": "Dunkler Anhänger"
   },
   "rescue scarf": {
     "en-US": "Rescue Scarf",
+    "fr-FR": "Foulard de Sauvetage",
     "es-ES": "Bufanda Rescatadora",
     "pt-BR": "Cachecol de Resgate",
-    "fr-FR": "Foulard de Sauvetage",
     "it-IT": "Sciarpa Salvagente",
     "de-DE": "Rettender Schal"
   },
   "potion": {
     "en-US": "Potion",
+    "fr-FR": "Potion",
     "es-ES": "Poción",
     "pt-BR": "Poção",
-    "fr-FR": "Potion",
     "it-IT": "Pozione",
     "de-DE": "Trank"
   },
   "x speed": {
     "en-US": "X Speed",
+    "fr-FR": "Vitesse +",
     "es-ES": "Velocidad X",
     "pt-BR": "Velocidade X",
-    "fr-FR": "Vitesse +",
     "it-IT": "Velocità X",
     "de-DE": "X-Initiative"
   },
   "hand scope": {
     "en-US": "Hand Scope",
+    "fr-FR": "Scrute Main",
     "es-ES": "Periscopio",
     "pt-BR": "Luneta",
-    "fr-FR": "Scrute Main",
     "it-IT": "Mirino Manuale",
     "de-DE": "Handperiskop"
   },
   "pokédex": {
     "en-US": "Pokédex",
+    "fr-FR": "Pokédex",
     "es-ES": "Pokédex",
     "pt-BR": "Pokédex",
-    "fr-FR": "Pokédex",
     "it-IT": "Pokédex",
     "de-DE": "Pokédex"
   },
   "red card": {
     "en-US": "Red Card",
+    "fr-FR": "Carton Rouge",
     "es-ES": "Tarjeta Roja",
     "pt-BR": "Cartão Vermelho",
-    "fr-FR": "Carton Rouge",
     "it-IT": "Cartelrosso",
     "de-DE": "Rote Karte"
   },
   "inflatable boat": {
     "en-US": "Inflatable Boat",
+    "fr-FR": "Canot Gonflable",
     "es-ES": "Balsa Hinchable",
     "pt-BR": "Bote Inflável",
-    "fr-FR": "Canot Gonflable",
     "it-IT": "Canotto Gonfiabile",
     "de-DE": "Gummiboot"
   },
   "memory light": {
     "en-US": "Memory Light",
+    "fr-FR": "Lumière Mémoire",
     "es-ES": "Luz Evocadora",
     "pt-BR": "Lâmpada da Memória",
-    "fr-FR": "Lumière Mémoire",
     "it-IT": "Luce della Memoria",
     "de-DE": "Gedächtnislicht"
   },
   "prank spinner": {
     "en-US": "Prank Spinner",
+    "fr-FR": "Roue Farceuse",
     "es-ES": "Ruleta Jugarreta",
     "pt-BR": "Roleta Travessa",
-    "fr-FR": "Roue Farceuse",
     "it-IT": "Ruota della Sfortuna",
     "de-DE": "Rad des Zufalls"
   },
   "plume fossil": {
     "en-US": "Plume Fossil",
+    "fr-FR": "Fossile Plume",
     "es-ES": "Fósil Pluma",
     "pt-BR": "Fóssil Pluma",
-    "fr-FR": "Fossile Plume",
     "it-IT": "Fossilpiuma",
     "de-DE": "Federfossil"
   },
   "hitting hammer": {
     "en-US": "Hitting Hammer",
+    "fr-FR": "Maillet Cognant",
     "es-ES": "Mazo Golpeador",
     "pt-BR": "Martelo Batedor",
-    "fr-FR": "Maillet Cognant",
     "it-IT": "Martello Debilitante",
     "de-DE": "Schlagender Hammer"
   },
   "cover fossil": {
     "en-US": "Cover Fossil",
+    "fr-FR": "Fossile Plaque",
     "es-ES": "Fósil Tapa",
     "pt-BR": "Fóssil Casca",
-    "fr-FR": "Fossile Plaque",
     "it-IT": "Fossiltappo",
     "de-DE": "Schildfossil"
   },
   "flame patch": {
     "en-US": "Flame Patch",
+    "fr-FR": "Fortifiant Flamboyant",
     "es-ES": "Refuerzo Fuego",
     "pt-BR": "Fragmento Incendiário",
-    "fr-FR": "Fortifiant Flamboyant",
     "it-IT": "Distintivo Fiamma",
     "de-DE": "Flammenpflaster"
   },
   "sitrus berry": {
     "en-US": "Sitrus Berry",
+    "fr-FR": "Baie Sitrus",
     "es-ES": "Baya Zidra",
     "pt-BR": "Fruta Sitrus",
-    "fr-FR": "Baie Sitrus",
     "it-IT": "Baccacedro",
     "de-DE": "Tsitrubeere"
   },
   "heavy helmet": {
     "en-US": "Heavy Helmet",
+    "fr-FR": "Casque Lourd",
     "es-ES": "Casco Pesado",
     "pt-BR": "Capacete Compacto",
-    "fr-FR": "Casque Lourd",
     "it-IT": "Casco Pesante",
     "de-DE": "Schwerer Helm"
   },
   "lucky mittens": {
     "en-US": "Lucky Mittens",
+    "fr-FR": "Moufles Chance",
     "es-ES": "Manoplas Suerte",
     "pt-BR": "Luvas Sortudas",
-    "fr-FR": "Moufles Chance",
     "it-IT": "Fortunguanti",
     "de-DE": "Glückshandschuhe"
   },
   "clemont's backpack": {
     "en-US": "Clemont's Backpack",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Sac de Lem",
-    "it-IT": null
+    "es-ES": "Mochila de Lem",
+    "pt-BR": "Mochila do Clemont",
+    "it-IT": null,
+    "de-DE": "Citros Rucksack"
   },
   "quick-grow extract": {
     "en-US": "Quick-Grow Extract",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Extrait de Croissance",
-    "it-IT": null
+    "es-ES": "Extracto de Maduración",
+    "pt-BR": "Extrato de Adubo",
+    "it-IT": null,
+    "de-DE": "Wachstumsextrakt"
   },
   "jaw fossil": {
     "en-US": "Jaw Fossil",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Fossile Mâchoire",
-    "it-IT": null
+    "es-ES": "Fósil Mandíbula",
+    "pt-BR": "Fóssil de Mandíbula",
+    "it-IT": null,
+    "de-DE": "Kieferfossil"
   },
   "lucky ice pop": {
     "en-US": "Lucky Ice Pop",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Glace Chanceuse",
-    "it-IT": null
+    "es-ES": "Helado Suerte",
+    "pt-BR": "Picolé da Sorte",
+    "it-IT": null,
+    "de-DE": "Glücks-Eis"
   },
   "sail fossil": {
     "en-US": "Sail Fossil",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Fossile Nageoire",
-    "it-IT": null
+    "es-ES": "Fósil Aleta",
+    "pt-BR": "Fóssil de Vela",
+    "it-IT": null,
+    "de-DE": "Flossenfossil"
   },
   "protective poncho": {
     "en-US": "Protective Poncho",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Poncho Protecteur",
-    "it-IT": null
+    "es-ES": "Poncho Protector",
+    "pt-BR": "Poncho Protetor",
+    "it-IT": null,
+    "de-DE": "Schützender Poncho"
   },
   "metal core barrier": {
     "en-US": "Metal Core Barrier",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Barrière de Métal Renforcé",
-    "it-IT": null
+    "es-ES": "Barrera Núcleo Metálico",
+    "pt-BR": "Barreira de Núcleo Metálico",
+    "it-IT": null,
+    "de-DE": "Metallkernbarriere"
   },
   "training area": {
     "en-US": "Training Area",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Zone d'entraînement",
-    "it-IT": null
+    "es-ES": "Área de Entrenamiento",
+    "pt-BR": "Área de Treinamento",
+    "it-IT": null,
+    "de-DE": "Trainingsbereich"
   },
   "starting plains": {
     "en-US": "Starting Plains",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Plaine du Départ",
-    "it-IT": null
+    "es-ES": "Planicie Inicial",
+    "pt-BR": "Planície Primordial",
+    "it-IT": null,
+    "de-DE": "Feld des Anfangs"
   },
   "peculiar plaza": {
     "en-US": "Peculiar Plaza",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Place Étrange",
-    "it-IT": null
+    "es-ES": "Plaza Peculiar",
+    "pt-BR": "Praça Peculiar",
+    "it-IT": null,
+    "de-DE": "Geheimnisvoller Platz"
   },
   "electric generator": {
     "en-US": "Electric Generator",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Générateur Électrique",
-    "it-IT": null
+    "es-ES": "Generador Eléctrico",
+    "pt-BR": "Gerador Elétrico",
+    "it-IT": null,
+    "de-DE": "Elektrischer Generator"
   },
   "big air balloon": {
     "en-US": "Big Air Balloon",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Gros Ballon",
-    "it-IT": null
+    "es-ES": "Globo Helio Grande",
+    "pt-BR": "Grande Balão de Ar",
+    "it-IT": null,
+    "de-DE": "Großer Luftballon"
   },
   "mesagoza": {
     "en-US": "Mesagoza",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Mesaledo",
-    "it-IT": null
+    "es-ES": "Ciudad Meseta",
+    "pt-BR": "Mesaledo",
+    "it-IT": null,
+    "de-DE": "Mesalona City"
   },
   "nasty notice": {
     "en-US": "Nasty Notice",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Message Désagréable",
-    "it-IT": null
+    "es-ES": "Nota Malévola",
+    "pt-BR": "Aviso Antipático",
+    "it-IT": null,
+    "de-DE": "Nasty Notice"
   },
   "maintenance": {
     "en-US": "Maintenance",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Entretien",
-    "it-IT": null
+    "es-ES": "Mantenimiento",
+    "pt-BR": "Manutenção",
+    "it-IT": null,
+    "de-DE": "Maintenance"
   },
   "hiking trail": {
     "en-US": "Hiking Trail",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Chemin de Randonnée",
-    "it-IT": null
+    "es-ES": "Ruta de Senderismo",
+    "pt-BR": "Trilha de Caminhada",
+    "it-IT": null,
+    "de-DE": "Hiking Trail"
   }
 }

--- a/frontend/assets/trainers_translations.json
+++ b/frontend/assets/trainers_translations.json
@@ -1,511 +1,522 @@
 {
   "erika": {
     "en-US": "Erika",
+    "fr-FR": "Erika",
     "es-ES": "Erika",
     "pt-BR": "Érica",
-    "fr-FR": "Erika",
     "it-IT": "Erika",
     "de-DE": "Erika"
   },
   "misty": {
     "en-US": "Misty",
+    "fr-FR": "Ondine",
     "es-ES": "Misty",
     "pt-BR": "Misty",
-    "fr-FR": "Ondine",
     "it-IT": "Misty",
     "de-DE": "Misty"
   },
   "blaine": {
     "en-US": "Blaine",
+    "fr-FR": "Auguste",
     "es-ES": "Blaine",
     "pt-BR": "Blaine",
-    "fr-FR": "Auguste",
     "it-IT": "Blaine",
     "de-DE": "Pyro"
   },
   "koga": {
     "en-US": "Koga",
+    "fr-FR": "Koga",
     "es-ES": "Koga",
     "pt-BR": "Koga",
-    "fr-FR": "Koga",
     "it-IT": "Koga",
     "de-DE": "Koga"
   },
   "giovanni": {
     "en-US": "Giovanni",
+    "fr-FR": "Giovanni",
     "es-ES": "Giovanni",
     "pt-BR": "Giovanni",
-    "fr-FR": "Giovanni",
     "it-IT": "Giovanni",
     "de-DE": "Giovanni"
   },
   "brock": {
     "en-US": "Brock",
+    "fr-FR": "Pierre",
     "es-ES": "Brock",
     "pt-BR": "Brock",
-    "fr-FR": "Pierre",
     "it-IT": "Brock",
     "de-DE": "Rocko"
   },
   "sabrina": {
     "en-US": "Sabrina",
+    "fr-FR": "Morgane",
     "es-ES": "Sabrina",
     "pt-BR": "Sabrina",
-    "fr-FR": "Morgane",
     "it-IT": "Sabrina",
     "de-DE": "Sabrina"
   },
   "lt. surge": {
     "en-US": "Lt. Surge",
+    "fr-FR": "Major Bob",
     "es-ES": "Teniente Surge",
     "pt-BR": "Ten. Surge",
-    "fr-FR": "Major Bob",
     "it-IT": "Lt. Surge",
     "de-DE": "Major Bob"
   },
   "budding expeditioner": {
     "en-US": "Budding Expeditioner",
+    "fr-FR": "Jeune Explorateur",
     "es-ES": "Explorador Novel",
     "pt-BR": "Expedicionário Principiante",
-    "fr-FR": "Jeune Explorateur",
     "it-IT": "Esploratore in Erba",
     "de-DE": "Abenteurer-Neuling"
   },
   "blue": {
     "en-US": "Blue",
+    "fr-FR": "Blue",
     "es-ES": "Azul",
     "pt-BR": "Blue",
-    "fr-FR": "Blue",
     "it-IT": "Blu",
     "de-DE": "Blau"
   },
   "leaf": {
     "en-US": "Leaf",
+    "fr-FR": "Leaf",
     "es-ES": "Hoja",
     "pt-BR": "Leaf",
-    "fr-FR": "Leaf",
     "it-IT": "Leaf",
     "de-DE": "Leaf"
   },
   "cyrus": {
     "en-US": "Cyrus",
+    "fr-FR": "Hélio",
     "es-ES": "Helio",
     "pt-BR": "Cyrus",
-    "fr-FR": "Hélio",
     "it-IT": "Cyrus",
     "de-DE": "Zyrus"
   },
   "team galactic grunt": {
     "en-US": "Team Galactic Grunt",
+    "fr-FR": "Sbire de la Team Galaxie",
     "es-ES": "Recluta del Equipo Galaxia",
     "pt-BR": "Recruta da Equipe Galáctica",
-    "fr-FR": "Sbire de la Team Galaxie",
     "it-IT": "Recluta del Team Galassia",
     "de-DE": "Rüpel von Team Galaktik"
   },
   "cynthia": {
     "en-US": "Cynthia",
+    "fr-FR": "Cynthia",
     "es-ES": "Cintia",
     "pt-BR": "Cintia",
-    "fr-FR": "Cynthia",
     "it-IT": "Camilla",
     "de-DE": "Cynthia"
   },
   "volkner": {
     "en-US": "Volkner",
+    "fr-FR": "Tanguy",
     "es-ES": "Lectro",
     "pt-BR": "Volkner",
-    "fr-FR": "Tanguy",
     "it-IT": "Corrado",
     "de-DE": "Volkner"
   },
   "dawn": {
     "en-US": "Dawn",
+    "fr-FR": "Aurore",
     "es-ES": "Maya",
     "pt-BR": "Dawn",
-    "fr-FR": "Aurore",
     "it-IT": "Lucinda",
     "de-DE": "Lucia"
   },
   "mars": {
     "en-US": "Mars",
+    "fr-FR": "Mars",
     "es-ES": "Venus",
     "pt-BR": "Marte",
-    "fr-FR": "Mars",
     "it-IT": "Martes",
     "de-DE": "Mars"
   },
   "irida": {
     "en-US": "Irida",
+    "fr-FR": "Nacchara",
     "es-ES": "Nákara",
     "pt-BR": "Irida",
-    "fr-FR": "Nacchara",
     "it-IT": "Perula",
     "de-DE": "Perla"
   },
   "celestic town elder": {
     "en-US": "Celestic Town Elder",
+    "fr-FR": "Doyenne de Célestia",
     "es-ES": "Anciana de Pueblo Caelestis",
     "pt-BR": "Anciã da Cidade Celestic",
-    "fr-FR": "Doyenne de Célestia",
     "it-IT": "Anziana di Memoride",
     "de-DE": "Älteste von Elyses"
   },
   "barry": {
     "en-US": "Barry",
+    "fr-FR": "René",
     "es-ES": "Israel",
     "pt-BR": "Barry",
-    "fr-FR": "René",
     "it-IT": "Barry",
     "de-DE": "Barry"
   },
   "adaman": {
     "en-US": "Adaman",
+    "fr-FR": "Adamantin",
     "es-ES": "Adamas",
     "pt-BR": "Ádamo",
-    "fr-FR": "Adamantin",
     "it-IT": "Damon",
     "de-DE": "Diam"
   },
   "iono": {
     "en-US": "Iono",
+    "fr-FR": "Mashynn",
     "es-ES": "e-Nigma",
     "pt-BR": "Kissera",
-    "fr-FR": "Mashynn",
     "it-IT": "Kissara",
     "de-DE": "Enigmara"
   },
   "pokémon center lady": {
     "en-US": "Pokémon Center Lady",
+    "fr-FR": "Dame du Centre Pokémon",
     "es-ES": "Chica del Centro Pokémon",
     "pt-BR": "Dama do Centro Pokémon",
-    "fr-FR": "Dame du Centre Pokémon",
     "it-IT": "Addetta del Centro Pokémon",
     "de-DE": "Pokémon-Center-Dame"
   },
   "red": {
     "en-US": "Red",
+    "fr-FR": "Red",
     "es-ES": "Rojo",
     "pt-BR": "Red",
-    "fr-FR": "Red",
     "it-IT": "Rosso",
     "de-DE": "Rot"
   },
   "team rocket grunt": {
     "en-US": "Team Rocket Grunt",
+    "fr-FR": "Sbire de la Team Rocket",
     "es-ES": "Recluta del Team Rocket",
     "pt-BR": "Recruta da Equipe Rocket",
-    "fr-FR": "Sbire de la Team Rocket",
     "it-IT": "Recluta del Team Rocket",
     "de-DE": "Rüpel von Team Rocket"
   },
   "acerola": {
     "en-US": "Acerola",
+    "fr-FR": "Margie",
     "es-ES": "Zarala",
     "pt-BR": "Acerola",
-    "fr-FR": "Margie",
     "it-IT": "Malpi",
     "de-DE": "Lola"
   },
   "ilima": {
     "en-US": "Ilima",
+    "fr-FR": "Althéo",
     "es-ES": "Liam",
     "pt-BR": "Luan",
-    "fr-FR": "Althéo",
     "it-IT": "Liam",
     "de-DE": "Elima"
   },
   "kiawe": {
     "en-US": "Kiawe",
+    "fr-FR": "Kiawe",
     "es-ES": "Kiawe",
     "pt-BR": "Kiawe",
-    "fr-FR": "Kiawe",
     "it-IT": "Kawe",
     "de-DE": "Kiawe"
   },
   "guzma": {
     "en-US": "Guzma",
+    "fr-FR": "Guzma",
     "es-ES": "Guzmán",
     "pt-BR": "Guzma",
-    "fr-FR": "Guzma",
     "it-IT": "Guzman",
     "de-DE": "Bromley"
   },
   "lana": {
     "en-US": "Lana",
+    "fr-FR": "Néphie",
     "es-ES": "Capitana Nereida",
     "pt-BR": "Vitória",
-    "fr-FR": "Néphie",
     "it-IT": "Suiren",
     "de-DE": "Tracy"
   },
   "sophocles": {
     "en-US": "Sophocles",
+    "fr-FR": "Chrys",
     "es-ES": "Chris",
     "pt-BR": "Chris",
-    "fr-FR": "Chrys",
     "it-IT": "Chrys",
     "de-DE": "Chrys"
   },
   "mallow": {
     "en-US": "Mallow",
+    "fr-FR": "Barbara",
     "es-ES": "Lulú",
     "pt-BR": "Lulú",
-    "fr-FR": "Barbara",
     "it-IT": "Ibis",
     "de-DE": "Maho"
   },
   "lillie": {
     "en-US": "Lillie",
+    "fr-FR": "Lilie",
     "es-ES": "Lylia",
     "pt-BR": "Lílian",
-    "fr-FR": "Lilie",
     "it-IT": "Lylia",
     "de-DE": "Lilly"
   },
   "gladion": {
     "en-US": "Gladion",
+    "fr-FR": "Gladio",
     "es-ES": "Gladio",
     "pt-BR": "Gladio",
-    "fr-FR": "Gladio",
     "it-IT": "Iridio",
     "de-DE": "Gladio"
   },
   "looker": {
     "en-US": "Looker",
+    "fr-FR": "Beladonis",
     "es-ES": "Handsome",
     "pt-BR": "Looker",
-    "fr-FR": "Beladonis",
     "it-IT": "Bellocchio",
     "de-DE": "LeBelle"
   },
   "lusamine": {
     "en-US": "Lusamine",
+    "fr-FR": "Elsa-Mina",
     "es-ES": "Samina",
     "pt-BR": "Samina",
-    "fr-FR": "Elsa-Mina",
     "it-IT": "Samina",
     "de-DE": "Samantha"
   },
   "hau": {
     "en-US": "Hau",
+    "fr-FR": "Tili",
     "es-ES": "Tilo",
     "pt-BR": "Hibi",
-    "fr-FR": "Tili",
     "it-IT": "Hau",
     "de-DE": "Tali"
   },
   "penny": {
     "en-US": "Penny",
+    "fr-FR": "Pania",
     "es-ES": "Noa",
     "pt-BR": "Penélope",
-    "fr-FR": "Pania",
     "it-IT": "Penny",
     "de-DE": "Cosima"
   },
   "will": {
     "en-US": "Will",
+    "fr-FR": "Clément",
     "es-ES": "Mento",
     "pt-BR": "Will",
-    "fr-FR": "Clément",
     "it-IT": "Pino",
     "de-DE": "Willi"
   },
   "lyra": {
     "en-US": "Lyra",
+    "fr-FR": "Célesta",
     "es-ES": "Lira",
     "pt-BR": "Lyra",
-    "fr-FR": "Célesta",
     "it-IT": "Cetra",
     "de-DE": "Lyra"
   },
   "silver": {
     "en-US": "Silver",
+    "fr-FR": "Silver",
     "es-ES": "Plata",
     "pt-BR": "Silver",
-    "fr-FR": "Silver",
     "it-IT": "Argento",
     "de-DE": "Silber"
   },
   "fisher": {
     "en-US": "Fisher",
+    "fr-FR": "Pêcheur",
     "es-ES": "Pescador",
     "pt-BR": "Pescador",
-    "fr-FR": "Pêcheur",
     "it-IT": "Pescatore",
     "de-DE": "Angler"
   },
   "jasmine": {
     "en-US": "Jasmine",
+    "fr-FR": "Jasmine",
     "es-ES": "Yasmina",
     "pt-BR": "Jasmine",
-    "fr-FR": "Jasmine",
     "it-IT": "Jasmine",
     "de-DE": "Jasmin"
   },
   "hiker": {
     "en-US": "Hiker",
+    "fr-FR": "Montagnard",
     "es-ES": "Montañero",
     "pt-BR": "Montanhista",
-    "fr-FR": "Montagnard",
     "it-IT": "Montanaro",
     "de-DE": "Wanderer"
   },
   "professor's research": {
     "en-US": "Professor's Research",
+    "fr-FR": "Recherches Professorales",
     "es-ES": "Investigación de Profesores",
     "pt-BR": "Pesquisa de Professores",
-    "fr-FR": "Recherches Professorales",
     "it-IT": "Ricerca Accademica",
     "de-DE": "Forschung des Professors"
   },
   "whitney": {
     "en-US": "Whitney",
+    "fr-FR": "Blanche",
     "es-ES": "Blanca",
     "pt-BR": "Whitney",
-    "fr-FR": "Blanche",
     "it-IT": "Chiara",
     "de-DE": "Bianka"
   },
   "traveling merchant": {
     "en-US": "Traveling Merchant",
+    "fr-FR": "Marchande Ambulante",
     "es-ES": "Mercader Ambulante",
     "pt-BR": "Mercadora Viajante",
-    "fr-FR": "Marchande Ambulante",
     "it-IT": "Venditrice Itinerante",
     "de-DE": "Reisende Händlerin"
   },
   "morty": {
     "en-US": "Morty",
+    "fr-FR": "Mortimer",
     "es-ES": "Morti",
     "pt-BR": "Morty",
-    "fr-FR": "Mortimer",
     "it-IT": "Angelo",
     "de-DE": "Jens"
   },
   "marlon": {
     "en-US": "Marlon",
+    "fr-FR": "Amana",
     "es-ES": "Ciprián",
     "pt-BR": "Marlon",
-    "fr-FR": "Amana",
     "it-IT": "Ciprian",
     "de-DE": "Benson"
   },
   "hala": {
     "en-US": "Hala",
+    "fr-FR": "Pectorius",
     "es-ES": "Kaudan",
     "pt-BR": "Pandam",
-    "fr-FR": "Pectorius",
     "it-IT": "Hala",
     "de-DE": "Hala"
   },
   "may": {
     "en-US": "May",
+    "fr-FR": "Flora",
     "es-ES": "Aura",
     "pt-BR": "May",
-    "fr-FR": "Flora",
     "it-IT": "Vera",
     "de-DE": "Maike"
   },
   "fantina": {
     "en-US": "Fantina",
+    "fr-FR": "Kiméra",
     "es-ES": "Fantina",
     "pt-BR": "Fantina",
-    "fr-FR": "Kiméra",
     "it-IT": "Fannie",
     "de-DE": "Lamina"
   },
   "copycat": {
     "en-US": "Copycat",
+    "fr-FR": "Copieuse",
     "es-ES": "Copiona",
     "pt-BR": "Imitadora",
-    "fr-FR": "Copieuse",
     "it-IT": "Copiona",
     "de-DE": "Nachahmerin"
   },
   "lisia": {
     "en-US": "Lisia",
+    "fr-FR": "Atalante",
     "es-ES": "Ariana",
     "pt-BR": "Elisia",
-    "fr-FR": "Atalante",
     "it-IT": "Orthilla",
     "de-DE": "Xenia"
   },
   "clemont": {
     "en-US": "Clemont",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Lem",
-    "it-IT": null
+    "es-ES": "Lem",
+    "pt-BR": "Clemont",
+    "it-IT": null,
+    "de-DE": "Citro"
   },
   "serena": {
     "en-US": "Serena",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Serena",
-    "it-IT": null
+    "es-ES": "Serena",
+    "pt-BR": "Serena",
+    "it-IT": null,
+    "de-DE": "Serena"
   },
   "diantha": {
     "en-US": "Diantha",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Dianthéa",
-    "it-IT": null
+    "es-ES": "Dianta",
+    "pt-BR": "Diantha",
+    "it-IT": null,
+    "de-DE": "Diantha"
   },
   "sightseer": {
     "en-US": "Sightseer",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Vacancière",
-    "it-IT": null
+    "es-ES": "Veraneante",
+    "pt-BR": "Excursionista",
+    "it-IT": null,
+    "de-DE": "Urlauberin"
   },
   "juggler": {
     "en-US": "Juggler",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Jongleur",
-    "it-IT": null
+    "es-ES": "Malabarista",
+    "pt-BR": "Malabarista",
+    "it-IT": null,
+    "de-DE": "Jongleur"
   },
   "piers": {
     "en-US": "Piers",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Peterson",
-    "it-IT": null
+    "es-ES": "Nerio",
+    "pt-BR": "Pietro",
+    "it-IT": null,
+    "de-DE": "Nezz"
   },
   "team star grunt": {
     "en-US": "Team Star Grunt",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Sbire de la Team Star",
-    "it-IT": null
+    "es-ES": "Recluta del Team Star",
+    "pt-BR": "Recruta da Equipe Star",
+    "it-IT": null,
+    "de-DE": "Rüpel von Team Star"
   },
   "nemona": {
     "en-US": "Nemona",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Menzi",
-    "it-IT": null
+    "es-ES": "Mencía",
+    "pt-BR": "Noêmia",
+    "it-IT": null,
+    "de-DE": "Nemila"
   },
   "arven": {
     "en-US": "Arven",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Pepper",
-    "it-IT": null
+    "es-ES": "Damián",
+    "pt-BR": "Arven",
+    "it-IT": null,
+    "de-DE": "Pepper"
   },
   "iris": {
     "en-US": "Iris",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Iris",
-    "it-IT": null
+    "es-ES": "Iris",
+    "pt-BR": "Iris",
+    "it-IT": null,
+    "de-DE": "Iris"
   },
   "calem": {
     "en-US": "Calem",
-    "es-ES": null,
-    "pt-BR": null,
     "fr-FR": "Kalem",
-    "it-IT": null
+    "es-ES": "Kalm",
+    "pt-BR": "Calem",
+    "it-IT": null,
+    "de-DE": "Calem"
   }
 }

--- a/scripts/sync-card-translations.js
+++ b/scripts/sync-card-translations.js
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 const CARD_DATA_DIR = 'frontend/assets'
 const TRANSLATIONS_DIR = 'frontend/assets'
-const SUPPORTED_LANGUAGES = ['en-US', 'es-ES', 'pt-BR', 'fr-FR', 'it-IT']
+const SUPPORTED_LANGUAGES = ['en-US', 'fr-FR', 'es-ES', 'pt-BR', 'it-IT', 'de-DE']
 
 function loadJsonFile(filePath) {
   try {


### PR DESCRIPTION
 * Fill in es-ES, pt-BR and de-DE translations for trainer and tool/item/stadium cards in:
      * Crimson Blaze
      * Fantastical Parade
      * Paldean Wonders
      * Mega Shine
  * Add de-DE to SUPPORTED_LANGUAGES in sync-card-translations.js so the schema stays consistent across the three translation files
  (pokemon_translations.json already used all 6 languages, trainers/tools did not)

  Translations sourced from pocket.pokemongohub.net.

  Italian (it-IT) is still null for these entries — the source does not cover it, so it's left for a follow-up PR.