### PR TITLE
Fix TradeWith scrolling to rarity

### DIFF
--- a/frontend/src/pages/trade/TradeMatchesResults.tsx
+++ b/frontend/src/pages/trade/TradeMatchesResults.tsx
@@ -39,7 +39,6 @@ export default function TradeMatchesResults() {
     return <p className="text-xl text-center py-8">{t('noTradePartners')}</p>
   }
 
-  const linkSuffix = card_id ? `?friend_card=${card_id}` : ''
   return (
     <div className="flex flex-col gap-4">
       {data.map((partner) => (
@@ -48,7 +47,7 @@ export default function TradeMatchesResults() {
             <span>{partner.username}</span>
             {partner.language && <small className="bg-neutral-800 px-2 rounded-full ml-1">{partner.language}</small>}
           </p>
-          <Link to={`/trade/${partner.friend_id}${linkSuffix}`}>
+          <Link to={`/trade/${partner.friend_id}`} state={{ friendCard: card_id }}>
             <Button variant="outline" className="my-auto">
               {t('viewTradePartner', { tradeMatches: partner.trade_matches })}
               <ChevronRight />

--- a/frontend/src/pages/trade/TradeWith.tsx
+++ b/frontend/src/pages/trade/TradeWith.tsx
@@ -1,7 +1,7 @@
 import { ChevronFirst, ChevronLeft, ChevronRight, UserPlus } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link, useParams, useSearchParams } from 'react-router'
+import { Link, useLocation, useParams } from 'react-router'
 import { Spinner } from '@/components/Spinner'
 import { Button } from '@/components/ui/button'
 import { FriendIdDisplay } from '@/components/ui/friend-id-display'
@@ -31,7 +31,7 @@ function getTradeCards(extraCards: number[], neededCards: number[]) {
 function TradeWith() {
   const { t } = useTranslation(['trade-matches', 'common'])
   const { friendId } = useParams()
-  const [searchParams] = useSearchParams()
+  const location = useLocation()
 
   const { data: friendAccount, isLoading: friendAccountLoading, isError: friendAccountError } = usePublicAccount(friendId)
   const { data: friendCards = new Map<number, CollectionRow>(), isLoading: friendCardsLoading, isError: friendCardsError } = usePublicCollection(friendId)
@@ -48,17 +48,16 @@ function TradeWith() {
   const allTrades = useAllTrades(friendAccount?.friend_id, viewHistory, pageHistory, true)
 
   const [yourCard, setYourCard] = useState<Card | null>(null)
-  const [friendCard, setFriendCard] = useState<Card | null>(() => {
-    const id = searchParams.get('friend_card')
-    return id ? (getCardByInternalId(Number(id)) ?? null) : null
-  })
+  const [friendCard, setFriendCard] = useState<Card | null>(
+    location.state?.friendCard === undefined ? null : (getCardByInternalId(location.state.friendCard) ?? null),
+  )
 
   useEffect(() => {
-    const id = searchParams.get('friend_card')
+    const id = location.state?.friendCard
     if (!id || !friendCards || !ownedCards) {
       return
     }
-    const card = getCardByInternalId(Number(id))
+    const card = getCardByInternalId(id)
     if (!card) {
       return
     }
@@ -66,7 +65,7 @@ function TradeWith() {
     if (el) {
       el.scrollIntoView({ behavior: 'smooth' })
     }
-  }, [searchParams, friendCards, ownedCards])
+  }, [location, friendCards, ownedCards?.size]) // Uses size because ReactQuery returns a different object every 10 seconds
 
   if (!account) {
     return null

--- a/frontend/src/services/collection/useCollection.ts
+++ b/frontend/src/services/collection/useCollection.ts
@@ -17,7 +17,7 @@ export function useCollection() {
     queryKey: ['collection', email],
     queryFn: () => getCollection(email as string, collectionLastUpdated),
     enabled: Boolean(email && account),
-    staleTime: 10, //set a short stale time here because we handle the cache internally already (in case someone is using two devices at the same time)
+    staleTime: 10, // Set a short stale time here because we handle the cache internally already (in case someone is using two devices at the same time)
   })
 }
 


### PR DESCRIPTION
On TradeWith, there was a feature that scrolled the interesting rarity when navigating to it with a preselected card. This PR fixes a bug, where the scroll happened too often, for example when selecting card to give. Additionally, passes the preselected card with navigation state instead of URL.