### PR TITLE
feat: B3 translations and themed collections refresh

### DIFF
--- a/frontend/assets/pokemon_translations.json
+++ b/frontend/assets/pokemon_translations.json
@@ -323,7 +323,7 @@
     "en-US": "Zubat",
     "fr-FR": "Nosferapti",
     "es-ES": "Zubat",
-    "pt-BR": null,
+    "pt-BR": "Zubat",
     "it-IT": "Zubat",
     "de-DE": "Zubat"
   },
@@ -331,7 +331,7 @@
     "en-US": "Golbat",
     "fr-FR": "Nosferalto",
     "es-ES": "Golbat",
-    "pt-BR": null,
+    "pt-BR": "Golbat",
     "it-IT": "Golbat",
     "de-DE": "Golbat"
   },
@@ -475,7 +475,7 @@
     "en-US": "Poliwag",
     "fr-FR": "Ptitard",
     "es-ES": "Poliwag",
-    "pt-BR": null,
+    "pt-BR": "Poliwag",
     "it-IT": "Poliwag",
     "de-DE": "Quapsel"
   },
@@ -483,7 +483,7 @@
     "en-US": "Poliwhirl",
     "fr-FR": "Têtarte",
     "es-ES": "Poliwhirl",
-    "pt-BR": null,
+    "pt-BR": "Poliwhirl",
     "it-IT": "Poliwhirl",
     "de-DE": "Quaputzi"
   },
@@ -643,7 +643,7 @@
     "en-US": "Magnemite",
     "fr-FR": "Magnéti",
     "es-ES": "Magnemite",
-    "pt-BR": null,
+    "pt-BR": "Magnemite",
     "it-IT": "Magnemite",
     "de-DE": "Magnetilo"
   },
@@ -651,7 +651,7 @@
     "en-US": "Magneton",
     "fr-FR": "Magnéton",
     "es-ES": "Magneton",
-    "pt-BR": null,
+    "pt-BR": "Magneton",
     "it-IT": "Magneton",
     "de-DE": "Magneton"
   },
@@ -699,7 +699,7 @@
     "en-US": "Grimer",
     "fr-FR": "Tadmorv",
     "es-ES": "Grimer",
-    "pt-BR": null,
+    "pt-BR": "Grimer",
     "it-IT": "Grimer",
     "de-DE": "Sleima"
   },
@@ -707,7 +707,7 @@
     "en-US": "Muk",
     "fr-FR": "Grotadmorv",
     "es-ES": "Muk",
-    "pt-BR": null,
+    "pt-BR": "Muk",
     "it-IT": "Muk",
     "de-DE": "Sleimok"
   },
@@ -755,7 +755,7 @@
     "en-US": "Onix",
     "fr-FR": "Onix",
     "es-ES": "Onix",
-    "pt-BR": null,
+    "pt-BR": "Onix",
     "it-IT": "Onix",
     "de-DE": "Onix"
   },
@@ -795,7 +795,7 @@
     "en-US": "Voltorb",
     "fr-FR": "Voltorbe",
     "es-ES": "Voltorb",
-    "pt-BR": null,
+    "pt-BR": "Voltorb",
     "it-IT": "Voltorb",
     "de-DE": "Voltobal"
   },
@@ -803,7 +803,7 @@
     "en-US": "Electrode",
     "fr-FR": "Électrode",
     "es-ES": "Electrode",
-    "pt-BR": null,
+    "pt-BR": "Electrode",
     "it-IT": "Electrode",
     "de-DE": "Lektrobal"
   },
@@ -851,7 +851,7 @@
     "en-US": "Hitmonchan",
     "fr-FR": "Tygnon",
     "es-ES": "Hitmonchan",
-    "pt-BR": null,
+    "pt-BR": "Hitmonchan",
     "it-IT": "Hitmonchan",
     "de-DE": "Nockchan"
   },
@@ -867,7 +867,7 @@
     "en-US": "Koffing",
     "fr-FR": "Smogo",
     "es-ES": "Koffing",
-    "pt-BR": null,
+    "pt-BR": "Koffing",
     "it-IT": "Koffing",
     "de-DE": "Smogon"
   },
@@ -875,7 +875,7 @@
     "en-US": "Weezing",
     "fr-FR": "Smogogo",
     "es-ES": "Weezing",
-    "pt-BR": null,
+    "pt-BR": "Weezing",
     "it-IT": "Weezing",
     "de-DE": "Smogmog"
   },
@@ -899,7 +899,7 @@
     "en-US": "Chansey",
     "fr-FR": "Leveinard",
     "es-ES": "Chansey",
-    "pt-BR": null,
+    "pt-BR": "Chansey",
     "it-IT": "Chansey",
     "de-DE": "Chaneira"
   },
@@ -907,7 +907,7 @@
     "en-US": "Tangela",
     "fr-FR": "Saquedeneu",
     "es-ES": "Tangela",
-    "pt-BR": null,
+    "pt-BR": "Tangela",
     "it-IT": "Tangela",
     "de-DE": "Tangela"
   },
@@ -1059,7 +1059,7 @@
     "en-US": "Eevee",
     "fr-FR": "Évoli",
     "es-ES": "Eevee",
-    "pt-BR": null,
+    "pt-BR": "Eevee",
     "it-IT": "Eevee",
     "de-DE": "Evoli"
   },
@@ -1067,7 +1067,7 @@
     "en-US": "Vaporeon",
     "fr-FR": "Aquali",
     "es-ES": "Vaporeon",
-    "pt-BR": null,
+    "pt-BR": "Vaporeon",
     "it-IT": "Vaporeon",
     "de-DE": "Aquana"
   },
@@ -1075,7 +1075,7 @@
     "en-US": "Jolteon",
     "fr-FR": "Voltali",
     "es-ES": "Jolteon",
-    "pt-BR": null,
+    "pt-BR": "Jolteon",
     "it-IT": "Jolteon",
     "de-DE": "Blitza"
   },
@@ -1091,7 +1091,7 @@
     "en-US": "Porygon",
     "fr-FR": "Porygon",
     "es-ES": "Porygon",
-    "pt-BR": null,
+    "pt-BR": "Porygon",
     "it-IT": "Porygon",
     "de-DE": "Porygon"
   },
@@ -1347,7 +1347,7 @@
     "en-US": "Crobat",
     "fr-FR": "Nostenfer",
     "es-ES": "Crobat",
-    "pt-BR": null,
+    "pt-BR": "Crobat",
     "it-IT": "Crobat",
     "de-DE": "Iksbat"
   },
@@ -1355,7 +1355,7 @@
     "en-US": "Chinchou",
     "fr-FR": "Loupio",
     "es-ES": "Chinchou",
-    "pt-BR": null,
+    "pt-BR": "Chinchou",
     "it-IT": "Chinchou",
     "de-DE": "Lampi"
   },
@@ -1363,7 +1363,7 @@
     "en-US": "Lanturn",
     "fr-FR": "Lanturn",
     "es-ES": "Lanturn",
-    "pt-BR": null,
+    "pt-BR": "Lanturn",
     "it-IT": "Lanturn",
     "de-DE": "Lanturn"
   },
@@ -1483,7 +1483,7 @@
     "en-US": "Politoed",
     "fr-FR": "Tarpaud",
     "es-ES": "Politoed",
-    "pt-BR": null,
+    "pt-BR": "Politoed",
     "it-IT": "Politoed",
     "de-DE": "Quaxo"
   },
@@ -1547,7 +1547,7 @@
     "en-US": "Wooper",
     "fr-FR": "Axoloto",
     "es-ES": "Wooper",
-    "pt-BR": null,
+    "pt-BR": "Wooper",
     "it-IT": "Wooper",
     "de-DE": "Felino"
   },
@@ -1555,7 +1555,7 @@
     "en-US": "Quagsire",
     "fr-FR": "Maraiste",
     "es-ES": "Quagsire",
-    "pt-BR": null,
+    "pt-BR": "Quagsire",
     "it-IT": "Quagsire",
     "de-DE": "Morlord"
   },
@@ -1643,7 +1643,7 @@
     "en-US": "Dunsparce",
     "fr-FR": "Insolourdo",
     "es-ES": "Dunsparce",
-    "pt-BR": null,
+    "pt-BR": "Dunsparce",
     "it-IT": "Dunsparce",
     "de-DE": "Dummisel"
   },
@@ -1651,7 +1651,7 @@
     "en-US": "Gligar",
     "fr-FR": "Scorplane",
     "es-ES": "Gligar",
-    "pt-BR": null,
+    "pt-BR": "Gligar",
     "it-IT": "Gligar",
     "de-DE": "Skorgla"
   },
@@ -1659,7 +1659,7 @@
     "en-US": "Steelix",
     "fr-FR": "Steelix",
     "es-ES": "Steelix",
-    "pt-BR": null,
+    "pt-BR": "Steelix",
     "it-IT": "Steelix",
     "de-DE": "Stahlos"
   },
@@ -1683,7 +1683,7 @@
     "en-US": "Qwilfish",
     "fr-FR": "Qwilfish",
     "es-ES": "Qwilfish",
-    "pt-BR": null,
+    "pt-BR": "Qwilfish",
     "it-IT": "Qwilfish",
     "de-DE": "Baldorfish"
   },
@@ -1707,7 +1707,7 @@
     "en-US": "Heracross",
     "fr-FR": "Scarhino",
     "es-ES": "Heracross",
-    "pt-BR": null,
+    "pt-BR": "Heracross",
     "it-IT": "Heracross",
     "de-DE": "Skaraborn"
   },
@@ -1723,7 +1723,7 @@
     "en-US": "Teddiursa",
     "fr-FR": "Teddiursa",
     "es-ES": "Teddiursa",
-    "pt-BR": null,
+    "pt-BR": "Teddiursa",
     "it-IT": "Teddiursa",
     "de-DE": "Teddiursa"
   },
@@ -1731,7 +1731,7 @@
     "en-US": "Ursaring",
     "fr-FR": "Ursaring",
     "es-ES": "Ursaring",
-    "pt-BR": null,
+    "pt-BR": "Ursaring",
     "it-IT": "Ursaring",
     "de-DE": "Ursaring"
   },
@@ -1859,7 +1859,7 @@
     "en-US": "Porygon2",
     "fr-FR": "Porygon2",
     "es-ES": "Porygon2",
-    "pt-BR": null,
+    "pt-BR": "Porygon2",
     "it-IT": "Porygon2",
     "de-DE": "Porygon2"
   },
@@ -1931,7 +1931,7 @@
     "en-US": "Blissey",
     "fr-FR": "Leuphorie",
     "es-ES": "Blissey",
-    "pt-BR": null,
+    "pt-BR": "Blissey",
     "it-IT": "Blissey",
     "de-DE": "Heiteira"
   },
@@ -2003,7 +2003,7 @@
     "en-US": "Celebi",
     "fr-FR": "Celebi",
     "es-ES": "Celebi",
-    "pt-BR": null,
+    "pt-BR": "Celebi",
     "it-IT": "Celebi",
     "de-DE": "Celebi"
   },
@@ -2011,7 +2011,7 @@
     "en-US": "Treecko",
     "fr-FR": "Arcko",
     "es-ES": "Treecko",
-    "pt-BR": null,
+    "pt-BR": "Treecko",
     "it-IT": "Treecko",
     "de-DE": "Geckarbor"
   },
@@ -2019,7 +2019,7 @@
     "en-US": "Grovyle",
     "fr-FR": "Massko",
     "es-ES": "Grovyle",
-    "pt-BR": null,
+    "pt-BR": "Grovyle",
     "it-IT": "Grovyle",
     "de-DE": "Reptain"
   },
@@ -2027,7 +2027,7 @@
     "en-US": "Sceptile",
     "fr-FR": "Jungko",
     "es-ES": "Sceptile",
-    "pt-BR": null,
+    "pt-BR": "Sceptile",
     "it-IT": "Sceptile",
     "de-DE": "Gewaldro"
   },
@@ -2035,7 +2035,7 @@
     "en-US": "Torchic",
     "fr-FR": "Poussifeu",
     "es-ES": "Torchic",
-    "pt-BR": null,
+    "pt-BR": "Torchic",
     "it-IT": "Torchic",
     "de-DE": "Flemmli"
   },
@@ -2043,7 +2043,7 @@
     "en-US": "Combusken",
     "fr-FR": "Galifeu",
     "es-ES": "Combusken",
-    "pt-BR": null,
+    "pt-BR": "Combusken",
     "it-IT": "Combusken",
     "de-DE": "Jungglut"
   },
@@ -2051,7 +2051,7 @@
     "en-US": "Blaziken",
     "fr-FR": "Braségali",
     "es-ES": "Blaziken",
-    "pt-BR": null,
+    "pt-BR": "Blaziken",
     "it-IT": "Blaziken",
     "de-DE": "Lohgock"
   },
@@ -2235,7 +2235,7 @@
     "en-US": "Ralts",
     "fr-FR": "Tarsal",
     "es-ES": "Ralts",
-    "pt-BR": null,
+    "pt-BR": "Ralts",
     "it-IT": "Ralts",
     "de-DE": "Trasla"
   },
@@ -2243,7 +2243,7 @@
     "en-US": "Kirlia",
     "fr-FR": "Kirlia",
     "es-ES": "Kirlia",
-    "pt-BR": null,
+    "pt-BR": "Kirlia",
     "it-IT": "Kirlia",
     "de-DE": "Kirlia"
   },
@@ -2259,7 +2259,7 @@
     "en-US": "Surskit",
     "fr-FR": "Arakdo",
     "es-ES": "Surskit",
-    "pt-BR": null,
+    "pt-BR": "Surskit",
     "it-IT": "Surskit",
     "de-DE": "Gehweiher"
   },
@@ -2267,7 +2267,7 @@
     "en-US": "Masquerain",
     "fr-FR": "Maskadra",
     "es-ES": "Masquerain",
-    "pt-BR": null,
+    "pt-BR": "Masquerain",
     "it-IT": "Masquerain",
     "de-DE": "Maskeregen"
   },
@@ -2275,7 +2275,7 @@
     "en-US": "Shroomish",
     "fr-FR": "Balignon",
     "es-ES": "Shroomish",
-    "pt-BR": null,
+    "pt-BR": "Shroomish",
     "it-IT": "Shroomish",
     "de-DE": "Knilz"
   },
@@ -2283,7 +2283,7 @@
     "en-US": "Breloom",
     "fr-FR": "Chapignon",
     "es-ES": "Breloom",
-    "pt-BR": null,
+    "pt-BR": "Breloom",
     "it-IT": "Breloom",
     "de-DE": "Kapilz"
   },
@@ -2571,7 +2571,7 @@
     "en-US": "Numel",
     "fr-FR": "Chamallot",
     "es-ES": "Numel",
-    "pt-BR": null,
+    "pt-BR": "Numel",
     "it-IT": "Numel",
     "de-DE": "Camaub"
   },
@@ -2579,7 +2579,7 @@
     "en-US": "Camerupt",
     "fr-FR": "Camérupt",
     "es-ES": "Camerupt",
-    "pt-BR": null,
+    "pt-BR": "Camerupt",
     "it-IT": "Camerupt",
     "de-DE": "Camerupt"
   },
@@ -2619,7 +2619,7 @@
     "en-US": "Trapinch",
     "fr-FR": "Kraknoix",
     "es-ES": "Trapinch",
-    "pt-BR": null,
+    "pt-BR": "Trapinch",
     "it-IT": "Trapinch",
     "de-DE": "Knacklion"
   },
@@ -2627,7 +2627,7 @@
     "en-US": "Vibrava",
     "fr-FR": "Vibraninf",
     "es-ES": "Vibrava",
-    "pt-BR": null,
+    "pt-BR": "Vibrava",
     "it-IT": "Vibrava",
     "de-DE": "Vibrava"
   },
@@ -2635,7 +2635,7 @@
     "en-US": "Flygon",
     "fr-FR": "Libégon",
     "es-ES": "Flygon",
-    "pt-BR": null,
+    "pt-BR": "Flygon",
     "it-IT": "Flygon",
     "de-DE": "Libelldra"
   },
@@ -2683,7 +2683,7 @@
     "en-US": "Seviper",
     "fr-FR": "Séviper",
     "es-ES": "Seviper",
-    "pt-BR": null,
+    "pt-BR": "Seviper",
     "it-IT": "Seviper",
     "de-DE": "Vipitis"
   },
@@ -2803,7 +2803,7 @@
     "en-US": "Castform",
     "fr-FR": "Morphéo",
     "es-ES": "Castform",
-    "pt-BR": null,
+    "pt-BR": "Castform",
     "it-IT": "Castform",
     "de-DE": "Formeo"
   },
@@ -2867,7 +2867,7 @@
     "en-US": "Absol",
     "fr-FR": "Absol",
     "es-ES": "Absol",
-    "pt-BR": null,
+    "pt-BR": "Absol",
     "it-IT": "Absol",
     "de-DE": "Absol"
   },
@@ -2923,7 +2923,7 @@
     "en-US": "Clamperl",
     "fr-FR": "Coquiperl",
     "es-ES": "Clamperl",
-    "pt-BR": null,
+    "pt-BR": "Clamperl",
     "it-IT": "Clamperl",
     "de-DE": "Perlu"
   },
@@ -2931,7 +2931,7 @@
     "en-US": "Huntail",
     "fr-FR": "Serpang",
     "es-ES": "Huntail",
-    "pt-BR": null,
+    "pt-BR": "Huntail",
     "it-IT": "Huntail",
     "de-DE": "Aalabyss"
   },
@@ -2939,7 +2939,7 @@
     "en-US": "Gorebyss",
     "fr-FR": "Rosabyss",
     "es-ES": "Gorebyss",
-    "pt-BR": null,
+    "pt-BR": "Gorebyss",
     "it-IT": "Gorebyss",
     "de-DE": "Saganabyss"
   },
@@ -3011,7 +3011,7 @@
     "en-US": "Regirock",
     "fr-FR": "Regirock",
     "es-ES": "Regirock",
-    "pt-BR": null,
+    "pt-BR": "Regirock",
     "it-IT": "Regirock",
     "de-DE": "Regirock"
   },
@@ -3019,7 +3019,7 @@
     "en-US": "Regice",
     "fr-FR": "Regice",
     "es-ES": "Regice",
-    "pt-BR": null,
+    "pt-BR": "Regice",
     "it-IT": "Regice",
     "de-DE": "Regice"
   },
@@ -3027,7 +3027,7 @@
     "en-US": "Registeel",
     "fr-FR": "Registeel",
     "es-ES": "Registeel",
-    "pt-BR": null,
+    "pt-BR": "Registeel",
     "it-IT": "Registeel",
     "de-DE": "Registeel"
   },
@@ -3243,7 +3243,7 @@
     "en-US": "Budew",
     "fr-FR": "Rozbouton",
     "es-ES": "Budew",
-    "pt-BR": null,
+    "pt-BR": "Budew",
     "it-IT": "Budew",
     "de-DE": "Knospi"
   },
@@ -3483,7 +3483,7 @@
     "en-US": "Bronzor",
     "fr-FR": "Archéomire",
     "es-ES": "Bronzor",
-    "pt-BR": null,
+    "pt-BR": "Bronzor",
     "it-IT": "Bronzor",
     "de-DE": "Bronzel"
   },
@@ -3491,7 +3491,7 @@
     "en-US": "Bronzong",
     "fr-FR": "Archéodong",
     "es-ES": "Bronzong",
-    "pt-BR": null,
+    "pt-BR": "Bronzong",
     "it-IT": "Bronzong",
     "de-DE": "Bronzong"
   },
@@ -3499,7 +3499,7 @@
     "en-US": "Bonsly",
     "fr-FR": "Manzaï",
     "es-ES": "Bonsly",
-    "pt-BR": null,
+    "pt-BR": "Bonsly",
     "it-IT": "Bonsly",
     "de-DE": "Mobai"
   },
@@ -3571,7 +3571,7 @@
     "en-US": "Riolu",
     "fr-FR": "Riolu",
     "es-ES": "Riolu",
-    "pt-BR": null,
+    "pt-BR": "Riolu",
     "it-IT": "Riolu",
     "de-DE": "Riolu"
   },
@@ -3579,7 +3579,7 @@
     "en-US": "Lucario",
     "fr-FR": "Lucario",
     "es-ES": "Lucario",
-    "pt-BR": null,
+    "pt-BR": "Lucario",
     "it-IT": "Lucario",
     "de-DE": "Lucario"
   },
@@ -3619,7 +3619,7 @@
     "en-US": "Croagunk",
     "fr-FR": "Cradopaud",
     "es-ES": "Croagunk",
-    "pt-BR": null,
+    "pt-BR": "Croagunk",
     "it-IT": "Croagunk",
     "de-DE": "Glibunkel"
   },
@@ -3627,7 +3627,7 @@
     "en-US": "Toxicroak",
     "fr-FR": "Coatox",
     "es-ES": "Toxicroak",
-    "pt-BR": null,
+    "pt-BR": "Toxicroak",
     "it-IT": "Toxicroak",
     "de-DE": "Toxiquak"
   },
@@ -3635,7 +3635,7 @@
     "en-US": "Carnivine",
     "fr-FR": "Vortente",
     "es-ES": "Carnivine",
-    "pt-BR": null,
+    "pt-BR": "Carnivine",
     "it-IT": "Carnivine",
     "de-DE": "Venuflibis"
   },
@@ -3691,7 +3691,7 @@
     "en-US": "Magnezone",
     "fr-FR": "Magnézone",
     "es-ES": "Magnezone",
-    "pt-BR": null,
+    "pt-BR": "Magnezone",
     "it-IT": "Magnezone",
     "de-DE": "Magnezone"
   },
@@ -3715,7 +3715,7 @@
     "en-US": "Tangrowth",
     "fr-FR": "Bouldeneu",
     "es-ES": "Tangrowth",
-    "pt-BR": null,
+    "pt-BR": "Tangrowth",
     "it-IT": "Tangrowth",
     "de-DE": "Tangoloss"
   },
@@ -3771,7 +3771,7 @@
     "en-US": "Gliscor",
     "fr-FR": "Scorvol",
     "es-ES": "Gliscor",
-    "pt-BR": null,
+    "pt-BR": "Gliscor",
     "it-IT": "Gliscor",
     "de-DE": "Skorgro"
   },
@@ -3787,7 +3787,7 @@
     "en-US": "Porygon-Z",
     "fr-FR": "Porygon-Z",
     "es-ES": "Porygon-Z",
-    "pt-BR": null,
+    "pt-BR": "Porygon-Z",
     "it-IT": "Porygon-Z",
     "de-DE": "Porygon-Z"
   },
@@ -3795,7 +3795,7 @@
     "en-US": "Gallade",
     "fr-FR": "Gallame",
     "es-ES": "Gallade",
-    "pt-BR": null,
+    "pt-BR": "Gallade",
     "it-IT": "Gallade",
     "de-DE": "Galagladi"
   },
@@ -3883,7 +3883,7 @@
     "en-US": "Regigigas",
     "fr-FR": "Regigigas",
     "es-ES": "Regigigas",
-    "pt-BR": null,
+    "pt-BR": "Regigigas",
     "it-IT": "Regigigas",
     "de-DE": "Regigigas"
   },
@@ -3947,7 +3947,7 @@
     "en-US": "Victini",
     "fr-FR": "Victini",
     "es-ES": "Victini",
-    "pt-BR": null,
+    "pt-BR": "Victini",
     "it-IT": "Victini",
     "de-DE": "Victini"
   },
@@ -3979,7 +3979,7 @@
     "en-US": "Tepig",
     "fr-FR": "Gruikui",
     "es-ES": "Tepig",
-    "pt-BR": null,
+    "pt-BR": "Tepig",
     "it-IT": "Tepig",
     "de-DE": "Floink"
   },
@@ -3987,7 +3987,7 @@
     "en-US": "Pignite",
     "fr-FR": "Grotichon",
     "es-ES": "Pignite",
-    "pt-BR": null,
+    "pt-BR": "Pignite",
     "it-IT": "Pignite",
     "de-DE": "Ferkokel"
   },
@@ -3995,7 +3995,7 @@
     "en-US": "Emboar",
     "fr-FR": "Roitiflam",
     "es-ES": "Emboar",
-    "pt-BR": null,
+    "pt-BR": "Emboar",
     "it-IT": "Emboar",
     "de-DE": "Flambirex"
   },
@@ -4027,7 +4027,7 @@
     "en-US": "Patrat",
     "fr-FR": "Ratentif",
     "es-ES": "Patrat",
-    "pt-BR": null,
+    "pt-BR": "Patrat",
     "it-IT": "Patrat",
     "de-DE": "Nagelotz"
   },
@@ -4035,7 +4035,7 @@
     "en-US": "Watchog",
     "fr-FR": "Miradar",
     "es-ES": "Watchog",
-    "pt-BR": null,
+    "pt-BR": "Watchog",
     "it-IT": "Watchog",
     "de-DE": "Kukmarda"
   },
@@ -4043,7 +4043,7 @@
     "en-US": "Lillipup",
     "fr-FR": "Ponchiot",
     "es-ES": "Lillipup",
-    "pt-BR": null,
+    "pt-BR": "Lillipup",
     "it-IT": "Lillipup",
     "de-DE": "Yorkleff"
   },
@@ -4051,7 +4051,7 @@
     "en-US": "Herdier",
     "fr-FR": "Ponchien",
     "es-ES": "Herdier",
-    "pt-BR": null,
+    "pt-BR": "Herdier",
     "it-IT": "Herdier",
     "de-DE": "Terribark"
   },
@@ -4059,7 +4059,7 @@
     "en-US": "Stoutland",
     "fr-FR": "Mastouffe",
     "es-ES": "Stoutland",
-    "pt-BR": null,
+    "pt-BR": "Stoutland",
     "it-IT": "Stoutland",
     "de-DE": "Bissbark"
   },
@@ -4243,7 +4243,7 @@
     "en-US": "Audino",
     "fr-FR": "Nanméouïe",
     "es-ES": "Audino",
-    "pt-BR": null,
+    "pt-BR": "Audino",
     "it-IT": "Audino",
     "de-DE": "Ohrdoch"
   },
@@ -4299,7 +4299,7 @@
     "en-US": "Throh",
     "fr-FR": "Judokrak",
     "es-ES": "Throh",
-    "pt-BR": null,
+    "pt-BR": "Throh",
     "it-IT": "Throh",
     "de-DE": "Jiutesto"
   },
@@ -4307,7 +4307,7 @@
     "en-US": "Sawk",
     "fr-FR": "Karaclée",
     "es-ES": "Sawk",
-    "pt-BR": null,
+    "pt-BR": "Sawk",
     "it-IT": "Sawk",
     "de-DE": "Karadonis"
   },
@@ -4315,7 +4315,7 @@
     "en-US": "Sewaddle",
     "fr-FR": "Larveyette",
     "es-ES": "Sewaddle",
-    "pt-BR": null,
+    "pt-BR": "Sewaddle",
     "it-IT": "Sewaddle",
     "de-DE": "Strawickl"
   },
@@ -4323,7 +4323,7 @@
     "en-US": "Swadloon",
     "fr-FR": "Couverdure",
     "es-ES": "Swadloon",
-    "pt-BR": null,
+    "pt-BR": "Swadloon",
     "it-IT": "Swadloon",
     "de-DE": "Folikon"
   },
@@ -4331,7 +4331,7 @@
     "en-US": "Leavanny",
     "fr-FR": "Manternel",
     "es-ES": "Leavanny",
-    "pt-BR": null,
+    "pt-BR": "Leavanny",
     "it-IT": "Leavanny",
     "de-DE": "Matrifol"
   },
@@ -4363,7 +4363,7 @@
     "en-US": "Cottonee",
     "fr-FR": "Doudouvet",
     "es-ES": "Cottonee",
-    "pt-BR": null,
+    "pt-BR": "Cottonee",
     "it-IT": "Cottonee",
     "de-DE": "Waumboll"
   },
@@ -4371,7 +4371,7 @@
     "en-US": "Whimsicott",
     "fr-FR": "Farfaduvet",
     "es-ES": "Whimsicott",
-    "pt-BR": null,
+    "pt-BR": "Whimsicott",
     "it-IT": "Whimsicott",
     "de-DE": "Elfun"
   },
@@ -4427,7 +4427,7 @@
     "en-US": "Darumaka",
     "fr-FR": "Darumarond",
     "es-ES": "Darumaka",
-    "pt-BR": null,
+    "pt-BR": "Darumaka",
     "it-IT": "Darumaka",
     "de-DE": "Flampion"
   },
@@ -4435,7 +4435,7 @@
     "en-US": "Darmanitan",
     "fr-FR": "Darumacho",
     "es-ES": "Darmanitan",
-    "pt-BR": null,
+    "pt-BR": "Darmanitan",
     "it-IT": "Darmanitan",
     "de-DE": "Flampivian"
   },
@@ -4451,7 +4451,7 @@
     "en-US": "Dwebble",
     "fr-FR": "Crabicoque",
     "es-ES": "Dwebble",
-    "pt-BR": null,
+    "pt-BR": "Dwebble",
     "it-IT": "Dwebble",
     "de-DE": "Lithomith"
   },
@@ -4459,7 +4459,7 @@
     "en-US": "Crustle",
     "fr-FR": "Crabaraque",
     "es-ES": "Crustle",
-    "pt-BR": null,
+    "pt-BR": "Crustle",
     "it-IT": "Crustle",
     "de-DE": "Castellith"
   },
@@ -4555,7 +4555,7 @@
     "en-US": "Zorua",
     "fr-FR": "Zorua",
     "es-ES": "Zorua",
-    "pt-BR": null,
+    "pt-BR": "Zorua",
     "it-IT": "Zorua",
     "de-DE": "Zorua"
   },
@@ -4563,7 +4563,7 @@
     "en-US": "Zoroark",
     "fr-FR": "Zoroark",
     "es-ES": "Zoroark",
-    "pt-BR": null,
+    "pt-BR": "Zoroark",
     "it-IT": "Zoroark",
     "de-DE": "Zoroark"
   },
@@ -4571,7 +4571,7 @@
     "en-US": "Minccino",
     "fr-FR": "Chinchidou",
     "es-ES": "Minccino",
-    "pt-BR": null,
+    "pt-BR": "Minccino",
     "it-IT": "Minccino",
     "de-DE": "Picochilla"
   },
@@ -4579,7 +4579,7 @@
     "en-US": "Cinccino",
     "fr-FR": "Pashmilla",
     "es-ES": "Cinccino",
-    "pt-BR": null,
+    "pt-BR": "Cinccino",
     "it-IT": "Cinccino",
     "de-DE": "Chillabell"
   },
@@ -4715,7 +4715,7 @@
     "en-US": "Foongus",
     "fr-FR": "Trompignon",
     "es-ES": "Foongus",
-    "pt-BR": null,
+    "pt-BR": "Foongus",
     "it-IT": "Foongus",
     "de-DE": "Tarnpignon"
   },
@@ -4723,7 +4723,7 @@
     "en-US": "Amoonguss",
     "fr-FR": "Gaulet",
     "es-ES": "Amoonguss",
-    "pt-BR": null,
+    "pt-BR": "Amoonguss",
     "it-IT": "Amoonguss",
     "de-DE": "Hutsassa"
   },
@@ -4731,7 +4731,7 @@
     "en-US": "Frillish",
     "fr-FR": "Viskuse",
     "es-ES": "Frillish",
-    "pt-BR": null,
+    "pt-BR": "Frillish",
     "it-IT": "Frillish",
     "de-DE": "Quabbel"
   },
@@ -4739,7 +4739,7 @@
     "en-US": "Jellicent",
     "fr-FR": "Moyade",
     "es-ES": "Jellicent",
-    "pt-BR": null,
+    "pt-BR": "Jellicent",
     "it-IT": "Jellicent",
     "de-DE": "Apoquallyp"
   },
@@ -4899,7 +4899,7 @@
     "en-US": "Cubchoo",
     "fr-FR": "Polarhume",
     "es-ES": "Cubchoo",
-    "pt-BR": null,
+    "pt-BR": "Cubchoo",
     "it-IT": "Cubchoo",
     "de-DE": "Petznief"
   },
@@ -4907,7 +4907,7 @@
     "en-US": "Beartic",
     "fr-FR": "Polagriffe",
     "es-ES": "Beartic",
-    "pt-BR": null,
+    "pt-BR": "Beartic",
     "it-IT": "Beartic",
     "de-DE": "Siberio"
   },
@@ -4987,7 +4987,7 @@
     "en-US": "Pawniard",
     "fr-FR": "Scalpion",
     "es-ES": "Pawniard",
-    "pt-BR": null,
+    "pt-BR": "Pawniard",
     "it-IT": "Pawniard",
     "de-DE": "Gladiantri"
   },
@@ -4995,7 +4995,7 @@
     "en-US": "Bisharp",
     "fr-FR": "Scalproie",
     "es-ES": "Bisharp",
-    "pt-BR": null,
+    "pt-BR": "Bisharp",
     "it-IT": "Bisharp",
     "de-DE": "Caesurio"
   },
@@ -5027,7 +5027,7 @@
     "en-US": "Vullaby",
     "fr-FR": "Vostourno",
     "es-ES": "Vullaby",
-    "pt-BR": null,
+    "pt-BR": "Vullaby",
     "it-IT": "Vullaby",
     "de-DE": "Skallyk"
   },
@@ -5035,7 +5035,7 @@
     "en-US": "Mandibuzz",
     "fr-FR": "Vaututrice",
     "es-ES": "Mandibuzz",
-    "pt-BR": null,
+    "pt-BR": "Mandibuzz",
     "it-IT": "Mandibuzz",
     "de-DE": "Grypheldis"
   },
@@ -5051,7 +5051,7 @@
     "en-US": "Durant",
     "fr-FR": "Fermite",
     "es-ES": "Durant",
-    "pt-BR": null,
+    "pt-BR": "Durant",
     "it-IT": "Durant",
     "de-DE": "Fermicula"
   },
@@ -5083,7 +5083,7 @@
     "en-US": "Larvesta",
     "fr-FR": "Pyronille",
     "es-ES": "Larvesta",
-    "pt-BR": null,
+    "pt-BR": "Larvesta",
     "it-IT": "Larvesta",
     "de-DE": "Ignivor"
   },
@@ -5091,7 +5091,7 @@
     "en-US": "Volcarona",
     "fr-FR": "Pyrax",
     "es-ES": "Volcarona",
-    "pt-BR": null,
+    "pt-BR": "Volcarona",
     "it-IT": "Volcarona",
     "de-DE": "Ramoth"
   },
@@ -5147,7 +5147,7 @@
     "en-US": "Zekrom",
     "fr-FR": "Zekrom",
     "es-ES": "Zekrom",
-    "pt-BR": null,
+    "pt-BR": "Zekrom",
     "it-IT": "Zekrom",
     "de-DE": "Zekrom"
   },
@@ -5179,7 +5179,7 @@
     "en-US": "Meloetta",
     "fr-FR": "Meloetta",
     "es-ES": "Meloetta",
-    "pt-BR": null,
+    "pt-BR": "Meloetta",
     "it-IT": "Meloetta",
     "de-DE": "Meloetta"
   },
@@ -5259,7 +5259,7 @@
     "en-US": "Greninja",
     "fr-FR": "Amphinobi",
     "es-ES": "Greninja",
-    "pt-BR": null,
+    "pt-BR": "Greninja",
     "it-IT": "Greninja",
     "de-DE": "Quajutsu"
   },
@@ -5403,7 +5403,7 @@
     "en-US": "Furfrou",
     "fr-FR": "Couafarel",
     "es-ES": "Furfrou",
-    "pt-BR": null,
+    "pt-BR": "Furfrou",
     "it-IT": "Furfrou",
     "de-DE": "Coiffwaff"
   },
@@ -5411,7 +5411,7 @@
     "en-US": "Espurr",
     "fr-FR": "Psystigri",
     "es-ES": "Espurr",
-    "pt-BR": null,
+    "pt-BR": "Espurr",
     "it-IT": "Espurr",
     "de-DE": "Psiau"
   },
@@ -5419,7 +5419,7 @@
     "en-US": "Meowstic",
     "fr-FR": "Mistigrix",
     "es-ES": "Meowstic",
-    "pt-BR": null,
+    "pt-BR": "Meowstic",
     "it-IT": "Meowstic",
     "de-DE": "Psiaugon"
   },
@@ -5483,7 +5483,7 @@
     "en-US": "Inkay",
     "fr-FR": "Sepiatop",
     "es-ES": "Inkay",
-    "pt-BR": null,
+    "pt-BR": "Inkay",
     "it-IT": "Inkay",
     "de-DE": "Iscalar"
   },
@@ -5491,7 +5491,7 @@
     "en-US": "Malamar",
     "fr-FR": "Sepiatroce",
     "es-ES": "Malamar",
-    "pt-BR": null,
+    "pt-BR": "Malamar",
     "it-IT": "Malamar",
     "de-DE": "Calamanero"
   },
@@ -5515,7 +5515,7 @@
     "en-US": "Skrelp",
     "fr-FR": "Venalgue",
     "es-ES": "Skrelp",
-    "pt-BR": null,
+    "pt-BR": "Skrelp",
     "it-IT": "Skrelp",
     "de-DE": "Algitt"
   },
@@ -5523,7 +5523,7 @@
     "en-US": "Dragalge",
     "fr-FR": "Kravarech",
     "es-ES": "Dragalge",
-    "pt-BR": null,
+    "pt-BR": "Dragalge",
     "it-IT": "Dragalge",
     "de-DE": "Tandrak"
   },
@@ -5747,7 +5747,7 @@
     "en-US": "Diancie",
     "fr-FR": "Diancie",
     "es-ES": "Diancie",
-    "pt-BR": null,
+    "pt-BR": "Diancie",
     "it-IT": "Diancie",
     "de-DE": "Diancie"
   },
@@ -5923,7 +5923,7 @@
     "en-US": "Oricorio",
     "fr-FR": "Plumeline",
     "es-ES": "Oricorio",
-    "pt-BR": null,
+    "pt-BR": "Oricorio",
     "it-IT": "Oricorio",
     "de-DE": "Choreogel"
   },
@@ -6067,7 +6067,7 @@
     "en-US": "Stufful",
     "fr-FR": "Nounourson",
     "es-ES": "Stufful",
-    "pt-BR": null,
+    "pt-BR": "Stufful",
     "it-IT": "Stufful",
     "de-DE": "Velursi"
   },
@@ -6075,7 +6075,7 @@
     "en-US": "Bewear",
     "fr-FR": "Chelours",
     "es-ES": "Bewear",
-    "pt-BR": null,
+    "pt-BR": "Bewear",
     "it-IT": "Bewear",
     "de-DE": "Kosturso"
   },
@@ -6403,7 +6403,7 @@
     "en-US": "Magearna",
     "fr-FR": "Magearna",
     "es-ES": "Magearna",
-    "pt-BR": null,
+    "pt-BR": "Magearna",
     "it-IT": "Magearna",
     "de-DE": "Magearna"
   },
@@ -6459,7 +6459,7 @@
     "en-US": "Meltan",
     "fr-FR": "Meltan",
     "es-ES": "Meltan",
-    "pt-BR": null,
+    "pt-BR": "Meltan",
     "it-IT": "Meltan",
     "de-DE": "Meltan"
   },
@@ -6467,7 +6467,7 @@
     "en-US": "Melmetal",
     "fr-FR": "Melmetal",
     "es-ES": "Melmetal",
-    "pt-BR": null,
+    "pt-BR": "Melmetal",
     "it-IT": "Melmetal",
     "de-DE": "Melmetal"
   },
@@ -6523,7 +6523,7 @@
     "en-US": "Sobble",
     "fr-FR": "Larméléon",
     "es-ES": "Sobble",
-    "pt-BR": null,
+    "pt-BR": "Sobble",
     "it-IT": "Sobble",
     "de-DE": "Memmeon"
   },
@@ -6531,7 +6531,7 @@
     "en-US": "Drizzile",
     "fr-FR": "Arrozard",
     "es-ES": "Drizzile",
-    "pt-BR": null,
+    "pt-BR": "Drizzile",
     "it-IT": "Drizzile",
     "de-DE": "Phlegleon"
   },
@@ -6539,7 +6539,7 @@
     "en-US": "Inteleon",
     "fr-FR": "Lézargus",
     "es-ES": "Inteleon",
-    "pt-BR": null,
+    "pt-BR": "Inteleon",
     "it-IT": "Inteleon",
     "de-DE": "Intelleon"
   },
@@ -6563,7 +6563,7 @@
     "en-US": "Rookidee",
     "fr-FR": "Minisange",
     "es-ES": "Rookidee",
-    "pt-BR": null,
+    "pt-BR": "Rookidee",
     "it-IT": "Rookidee",
     "de-DE": "Meikro"
   },
@@ -6571,7 +6571,7 @@
     "en-US": "Corvisquire",
     "fr-FR": "Bleuseille",
     "es-ES": "Corvisquire",
-    "pt-BR": null,
+    "pt-BR": "Corvisquire",
     "it-IT": "Corvisquire",
     "de-DE": "Kranoviz"
   },
@@ -6579,7 +6579,7 @@
     "en-US": "Corviknight",
     "fr-FR": "Corvaillus",
     "es-ES": "Corviknight",
-    "pt-BR": null,
+    "pt-BR": "Corviknight",
     "it-IT": "Corviknight",
     "de-DE": "Krarmor"
   },
@@ -6691,7 +6691,7 @@
     "en-US": "Rolycoly",
     "fr-FR": "Charbi",
     "es-ES": "Rolycoly",
-    "pt-BR": null,
+    "pt-BR": "Rolycoly",
     "it-IT": "Rolycoly",
     "de-DE": "Klonkett"
   },
@@ -6699,7 +6699,7 @@
     "en-US": "Carkol",
     "fr-FR": "Wagomine",
     "es-ES": "Carkol",
-    "pt-BR": null,
+    "pt-BR": "Carkol",
     "it-IT": "Carkol",
     "de-DE": "Wagong"
   },
@@ -6707,7 +6707,7 @@
     "en-US": "Coalossal",
     "fr-FR": "Monthracite",
     "es-ES": "Coalossal",
-    "pt-BR": null,
+    "pt-BR": "Coalossal",
     "it-IT": "Coalossal",
     "de-DE": "Montecarbo"
   },
@@ -6715,7 +6715,7 @@
     "en-US": "Applin",
     "fr-FR": "Verpom",
     "es-ES": "Applin",
-    "pt-BR": null,
+    "pt-BR": "Applin",
     "it-IT": "Applin",
     "de-DE": "Knapfel"
   },
@@ -6723,7 +6723,7 @@
     "en-US": "Flapple",
     "fr-FR": "Pomdrapi",
     "es-ES": "Flapple",
-    "pt-BR": null,
+    "pt-BR": "Flapple",
     "it-IT": "Flapple",
     "de-DE": "Drapfel"
   },
@@ -6739,7 +6739,7 @@
     "en-US": "Silicobra",
     "fr-FR": "Dunaja",
     "es-ES": "Silicobra",
-    "pt-BR": null,
+    "pt-BR": "Silicobra",
     "it-IT": "Silicobra",
     "de-DE": "Salanga"
   },
@@ -6747,7 +6747,7 @@
     "en-US": "Sandaconda",
     "fr-FR": "Dunaconda",
     "es-ES": "Sandaconda",
-    "pt-BR": null,
+    "pt-BR": "Sandaconda",
     "it-IT": "Sandaconda",
     "de-DE": "Sanaconda"
   },
@@ -6779,7 +6779,7 @@
     "en-US": "Toxel",
     "fr-FR": "Toxizap",
     "es-ES": "Toxel",
-    "pt-BR": null,
+    "pt-BR": "Toxel",
     "it-IT": "Toxel",
     "de-DE": "Toxel"
   },
@@ -6787,7 +6787,7 @@
     "en-US": "Toxtricity",
     "fr-FR": "Salarsen",
     "es-ES": "Toxtricity",
-    "pt-BR": null,
+    "pt-BR": "Toxtricity",
     "it-IT": "Toxtricity",
     "de-DE": "Riffex"
   },
@@ -6843,7 +6843,7 @@
     "en-US": "Hatenna",
     "fr-FR": "Bibichut",
     "es-ES": "Hatenna",
-    "pt-BR": null,
+    "pt-BR": "Hatenna",
     "it-IT": "Hatenna",
     "de-DE": "Brimova"
   },
@@ -6851,7 +6851,7 @@
     "en-US": "Hattrem",
     "fr-FR": "Chapotus",
     "es-ES": "Hattrem",
-    "pt-BR": null,
+    "pt-BR": "Hattrem",
     "it-IT": "Hattrem",
     "de-DE": "Brimano"
   },
@@ -6859,7 +6859,7 @@
     "en-US": "Hatterene",
     "fr-FR": "Sorcilence",
     "es-ES": "Hatterene",
-    "pt-BR": null,
+    "pt-BR": "Hatterene",
     "it-IT": "Hatterene",
     "de-DE": "Silembrim"
   },
@@ -7011,7 +7011,7 @@
     "en-US": "Morpeko",
     "fr-FR": "Morpeko",
     "es-ES": "Morpeko",
-    "pt-BR": null,
+    "pt-BR": "Morpeko",
     "it-IT": "Morpeko",
     "de-DE": "Morpeko"
   },
@@ -7123,7 +7123,7 @@
     "en-US": "Kubfu",
     "fr-FR": "Wushours",
     "es-ES": "Kubfu",
-    "pt-BR": null,
+    "pt-BR": "Kubfu",
     "it-IT": "Kubfu",
     "de-DE": "Dakuma"
   },
@@ -7139,7 +7139,7 @@
     "en-US": "Zarude",
     "fr-FR": "Zarude",
     "es-ES": "Zarude",
-    "pt-BR": null,
+    "pt-BR": "Zarude",
     "it-IT": "Zarude",
     "de-DE": "Zarude"
   },
@@ -7563,7 +7563,7 @@
     "en-US": "Bramblin",
     "fr-FR": "Virovent",
     "es-ES": "Bramblin",
-    "pt-BR": null,
+    "pt-BR": "Bramblin",
     "it-IT": "Bramblin",
     "de-DE": "Weherba"
   },
@@ -7571,7 +7571,7 @@
     "en-US": "Brambleghast",
     "fr-FR": "Virevorreur",
     "es-ES": "Brambleghast",
-    "pt-BR": null,
+    "pt-BR": "Brambleghast",
     "it-IT": "Brambleghast",
     "de-DE": "Horrerba"
   },
@@ -7691,7 +7691,7 @@
     "en-US": "Bombirdier",
     "fr-FR": "Lestombaile",
     "es-ES": "Bombirdier",
-    "pt-BR": null,
+    "pt-BR": "Bombirdier",
     "it-IT": "Bombirdier",
     "de-DE": "Adebom"
   },
@@ -8257,8 +8257,8 @@
   },
   "paldean tauros": {
     "en-US": "Paldean Tauros",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Tauros de Paldea",
+    "pt-BR": "Tauros de Paldea",
     "fr-FR": "Tauros de Paldea",
     "it-IT": null,
     "de-DE": "Paldea-Tauros"
@@ -8541,8 +8541,8 @@
   },
   "mega steelix": {
     "en-US": "Mega Steelix",
-    "es-ES": null,
-    "pt-BR": null,
+    "es-ES": "Mega-Steelix",
+    "pt-BR": "Mega Steelix",
     "fr-FR": "Méga-Steelix",
     "it-IT": null
   },
@@ -8730,74 +8730,74 @@
   },
   "mega sceptile": {
     "en-US": "Mega Sceptile",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Méga-Jungko",
+    "es-ES": "Mega-Sceptile",
+    "pt-BR": "Mega Sceptile",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Mega-Gewaldro"
   },
   "mega camerupt": {
     "en-US": "Mega Camerupt",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Méga-Camérupt",
+    "es-ES": "Mega-Camerupt",
+    "pt-BR": "Mega Camerupt",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Mega-Camerupt"
   },
   "castform sunny form": {
     "en-US": "Castform Sunny Form",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Morphéo Forme Solaire",
+    "es-ES": "Castform Forma Sol",
+    "pt-BR": "Castform Forma Ensolarada",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Formeo Sonnenform"
   },
   "castform rainy form": {
     "en-US": "Castform Rainy Form",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Morphéo Forme Eau de Pluie",
+    "es-ES": "Castform Forma Lluvia",
+    "pt-BR": "Castform Forma Chuvosa",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Formeo Regenform"
   },
   "castform snowy form": {
     "en-US": "Castform Snowy Form",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Morphéo Forme Blizzard",
+    "es-ES": "Castform Forma Nieve",
+    "pt-BR": "Castform Forma Nevada",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Formeo Schneeform"
   },
   "rapid strike urshifu": {
     "en-US": "Rapid Strike Urshifu",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Shifours Mille Poings",
+    "es-ES": "Urshifu Golpe Fluido",
+    "pt-BR": "Urshifu Golpe Fluido",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Fließender-Angriff-Wulaosu"
   },
   "mega lucario": {
     "en-US": "Mega Lucario",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Méga-Lucario",
+    "es-ES": "Mega-Lucario",
+    "pt-BR": "Mega Lucario",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Mega-Lucario"
   },
   "single strike urshifu": {
     "en-US": "Single Strike Urshifu",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Shifours Poing Final",
+    "es-ES": "Urshifu Golpe Brusco",
+    "pt-BR": "Urshifu Golpe Decisivo",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Fokussierter-Angriff-Wulaosu"
   },
   "mega audino": {
     "en-US": "Mega Audino",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Méga-Nanméouïe",
+    "es-ES": "Mega-Audino",
+    "pt-BR": "Mega Audino",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Mega-Ohrdoch"
   }
 }

--- a/frontend/assets/themed-collections/A1-missions.json
+++ b/frontend/assets/themed-collections/A1-missions.json
@@ -4,19 +4,20 @@
     "name": "First Choice",
     "requiredCards": [
       {
-        "options": ["A1-1", "A1-227"],
+        "options": ["A4b-1", "A1-227", "A3-210", "A4b-2", "P-A-23"],
         "amount": 1
       },
       {
-        "options": ["A1-33", "A1-230"],
+        "options": ["A4b-55", "A1-230", "A4b-56", "P-A-32"],
         "amount": 1
       },
       {
-        "options": ["A1-53", "A1-232"],
+        "options": ["A4b-83", "A1-232", "A3-215", "A4b-84", "P-A-33"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Genetic Apex) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -31,7 +32,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Genetic Apex) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -54,11 +56,12 @@
         "amount": 1
       },
       {
-        "options": ["A1-94", "A1-96", "A1-259", "A1-281", "A1-285"],
+        "options": ["A4b-128", "A4b-129", "P-A-9", "P-A-15", "P-A-26"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Genetic Apex) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -73,11 +76,12 @@
         "amount": 1
       },
       {
-        "options": ["A1-188", "A1-245"],
+        "options": ["A1-188", "A1-245", "A3a-97"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×7"
+    "reward": "Shinedust ×700",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -92,7 +96,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-168", "A1-240"],
+        "options": ["A1-168", "A1-240", "A4-225"],
         "amount": 1
       },
       {
@@ -104,11 +108,12 @@
         "amount": 1
       },
       {
-        "options": ["A1-171", "A1-241"],
+        "options": ["A1-171", "A1-241", "A4-228"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×14"
+    "reward": "Shinedust ×1400",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -135,33 +140,35 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×20"
+    "reward": "Shinedust ×2000",
+    "secret": false
   },
   {
     "expansionId": "A1",
     "name": "The Legendary Flight",
     "requiredCards": [
       {
-        "options": ["A1-46", "A1-47", "A1-255", "A1-274"],
+        "options": ["A1-46", "B1-292"],
         "amount": 1
       },
       {
-        "options": ["A1-83", "A1-84", "A1-258", "A1-275"],
+        "options": ["A1-83", "B1-298"],
         "amount": 1
       },
       {
-        "options": ["A1-103", "A1-104", "A1-260", "A1-276"],
+        "options": ["A1-103", "B1-302"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×17"
+    "reward": "Shinedust ×1700",
+    "secret": false
   },
   {
     "expansionId": "A1",
     "name": "Triple Power",
     "requiredCards": [
       {
-        "options": ["A1-22", "A1-23", "A1-252"],
+        "options": ["A1-22"],
         "amount": 1
       },
       {
@@ -177,7 +184,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -200,7 +208,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×14"
+    "reward": "Shinedust ×1400",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -211,11 +220,11 @@
         "amount": 1
       },
       {
-        "options": ["A1-121"],
+        "options": ["A1-127"],
         "amount": 1
       },
       {
-        "options": ["A1-127"],
+        "options": ["A4b-153"],
         "amount": 1
       },
       {
@@ -235,14 +244,15 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×24<br />Shop Ticket ×5<br />Emblem Ticket (Genetic Apex) ×4"
+    "reward": "Wonder Hourglass ×24<br />Shop Ticket ×5<br />Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A1",
     "name": "The Gym Leaders of the Kanto Region",
     "requiredCards": [
       {
-        "options": ["A1-219", "A1-266"],
+        "options": ["A4b-328", "A1-266", "A4b-329"],
         "amount": 1
       },
       {
@@ -258,7 +268,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-223", "A1-270"],
+        "options": ["A4b-334", "A1-270", "A4b-335"],
         "amount": 1
       },
       {
@@ -266,34 +276,35 @@
         "amount": 1
       },
       {
-        "options": ["A1-225", "A1-272"],
+        "options": ["A1-226", "A1-273"],
         "amount": 1
       },
       {
-        "options": ["A1-226", "A1-273"],
+        "options": ["A4b-338", "A1-272", "A4b-339"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×24<br />Shop Ticket ×5<br />Emblem Ticket (Genetic Apex) ×8"
+    "reward": "Wonder Hourglass ×24<br />Shop Ticket ×5<br />Shinedust ×800",
+    "secret": false
   },
   {
     "expansionId": "A1",
     "name": "Different Journeys, Different Growth",
     "requiredCards": [
       {
-        "options": ["A1-1", "A1-227"],
+        "options": ["A4b-1", "A1-227", "A3-210", "A4b-2", "P-A-23"],
         "amount": 1
       },
       {
-        "options": ["A1-2"],
+        "options": ["A1-3", "A3-212", "P-A-18"],
         "amount": 1
       },
       {
-        "options": ["A1-3", "A1-4", "A1-251"],
+        "options": ["A4b-3"],
         "amount": 1
       },
       {
-        "options": ["A1-33", "A1-230"],
+        "options": ["A4b-55", "A1-230", "A4b-56", "P-A-32"],
         "amount": 1
       },
       {
@@ -301,11 +312,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-35", "A1-36", "A1-253", "A1-280", "A1-284"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-53", "A1-232"],
+        "options": ["A1-35"],
         "amount": 1
       },
       {
@@ -313,11 +320,16 @@
         "amount": 1
       },
       {
-        "options": ["A1-55", "A1-56", "A1-256"],
+        "options": ["A1-55", "A3-217", "P-A-29"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-83", "A1-232", "A3-215", "A4b-84", "P-A-33"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×22"
+    "reward": "Shinedust ×2200",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -368,18 +380,19 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "A1",
     "name": "Category: Mouse Pokémon",
     "requiredCards": [
       {
-        "options": ["A1-94", "A1-96", "A1-259", "A1-281", "A1-285"],
+        "options": ["A1-95"],
         "amount": 1
       },
       {
-        "options": ["A1-95"],
+        "options": ["A4b-128", "A4b-129", "P-A-9", "P-A-15", "P-A-26"],
         "amount": 1
       },
       {
@@ -399,14 +412,15 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A1",
     "name": "Pokémon Super Express",
     "requiredCards": [
       {
-        "options": ["A1-40", "A1-41", "A1-254"],
+        "options": ["A1-40", "A3a-90"],
         "amount": 1
       },
       {
@@ -422,7 +436,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Genetic Apex) ×13"
+    "reward": "Shinedust ×1300",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -433,18 +448,8 @@
         "amount": 3
       }
     ],
-    "reward": "Electrode (profile icon)"
-  },
-  {
-    "expansionId": "A1",
-    "name": "Collect 5 Gardevoir cards",
-    "requiredCards": [
-      {
-        "options": ["A1-132"],
-        "amount": 5
-      }
-    ],
-    "reward": "Gardevoir (profile icon)"
+    "reward": "Electrode (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -455,7 +460,8 @@
         "amount": 5
       }
     ],
-    "reward": "Charizard (profile icon)"
+    "reward": "Charizard (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A1",
@@ -466,220 +472,23 @@
         "amount": 5
       }
     ],
-    "reward": "Mewtwo (profile icon)"
+    "reward": "Mewtwo (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A1",
-    "name": "Genetic Apex Museum 1 (Mewtwo)",
+    "name": "Complete the Kanto Pokédex!",
     "requiredCards": [
       {
-        "options": ["A1-227"],
+        "options": ["A4b-1", "A1-227", "A3-210", "A4b-2", "P-A-23"],
         "amount": 1
       },
       {
-        "options": ["A1-239"],
+        "options": ["A4b-3"],
         "amount": 1
       },
       {
-        "options": ["A1-242"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-243"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-244"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-245"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-247"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-249"],
-        "amount": 1
-      }
-    ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×20"
-  },
-  {
-    "expansionId": "A1",
-    "name": "Genetic Apex Museum 2 (Charizard)",
-    "requiredCards": [
-      {
-        "options": ["A1-228"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-229"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-230"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-231"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-234"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-236"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-237"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-246"],
-        "amount": 1
-      }
-    ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×20"
-  },
-  {
-    "expansionId": "A1",
-    "name": "Genetic Apex Museum 3 (Pikachu)",
-    "requiredCards": [
-      {
-        "options": ["A1-232"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-233"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-235"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-238"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-240"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-241"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-248"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-250"],
-        "amount": 1
-      }
-    ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×20"
-  },
-  {
-    "expansionId": "A1",
-    "name": "The Gym Leaders of the Kanto Region 2",
-    "requiredCards": [
-      {
-        "options": ["A1-266"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-267"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-268"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-269"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-270"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-271"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-272"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-273"],
-        "amount": 1
-      }
-    ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×48<br />Shop Ticket ×10"
-  },
-  {
-    "expansionId": "A1",
-    "name": "The Legendary Flight Continues",
-    "requiredCards": [
-      {
-        "options": ["A1-274"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-275"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-276"],
-        "amount": 1
-      }
-    ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Moltres, Zapdos, and Articuno (emblem)"
-  },
-  {
-    "expansionId": "A1",
-    "name": "The Immersive 4",
-    "requiredCards": [
-      {
-        "options": ["A1-280"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-281"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-282"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-283"],
-        "amount": 1
-      }
-    ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×48<br />Shop Ticket ×20"
-  },
-  {
-    "expansionId": "A1",
-    "name": "Complete the Kanto Pokedex",
-    "requiredCards": [
-      {
-        "options": ["A1-1", "A1-227"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-2"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-3", "A1-4", "A1-251"],
+        "options": ["A1-3", "A3-212", "P-A-18"],
         "amount": 1
       },
       {
@@ -751,7 +560,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-22", "A1-23", "A1-252"],
+        "options": ["A1-22"],
         "amount": 1
       },
       {
@@ -767,7 +576,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-33", "A1-230"],
+        "options": ["A4b-55", "A1-230", "A4b-56", "P-A-32"],
         "amount": 1
       },
       {
@@ -775,7 +584,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-35", "A1-36", "A1-253", "A1-280", "A1-284"],
+        "options": ["A1-35"],
         "amount": 1
       },
       {
@@ -791,7 +600,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-40", "A1-41", "A1-254"],
+        "options": ["A1-40", "A3a-90"],
         "amount": 1
       },
       {
@@ -811,11 +620,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-46", "A1-47", "A1-255", "A1-274"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-53", "A1-232"],
+        "options": ["A1-46", "B1-292"],
         "amount": 1
       },
       {
@@ -823,7 +628,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-55", "A1-56", "A1-256"],
+        "options": ["A1-55", "A3-217", "P-A-29"],
         "amount": 1
       },
       {
@@ -899,7 +704,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-75", "A1-76", "A1-257"],
+        "options": ["A1-75", "A3-219"],
         "amount": 1
       },
       {
@@ -911,7 +716,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-79", "A1-234"],
+        "options": ["A1-79", "A1-234", "A3b-94"],
         "amount": 1
       },
       {
@@ -927,19 +732,15 @@
         "amount": 1
       },
       {
-        "options": ["A1-83", "A1-84", "A1-258", "A1-275"],
+        "options": ["A4b-83", "A1-232", "A3-215", "A4b-84", "P-A-33"],
         "amount": 1
       },
       {
-        "options": ["A1-94", "A1-96", "A1-259", "A1-281", "A1-285"],
+        "options": ["A1-83", "B1-298"],
         "amount": 1
       },
       {
         "options": ["A1-95"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-97"],
         "amount": 1
       },
       {
@@ -963,7 +764,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-103", "A1-104", "A1-260", "A1-276"],
+        "options": ["A1-103", "B1-302"],
         "amount": 1
       },
       {
@@ -999,11 +800,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-121"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-122", "A1-123", "A1-261", "A1-277"],
+        "options": ["A1-122", "A3-222"],
         "amount": 1
       },
       {
@@ -1023,7 +820,15 @@
         "amount": 1
       },
       {
-        "options": ["A1-128", "A1-129", "A1-262", "A1-282", "A1-286"],
+        "options": ["A4b-128", "A4b-129", "P-A-9", "P-A-15", "P-A-26"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-128", "P-A-10"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-133"],
         "amount": 1
       },
       {
@@ -1059,7 +864,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-145", "A1-146", "A1-263", "A1-278"],
+        "options": ["A1-145"],
         "amount": 1
       },
       {
@@ -1079,11 +884,11 @@
         "amount": 1
       },
       {
-        "options": ["A1-151", "A1-239"],
+        "options": ["A1-152", "A3-227"],
         "amount": 1
       },
       {
-        "options": ["A1-152", "A1-153", "A1-264"],
+        "options": ["A4b-153"],
         "amount": 1
       },
       {
@@ -1127,7 +932,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-168", "A1-240"],
+        "options": ["A1-168", "A1-240", "A4-225"],
         "amount": 1
       },
       {
@@ -1139,7 +944,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-171", "A1-241"],
+        "options": ["A1-171", "A1-241", "A4-228"],
         "amount": 1
       },
       {
@@ -1187,7 +992,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-188", "A1-245"],
+        "options": ["A1-188", "A1-245", "A3a-97"],
         "amount": 1
       },
       {
@@ -1211,19 +1016,19 @@
         "amount": 1
       },
       {
-        "options": ["A1-194", "A1-195", "A1-265", "A1-279"],
+        "options": ["A4b-194", "A1-239", "A3-226", "A4b-195"],
         "amount": 1
       },
       {
-        "options": ["A1-196", "A1-246"],
+        "options": ["A1-194"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-196", "A1-246", "B1-312", "P-A-12"],
         "amount": 1
       },
       {
         "options": ["A1-197"],
-        "amount": 1
-      },
-      {
-        "options": ["A1-198"],
         "amount": 1
       },
       {
@@ -1255,7 +1060,7 @@
         "amount": 1
       },
       {
-        "options": ["A1-206", "A1-207", "A1-208", "A1-248"],
+        "options": ["A1-206", "A1-207", "A1-208", "A1-248", "P-A-92"],
         "amount": 1
       },
       {
@@ -1269,8 +1074,217 @@
       {
         "options": ["A1-211", "A1-250"],
         "amount": 1
+      },
+      {
+        "options": ["A4b-280"],
+        "amount": 1
       }
     ],
-    "reward": "Immersive Mew"
+    "reward": "Mew ×1",
+    "secret": true
+  },
+  {
+    "expansionId": "A1",
+    "name": "Genetic Apex Museum 1 (Mewtwo)",
+    "requiredCards": [
+      {
+        "options": ["A1-227"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-239"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-242"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-243"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-244"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-245"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-247"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-249"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "A1",
+    "name": "Genetic Apex Museum 2 (Charizard)",
+    "requiredCards": [
+      {
+        "options": ["A1-228"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-229"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-230"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-231"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-234"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-236"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-237"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-246"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "A1",
+    "name": "Genetic Apex Museum 3 (Pikachu)",
+    "requiredCards": [
+      {
+        "options": ["A1-232"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-233"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-235"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-238"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-240"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-241"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-248"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-250"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "A1",
+    "name": "The Gym Leaders of the Kanto Region 2",
+    "requiredCards": [
+      {
+        "options": ["A1-266"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-267"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-268"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-269"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-270"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-271"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-272"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-273"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×48<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "A1",
+    "name": "The Legendary Flight Continues",
+    "requiredCards": [
+      {
+        "options": ["A1-274"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-275"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-276"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×48<br />Pack Hourglass ×12<br />Moltres, Zapdos, And Articuno (emblem)",
+    "secret": true
+  },
+  {
+    "expansionId": "A1",
+    "name": "The Immersive 4",
+    "requiredCards": [
+      {
+        "options": ["A1-280"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-281"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-282"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-283"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×48<br />Pack Hourglass ×12<br />Shop Ticket ×20",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A1a-missions.json
+++ b/frontend/assets/themed-collections/A1a-missions.json
@@ -4,48 +4,52 @@
     "name": "Untouched Forest",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A1a-2", "A1a-69", "A1a-8", "A1a-26", "A1a-28", "A1a-41", "A1a-52", "A1a-53", "A1a-62"]
+        "options": ["A1a-52"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Mythical Island) ×5<br />Untouched Forest (cover)"
+    "reward": "Shinedust ×500<br />Untouched Forest (cover)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
     "name": "Tranquil Lake",
     "requiredCards": [
       {
-        "amount": "7",
-        "options": ["A1a-11", "A1a-17", "A1a-18", "A1a-76", "A1a-23", "A1a-24"]
+        "options": ["A4b-96", "A4-214", "A4b-97"],
+        "amount": 7
       }
     ],
-    "reward": "Emblem Ticket (Mythical Island) ×13<br />Tranquil Lake (cover)"
+    "reward": "Shinedust ×1300<br />Tranquil Lake (cover)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
     "name": "Scorching Wilderness",
     "requiredCards": [
       {
-        "amount": "10",
-        "options": ["A1a-12", "A1a-14", "A1a-15", "A1a-71", "A1a-43", "A1a-50"]
+        "options": ["A1a-15", "A1a-71"],
+        "amount": 10
       }
     ],
-    "reward": "Emblem Ticket (Mythical Island) ×7<br />Scorching Wilderness (cover)"
+    "reward": "Shinedust ×700<br />Scorching Wilderness (cover)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
     "name": "Forgotten Ruins",
     "requiredCards": [
       {
-        "options": ["A1a-65"],
-        "amount": 1
+        "options": ["A1a-48"],
+        "amount": 9
       },
       {
-        "amount": "9",
-        "options": ["A1a-6", "A1a-70", "A1a-35", "A1a-48"]
+        "options": ["A1a-65"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mythical Island) ×15<br />Forgotten Ruins (cover)"
+    "reward": "Shinedust ×1500<br />Forgotten Ruins (cover)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
@@ -60,80 +64,6 @@
         "amount": 1
       },
       {
-        "options": ["A1a-14"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-29"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-55"],
-        "amount": 1
-      }
-    ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mythical Island) ×2<br />Shop Ticket ×2"
-  },
-  {
-    "expansionId": "A1a",
-    "name": "Pokémon That Fly",
-    "requiredCards": [
-      {
-        "options": ["A1a-24", "A1a-46"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-36", "A1a-33"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-37", "A1a-14"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-57", "A1a-58", "A1a-59"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-62", "A1a-18"],
-        "amount": 1
-      }
-    ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mythical Island) ×2<br />Shop Ticket ×2"
-  },
-  {
-    "expansionId": "A1a",
-    "name": "Attacks with 20 Damage",
-    "requiredCards": [
-      {
-        "options": ["A1a-7"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-20"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-31"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-34"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-32"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-39"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-51"],
-        "amount": 1
-      },
-      {
         "options": ["A1a-53"],
         "amount": 1
       },
@@ -142,26 +72,19 @@
         "amount": 1
       },
       {
-        "options": ["A1a-57"],
+        "options": ["A1a-55"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mythical Island) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A1a",
-    "name": "Small Pokémon",
+    "name": "Pokémon That Fly",
     "requiredCards": [
       {
-        "options": ["A1a-7"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-57"],
-        "amount": 1
-      },
-      {
-        "options": ["A1a-22"],
+        "options": ["A1a-24"],
         "amount": 1
       },
       {
@@ -173,23 +96,72 @@
         "amount": 1
       },
       {
+        "options": ["A1a-62"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-272", "A4b-273"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
+  },
+  {
+    "expansionId": "A1a",
+    "name": "Attacks with 20 Damage",
+    "requiredCards": [
+      {
+        "options": ["A1a-7"],
+        "amount": 1
+      },
+      {
+        "options": ["A1a-34"],
+        "amount": 1
+      },
+      {
+        "options": ["A1a-39"],
+        "amount": 1
+      },
+      {
+        "options": ["A1a-51"],
+        "amount": 1
+      },
+      {
+        "options": ["A1a-54"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
+  },
+  {
+    "expansionId": "A1a",
+    "name": "Small Pokémon",
+    "requiredCards": [
+      {
+        "options": ["A1a-7"],
+        "amount": 1
+      },
+      {
+        "options": ["A1a-22"],
+        "amount": 1
+      },
+      {
         "options": ["A1a-28"],
         "amount": 1
       },
       {
-        "options": ["A1a-30"],
+        "options": ["A1a-36"],
         "amount": 1
       },
       {
         "options": ["A1a-61"],
         "amount": 1
-      },
-      {
-        "options": ["A1a-62"],
-        "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mythical Island) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A1a",
@@ -208,11 +180,12 @@
         "amount": 1
       },
       {
-        "options": ["A1a-58"],
+        "options": ["A4b-274"],
         "amount": 1
       }
     ],
-    "reward": "Tree of Repose (cover)"
+    "reward": "Tree Of Repose (cover)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
@@ -231,7 +204,15 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mythical Island) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
+  },
+  {
+    "expansionId": "A1a",
+    "name": "Use pack stamina to open 60 Mythical Island booster packs",
+    "requiredCards": [],
+    "reward": "Mythical Island: Mew (playmat) ×1<br />Mythical Island: Mew (card sleeve) ×1<br />Mew (pokémon coin) ×1<br />Mythical Island: Mew (cover)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
@@ -242,7 +223,8 @@
         "amount": 3
       }
     ],
-    "reward": "Mew (icon)"
+    "reward": "Mew (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
@@ -253,7 +235,8 @@
         "amount": 3
       }
     ],
-    "reward": "Blue (icon)"
+    "reward": "Blue (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A1a",
@@ -284,7 +267,8 @@
         "amount": 1
       }
     ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A1a",
@@ -299,14 +283,15 @@
         "amount": 1
       }
     ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A1a",
     "name": "Mew ex Museum",
     "requiredCards": [
       {
-        "options": ["A1a-32"],
+        "options": ["A1a-77"],
         "amount": 1
       },
       {
@@ -314,26 +299,27 @@
         "amount": 1
       },
       {
-        "options": ["A1a-77"],
+        "options": ["A1a-86"],
         "amount": 1
       },
       {
-        "options": ["A1a-86"],
+        "options": ["A4b-159"],
         "amount": 1
       }
     ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A1a",
     "name": "Mythical Island Tale of Adventure",
     "requiredCards": [
       {
-        "options": ["A1a-66"],
+        "options": ["A1a-65"],
         "amount": 1
       },
       {
-        "options": ["A1a-65"],
+        "options": ["A1a-66"],
         "amount": 1
       },
       {
@@ -345,6 +331,7 @@
         "amount": 1
       }
     ],
-    "reward": "Celebi (emblem)"
+    "reward": "Celebi (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A2-missions.json
+++ b/frontend/assets/themed-collections/A2-missions.json
@@ -4,7 +4,7 @@
     "name": "Myths of Sinnoh Resurrected",
     "requiredCards": [
       {
-        "options": ["A2-49", "A2-182", "A2-204", "A2-206"],
+        "options": ["A4b-107", "A2-182", "A2-204", "A2-206", "A4b-363", "B1-319"],
         "amount": 1
       },
       {
@@ -20,15 +20,16 @@
         "amount": 1
       },
       {
-        "options": ["A2-78", "A2-167"],
+        "options": ["A4b-170", "A2-167", "A4b-171"],
         "amount": 1
       },
       {
-        "options": ["A2-119", "A2-188", "A2-205", "A2-207"],
+        "options": ["A4b-254", "A2-188", "A2-205", "A2-207", "A4b-368", "B1-326"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×22"
+    "reward": "Shinedust ×2200",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -47,11 +48,12 @@
         "amount": 1
       },
       {
-        "options": ["A2-78", "A2-167"],
+        "options": ["A4b-170", "A2-167", "A4b-171"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -66,7 +68,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×5"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -85,11 +88,12 @@
         "amount": 1
       },
       {
-        "options": ["A2-143", "A2-179"],
+        "options": ["A2-143", "A2-179", "P-A-115"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -100,7 +104,7 @@
         "amount": 1
       },
       {
-        "options": ["A2-22", "A2-159"],
+        "options": ["A4b-30", "A2-159", "A4b-31", "P-A-116"],
         "amount": 1
       },
       {
@@ -112,7 +116,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -131,7 +136,7 @@
         "amount": 1
       },
       {
-        "options": ["A2-50", "A2-162"],
+        "options": ["A4b-108", "A2-162", "A4b-109", "B1-299", "P-A-48"],
         "amount": 1
       },
       {
@@ -139,7 +144,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Space-Time Smackdown) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -162,7 +168,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -177,11 +184,7 @@
         "amount": 1
       },
       {
-        "options": ["A2-98"],
-        "amount": 1
-      },
-      {
-        "options": ["A2-99", "A2-186", "A2-201"],
+        "options": ["A4b-244", "A2-186", "A2-201", "A4-238"],
         "amount": 1
       },
       {
@@ -211,145 +214,82 @@
       {
         "options": ["A2-172"],
         "amount": 1
+      },
+      {
+        "options": ["A4b-242"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×16"
+    "reward": "Shinedust ×1600",
+    "secret": false
   },
   {
     "expansionId": "A2",
     "name": "Battle with Champion Cynthia",
     "requiredCards": [
       {
-        "options": ["A2-152", "A2-192"],
-        "amount": 1
+        "options": ["A2-104", "A2-172"],
+        "amount": 2
       },
       {
         "options": ["A2-123", "A2-175"],
         "amount": 1
       },
       {
-        "amount": "2",
-        "options": ["A2-9", "A2-41", "A2-161", "A2-92", "A2-170", "A2-104", "A2-172"]
+        "options": ["A2-152", "A2-192"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A2",
     "name": "A Variety of Pokémon Abilities",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": [
-          "A2-22",
-          "A2-159",
-          "A2-32",
-          "A2-33",
-          "A2-160",
-          "A2-34",
-          "A2-72",
-          "A2-78",
-          "A2-167",
-          "A2-87",
-          "A2-92",
-          "A2-170",
-          "A2-110",
-          "A2-187",
-          "A2-202",
-          "A2-114",
-          "A2-123",
-          "A2-175"
-        ]
+        "options": ["A2-32"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A2",
     "name": "Slightly Scary Pokémon",
     "requiredCards": [
       {
-        "amount": "4",
-        "options": ["A2-66", "A2-67", "A2-185", "A2-199", "A2-70", "A2-71", "A2-72", "A2-73", "A2-165", "A2-74", "A2-110", "A2-187", "A2-202"]
+        "options": ["A2-70"],
+        "amount": 4
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×9"
+    "reward": "Shinedust ×900",
+    "secret": false
   },
   {
     "expansionId": "A2",
     "name": "Pokémon Grown Large",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": [
-          "A2-5",
-          "A2-12",
-          "A2-24",
-          "A2-33",
-          "A2-160",
-          "A2-45",
-          "A2-53",
-          "A2-57",
-          "A2-72",
-          "A2-82",
-          "A2-169",
-          "A2-89",
-          "A2-94",
-          "A2-114",
-          "A2-117",
-          "A2-118",
-          "A2-125",
-          "A2-189",
-          "A2-203"
-        ]
+        "options": ["A2-94"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A2",
     "name": "New Discoveries of the Sinnoh Region",
     "requiredCards": [
       {
-        "amount": "10",
-        "options": [
-          "A2-5",
-          "A2-7",
-          "A2-180",
-          "A2-196",
-          "A2-9",
-          "A2-20",
-          "A2-24",
-          "A2-33",
-          "A2-160",
-          "A2-46",
-          "A2-53",
-          "A2-57",
-          "A2-65",
-          "A2-67",
-          "A2-185",
-          "A2-199",
-          "A2-72",
-          "A2-82",
-          "A2-169",
-          "A2-84",
-          "A2-95",
-          "A2-185",
-          "A2-200",
-          "A2-97",
-          "A2-99",
-          "A2-186",
-          "A2-201",
-          "A2-118",
-          "A2-125",
-          "A2-189",
-          "A2-203",
-          "A2-129",
-          "A2-118"
-        ]
+        "options": ["A2-131"],
+        "amount": 10
       }
     ],
-    "reward": "Emblem Ticket (Space-Time Smackdown) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -380,7 +320,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Space-Time Smackdown) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -399,19 +340,20 @@
         "amount": 1
       },
       {
-        "options": ["A2-150", "A2-190"],
-        "amount": 1
-      },
-      {
         "options": ["A2-151", "A2-191"],
         "amount": 1
       },
       {
-        "options": ["A2-155", "A2-195"],
+        "options": ["A4b-326", "A2-190", "A4b-327"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-344", "A2-195", "A4b-345"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Space-Time Smackdown) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -422,7 +364,8 @@
         "amount": 3
       }
     ],
-    "reward": "Turtwig (profile icon)"
+    "reward": "Turtwig (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -433,7 +376,8 @@
         "amount": 3
       }
     ],
-    "reward": "Chimchar (profile icon)"
+    "reward": "Chimchar (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A2",
@@ -444,7 +388,32 @@
         "amount": 3
       }
     ],
-    "reward": "Piplup (profile icon)"
+    "reward": "Piplup (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "A2",
+    "name": "Garden of Smiling Flowers 2",
+    "requiredCards": [
+      {
+        "options": ["A2-4"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-30", "A2-159", "A4b-31", "P-A-116"],
+        "amount": 1
+      },
+      {
+        "options": ["A2-63"],
+        "amount": 1
+      },
+      {
+        "options": ["A2-137"],
+        "amount": 1
+      }
+    ],
+    "reward": "Garden Of Smiling Flowers (cover)",
+    "secret": true
   },
   {
     "expansionId": "A2",
@@ -499,7 +468,8 @@
         "amount": 1
       }
     ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2",
@@ -554,7 +524,8 @@
         "amount": 1
       }
     ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2",
@@ -577,7 +548,8 @@
         "amount": 1
       }
     ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2",
@@ -600,7 +572,8 @@
         "amount": 1
       }
     ],
-    "reward": "Pack Hourglass ×12<br />Wonder Hourglass ×36<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2",
@@ -627,6 +600,7 @@
         "amount": 1
       }
     ],
-    "reward": "Garchomp (emblem)"
+    "reward": "Garchomp (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A2a-missions.json
+++ b/frontend/assets/themed-collections/A2a-missions.json
@@ -1,14 +1,17 @@
 [
   {
     "expansionId": "A2a",
-    "name": "Pokémon with Abilities that \"Link\" with Arceus",
+    "name": "Use pack stamina to open 4 4 booster packs",
+    "requiredCards": [],
+    "reward": "Arceus ×1",
+    "secret": false
+  },
+  {
+    "expansionId": "A2a",
+    "name": "Pokémon with Abilities that “Link” with Arceus",
     "requiredCards": [
       {
         "options": ["A2a-9"],
-        "amount": 1
-      },
-      {
-        "options": ["A2a-13"],
         "amount": 1
       },
       {
@@ -28,10 +31,6 @@
         "amount": 1
       },
       {
-        "options": ["A2a-50"],
-        "amount": 1
-      },
-      {
         "options": ["A2a-55"],
         "amount": 1
       },
@@ -40,41 +39,48 @@
         "amount": 1
       },
       {
-        "options": ["A2a-71", "A2a-86", "A2a-95", "A2a-96"],
+        "options": ["A4b-76"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-230"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Triumphant Light) ×25"
+    "reward": "Shinedust ×2500",
+    "secret": false
   },
   {
     "expansionId": "A2a",
     "name": "Magnezone of Fuego Ironworks",
     "requiredCards": [
       {
-        "options": ["A2a-55"],
-        "amount": 1
+        "options": ["A2a-53", "A2a-80"],
+        "amount": 4
       },
       {
-        "amount": "4",
-        "options": ["A2a-53", "A2a-80", "A2a-54"]
+        "options": ["A2a-55"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Triumphant Light) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2a",
     "name": "Rotom of the Old Chateau",
     "requiredCards": [
       {
-        "options": ["A2a-35"],
-        "amount": 1
-      },
-      {
         "options": ["A2a-31"],
         "amount": 4
+      },
+      {
+        "options": ["A2a-35"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Triumphant Light) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2a",
@@ -97,7 +103,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Triumphant Light) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2a",
@@ -120,7 +127,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Triumphant Light) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2a",
@@ -139,41 +147,20 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Triumphant Light) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2a",
     "name": "Pokémon with 60 HP",
     "requiredCards": [
       {
-        "amount": "4",
-        "options": [
-          "A2a-11",
-          "A2a-14",
-          "A2a-77",
-          "A2a-16",
-          "A2a-18",
-          "A2a-24",
-          "A2a-25",
-          "A2a-27",
-          "A2a-29",
-          "A2a-34",
-          "A2a-78",
-          "A2a-37",
-          "A2a-39",
-          "A2a-43",
-          "A2a-45",
-          "A2a-51",
-          "A2a-53",
-          "A2a-80",
-          "A2a-58",
-          "A2a-62",
-          "A2a-64",
-          "A2a-66"
-        ]
+        "options": ["A2a-43"],
+        "amount": 4
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Triumphant Light) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2a",
@@ -196,18 +183,20 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Triumphant Light) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2a",
     "name": "Water-type Pokémon",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A2a-14", "A2a-77", "A2a-15", "A2a-16", "A2a-17", "A2a-18", "A2a-19", "A2a-20", "A2a-22", "A2a-23"]
+        "options": ["A2a-18"],
+        "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Triumphant Light) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2a",
@@ -226,18 +215,20 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Triumphant Light) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2a",
     "name": "Hard-Bodied Pokémon",
     "requiredCards": [
       {
-        "amount": "4",
-        "options": ["A2a-38", "A2a-42", "A2a-65", "A2a-80", "A2a-55", "A2a-57", "A2a-85", "A2a-94"]
+        "options": ["A4b-203", "A4b-204"],
+        "amount": 4
       }
     ],
-    "reward": "Emblem Ticket (Triumphant Light) ×8"
+    "reward": "Shinedust ×800",
+    "secret": false
   },
   {
     "expansionId": "A2a",
@@ -248,7 +239,8 @@
         "amount": 3
       }
     ],
-    "reward": "Marill (icon)"
+    "reward": "Marill (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A2a",
@@ -279,7 +271,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2a",
@@ -302,7 +295,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2a",
@@ -329,16 +323,13 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2a",
     "name": "Pokémon from Ancient Records",
     "requiredCards": [
-      {
-        "options": ["A2a-13"],
-        "amount": 1
-      },
       {
         "options": ["A2a-23"],
         "amount": 1
@@ -356,6 +347,10 @@
         "amount": 1
       },
       {
+        "options": ["A4b-76"],
+        "amount": 1
+      },
+      {
         "options": ["A2a-81"],
         "amount": 1
       },
@@ -364,6 +359,7 @@
         "amount": 1
       }
     ],
-    "reward": "Shaymin"
+    "reward": "Shaymin (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A2b-missions.json
+++ b/frontend/assets/themed-collections/A2b-missions.json
@@ -12,15 +12,16 @@
         "amount": 1
       },
       {
-        "options": ["A2b-10", "A2b-80", "A2b-108"],
+        "options": ["A4b-60", "A2b-80", "A2b-108"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
-    "name": "Magmar's Evolution",
+    "name": "Magmar’s Evolution",
     "requiredCards": [
       {
         "options": ["A2b-11"],
@@ -31,7 +32,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -42,22 +44,24 @@
         "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Beach Peekaboo",
     "requiredCards": [
       {
-        "options": ["A2b-18", "A2b-101"],
+        "options": ["A4b-127", "A2b-81", "A2b-109"],
         "amount": 1
       },
       {
-        "options": ["A2b-19", "A2b-109"],
+        "options": ["A4b-125", "A2b-101", "A4b-126"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -72,7 +76,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -87,7 +92,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -102,18 +108,20 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Shadows of the Distortion World",
     "requiredCards": [
       {
-        "options": ["A2b-35", "A2b-83", "A2b-96"],
+        "options": ["A4b-172", "A2b-83", "A2b-96", "A4b-377"],
         "amount": 2
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -132,7 +140,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -143,7 +152,8 @@
         "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -158,45 +168,48 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Needling Frenzy",
     "requiredCards": [
       {
-        "options": ["A2b-1", "A2b-97"],
+        "options": ["A4b-6", "A2b-97", "A4b-7"],
         "amount": 1
       },
       {
-        "options": ["A2b-2", "A2b-98"],
+        "options": ["A4b-8", "A2b-98", "A4b-9"],
         "amount": 1
       },
       {
-        "options": ["A2b-3", "A2b-79", "A2b-107"],
+        "options": ["A4b-10", "A2b-79", "A2b-107"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
-    "name": "Sprigatito's Green Sprouting",
+    "name": "Sprigatito’s Green Sprouting",
     "requiredCards": [
       {
         "options": ["A2b-5"],
         "amount": 1
       },
       {
-        "options": ["A2b-6"],
+        "options": ["A4b-53", "A2b-73", "A4b-54", "B2a-118"],
         "amount": 1
       },
       {
-        "options": ["A2b-7", "A2b-73"],
+        "options": ["A4b-51"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -207,7 +220,8 @@
         "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -218,15 +232,16 @@
         "amount": 1
       },
       {
-        "options": ["A2b-53"],
+        "options": ["A4b-266", "A2b-86", "A2b-94", "B2a-129"],
         "amount": 1
       },
       {
-        "options": ["A2b-54", "A2b-86", "A2b-94"],
+        "options": ["A4b-264"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -237,11 +252,12 @@
         "amount": 1
       },
       {
-        "options": ["A2b-57"],
+        "options": ["A2b-57", "A2b-77", "B2a-125"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -256,22 +272,24 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Aura Masters",
     "requiredCards": [
       {
-        "options": ["A2b-42", "A2b-104"],
+        "options": ["A4b-214", "A2b-84", "A2b-110"],
         "amount": 1
       },
       {
-        "options": ["A2b-43", "A2b-84", "A2b-110"],
+        "options": ["A4b-210", "A2b-104", "A4b-211", "P-A-59"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -290,7 +308,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -305,7 +324,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -316,18 +336,20 @@
         "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Electric Cheeks",
     "requiredCards": [
       {
-        "options": ["A2b-22", "A2b-82", "A2b-92"],
+        "options": ["A4b-132", "A2b-82", "A2b-92", "B1-321"],
         "amount": 2
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -346,7 +368,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -361,22 +384,24 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Dangerous Poison Spikes",
     "requiredCards": [
       {
-        "options": ["A2b-47"],
+        "options": ["A4b-238", "A2b-85", "A2b-93", "A4a-104"],
         "amount": 1
       },
       {
-        "options": ["A2b-48", "A2b-85", "A2b-93"],
+        "options": ["A4b-236"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -391,7 +416,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -406,7 +432,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -417,7 +444,8 @@
         "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Shining Revelry) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -428,11 +456,12 @@
         "amount": 1
       },
       {
-        "options": ["A2b-65", "A2b-87", "A2b-95"],
+        "options": ["A4b-296", "A2b-87", "A2b-95", "B1-327"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -447,18 +476,20 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Shiny Museum 1",
     "requiredCards": [
       {
-        "amount": "1",
-        "options": ["A2b-97", "A2b-98", "A2b-99", "A2b-100", "A2b-101", "A2b-102", "A2b-103", "A2b-104", "A2b-105", "A2b-106"]
+        "options": ["A4b-6", "A2b-97", "A4b-7"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Shining Revelry) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A2b",
@@ -469,62 +500,68 @@
         "amount": 3
       }
     ],
-    "reward": "Sprigatito (icon)"
+    "reward": "Sprigatito (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A2b",
     "name": "Shiny Museum 2",
     "requiredCards": [
       {
-        "amount": "2",
-        "options": ["A2b-97", "A2b-98", "A2b-99", "A2b-100", "A2b-101", "A2b-102", "A2b-103", "A2b-104", "A2b-105", "A2b-106"]
+        "options": ["A4b-6", "A2b-97", "A4b-7"],
+        "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2b",
     "name": "Shiny Museum 3",
     "requiredCards": [
       {
-        "amount": "3",
-        "options": ["A2b-97", "A2b-98", "A2b-99", "A2b-100", "A2b-101", "A2b-102", "A2b-103", "A2b-104", "A2b-105", "A2b-106"]
+        "options": ["A4b-6", "A2b-97", "A4b-7"],
+        "amount": 3
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2b",
     "name": "Shiny Museum 4",
     "requiredCards": [
       {
-        "amount": "1",
-        "options": ["A2b-107", "A2b-108", "A2b-109", "A2b-110"]
+        "options": ["A4b-10", "A2b-79", "A2b-107"],
+        "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2b",
     "name": "Shiny Museum 5",
     "requiredCards": [
       {
-        "amount": "2",
-        "options": ["A2b-107", "A2b-108", "A2b-109", "A2b-110"]
+        "options": ["A4b-10", "A2b-79", "A2b-107"],
+        "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2b",
     "name": "Shiny Museum 6",
     "requiredCards": [
       {
-        "amount": "3",
-        "options": ["A2b-107", "A2b-108", "A2b-109", "A2b-110"]
+        "options": ["A4b-10", "A2b-79", "A2b-107"],
+        "amount": 3
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2b",
@@ -555,7 +592,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2b",
@@ -578,7 +616,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A2b",
@@ -589,6 +628,7 @@
         "amount": 99
       }
     ],
-    "reward": "Gholdengo (emblem)"
+    "reward": "Gholdengo (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A3-missions.json
+++ b/frontend/assets/themed-collections/A3-missions.json
@@ -20,7 +20,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -43,7 +44,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×5"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -62,11 +64,12 @@
         "amount": 1
       },
       {
-        "options": ["A3-77"],
+        "options": ["A4b-178"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -81,7 +84,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -96,7 +100,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -107,11 +112,12 @@
         "amount": 1
       },
       {
-        "options": ["A3-110"],
+        "options": ["A4b-233"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -122,26 +128,28 @@
         "amount": 1
       },
       {
-        "options": ["A3-10"],
+        "options": ["A4b-38"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "A Day in the Life of Litten",
     "requiredCards": [
       {
-        "options": ["A3-30"],
+        "options": ["A3-31"],
         "amount": 1
       },
       {
-        "options": ["A3-31"],
+        "options": ["A4b-78"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -156,16 +164,13 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Kiawe and Volcano Park Pokémon",
     "requiredCards": [
-      {
-        "options": ["A3-150", "A3-192"],
-        "amount": 1
-      },
       {
         "options": ["A3-27", "A3-160"],
         "amount": 3
@@ -173,18 +178,19 @@
       {
         "options": ["A3-36"],
         "amount": 1
+      },
+      {
+        "options": ["A3-150", "A3-192"],
+        "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Mallow and Jungle Pokémon",
     "requiredCards": [
-      {
-        "options": ["A3-154", "A3-196"],
-        "amount": 1
-      },
       {
         "options": ["A3-14"],
         "amount": 1
@@ -200,18 +206,19 @@
       {
         "options": ["A3-80", "A3-168"],
         "amount": 1
+      },
+      {
+        "options": ["A3-154", "A3-196"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Ilima and Cave Pokémon",
     "requiredCards": [
-      {
-        "options": ["A3-149", "A3-191"],
-        "amount": 1
-      },
       {
         "options": ["A3-136"],
         "amount": 2
@@ -219,20 +226,21 @@
       {
         "options": ["A3-137"],
         "amount": 2
+      },
+      {
+        "options": ["A3-149", "A3-191"],
+        "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Acerola and Spooky Pokémon",
     "requiredCards": [
       {
-        "options": ["A3-148", "A3-190"],
-        "amount": 1
-      },
-      {
-        "options": ["A3-23", "A3-181", "A3-199"],
+        "options": ["A4b-43", "A3-181", "A3-199"],
         "amount": 1
       },
       {
@@ -242,22 +250,19 @@
       {
         "options": ["A3-83"],
         "amount": 1
+      },
+      {
+        "options": ["A3-148", "A3-190"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×8"
+    "reward": "Shinedust ×800",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Lana and Waterside Pokémon",
     "requiredCards": [
-      {
-        "options": ["A3-152", "A3-194"],
-        "amount": 1
-      },
-      {
-        "options": ["A3-51", "A3-184", "A3-202"],
-        "amount": 1
-      },
       {
         "options": ["A3-52"],
         "amount": 1
@@ -265,18 +270,23 @@
       {
         "options": ["A3-53"],
         "amount": 1
+      },
+      {
+        "options": ["A4b-124", "A3-184", "A3-202"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-152", "A3-194"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Sophocles and Electric Discharge Pokémon",
     "requiredCards": [
-      {
-        "options": ["A3-153", "A3-195"],
-        "amount": 1
-      },
       {
         "options": ["A3-61"],
         "amount": 1
@@ -288,9 +298,14 @@
       {
         "options": ["A3-67"],
         "amount": 1
+      },
+      {
+        "options": ["A3-153", "A3-195"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×5"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -321,49 +336,52 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Celestial Guardians) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3",
-    "name": "Team Skull's Nasty Plot",
+    "name": "Team Skull’s Nasty Plot",
     "requiredCards": [
-      {
-        "options": ["A3-151", "A3-193", "A3-208"],
-        "amount": 1
-      },
       {
         "options": ["A3-22"],
         "amount": 1
       },
       {
-        "amount": "1",
-        "options": ["A3-35", "A3-107", "A3-110", "A3-115"]
+        "options": ["A3-151", "A3-193", "A3-208"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-233", "A4b-234"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "A3",
-    "name": "Lillie and Nebby's Growth",
+    "name": "Lillie and Nebby’s Growth",
     "requiredCards": [
       {
-        "options": ["A3-155", "A3-197", "A3-209"],
+        "options": ["A4b-180", "A3-171", "A4b-181", "P-A-67"],
         "amount": 1
       },
       {
-        "options": ["A3-85", "A3-171"],
+        "options": ["A4b-259", "A3-189", "A3-207", "A3-239", "A4b-369", "B1a-101"],
         "amount": 1
       },
       {
-        "options": ["A3-86"],
+        "options": ["A4b-182"],
         "amount": 1
       },
       {
-        "amount": "1",
-        "options": ["A3-87", "A3-186", "A3-204", "A3-238", "A3-122", "A3-189", "A3-207", "A3-239"]
+        "options": ["A4b-348", "A3-197", "A3-209", "A4b-349", "A4b-374"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×7"
+    "reward": "Shinedust ×700",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -386,7 +404,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×14"
+    "reward": "Shinedust ×1400",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -398,10 +417,6 @@
       },
       {
         "options": ["A3-36"],
-        "amount": 1
-      },
-      {
-        "options": ["A3-51", "A3-184", "A3-202"],
         "amount": 1
       },
       {
@@ -417,18 +432,27 @@
         "amount": 1
       },
       {
+        "options": ["A4b-124", "A3-184", "A3-202"],
+        "amount": 1
+      },
+      {
         "options": ["A3-127"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-137"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "An Assembly of Alolan Forms 1",
     "requiredCards": [
       {
-        "options": ["A3-2", "A3-156"],
+        "options": ["A3-2", "A3-156", "P-A-69"],
         "amount": 1
       },
       {
@@ -441,10 +465,6 @@
       },
       {
         "options": ["A3-41"],
-        "amount": 1
-      },
-      {
-        "options": ["A3-58", "A3-185", "A3-203"],
         "amount": 1
       },
       {
@@ -462,9 +482,14 @@
       {
         "options": ["A3-118"],
         "amount": 1
+      },
+      {
+        "options": ["A4b-130", "A3-185", "A3-203"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×14"
+    "reward": "Shinedust ×1400",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -499,48 +524,52 @@
         "amount": 1
       },
       {
-        "options": ["A3-110"],
+        "options": ["A4b-235", "A3-188", "A3-206"],
         "amount": 1
       },
       {
-        "options": ["A3-111", "A3-188", "A3-206"],
+        "options": ["A4b-233"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Celestial Guardians) ×10"
+    "reward": "Shinedust ×1000",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Collect 3 Rowlet cards",
     "requiredCards": [
       {
-        "amount": "3",
-        "options": ["A3-9", "A3-10"]
+        "options": ["A3-9"],
+        "amount": 3
       }
     ],
-    "reward": "Rowlet (profile icon)"
+    "reward": "Rowlet (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Collect 3 Litten cards",
     "requiredCards": [
       {
-        "amount": "3",
-        "options": ["A3-30", "A3-31"]
+        "options": ["A4b-78", "A4b-79", "B1-293"],
+        "amount": 3
       }
     ],
-    "reward": "Litten (profile icon)"
+    "reward": "Litten (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A3",
     "name": "Collect 3 Popplio cards",
     "requiredCards": [
       {
-        "amount": "3",
-        "options": ["A3-45", "A3-46"]
+        "options": ["A3-46"],
+        "amount": 3
       }
     ],
-    "reward": "Popplio (profile icon)"
+    "reward": "Popplio (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A3",
@@ -548,10 +577,6 @@
     "requiredCards": [
       {
         "options": ["A3-9"],
-        "amount": 1
-      },
-      {
-        "options": ["A3-30"],
         "amount": 1
       },
       {
@@ -564,6 +589,10 @@
       },
       {
         "options": ["A3-76"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-78"],
         "amount": 1
       },
       {
@@ -599,22 +628,23 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3",
     "name": "Moon Collection",
     "requiredCards": [
       {
-        "options": ["A3-10"],
-        "amount": 1
-      },
-      {
         "options": ["A3-31"],
         "amount": 1
       },
       {
         "options": ["A3-34"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-38"],
         "amount": 1
       },
       {
@@ -646,15 +676,20 @@
         "amount": 1
       },
       {
-        "options": ["A3-110"],
+        "options": ["A4b-178"],
         "amount": 1
       },
       {
         "options": ["A3-204"],
         "amount": 1
+      },
+      {
+        "options": ["A4b-233"],
+        "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3",
@@ -709,7 +744,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3",
@@ -764,7 +800,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3",
@@ -791,7 +828,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3",
@@ -818,18 +856,19 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3",
-    "name": "Lana and Wishiwashi's School",
+    "name": "Lana and Wishiwashi’s School",
     "requiredCards": [
       {
         "options": ["A3-50"],
         "amount": 1
       },
       {
-        "options": ["A3-51"],
+        "options": ["A4b-124"],
         "amount": 1
       },
       {
@@ -849,11 +888,12 @@
         "amount": 1
       }
     ],
-    "reward": "Wishiwashi (emblem)"
+    "reward": "Wishiwashi (emblem)",
+    "secret": true
   },
   {
     "expansionId": "A3",
-    "name": "Guidance of the Sun and Moon",
+    "name": "Guidance of the Sun and the Moon",
     "requiredCards": [
       {
         "options": ["A3-204"],
@@ -864,6 +904,7 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A3a-missions.json
+++ b/frontend/assets/themed-collections/A3a-missions.json
@@ -4,19 +4,11 @@
     "name": "Ultra Beast Collection",
     "requiredCards": [
       {
-        "options": ["A3a-6", "A3a-76", "A3a-88"],
-        "amount": 1
-      },
-      {
-        "options": ["A3a-7", "A3a-71"],
-        "amount": 1
-      },
-      {
         "options": ["A3a-8"],
         "amount": 1
       },
       {
-        "options": ["A3a-9", "A3a-72"],
+        "options": ["A3a-9", "A3a-72", "P-A-76"],
         "amount": 1
       },
       {
@@ -24,11 +16,7 @@
         "amount": 1
       },
       {
-        "options": ["A3a-42", "A3a-103"],
-        "amount": 1
-      },
-      {
-        "options": ["A3a-43", "A3a-79", "A3a-86"],
+        "options": ["A4b-246", "A3a-103", "A4b-247"],
         "amount": 1
       },
       {
@@ -36,7 +24,15 @@
         "amount": 1
       },
       {
+        "options": ["A4b-44", "A3a-76", "A3a-88", "A4b-360", "B1a-98"],
+        "amount": 1
+      },
+      {
         "options": ["A3a-45"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-45", "A3a-71", "A4b-46"],
         "amount": 1
       },
       {
@@ -44,11 +40,16 @@
         "amount": 1
       },
       {
-        "options": ["A3a-62", "A3a-75"],
+        "options": ["A4b-248", "A3a-79", "A3a-86", "B1a-100"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-304", "A3a-75", "A4b-305"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Extradimensional Crisis) ×25"
+    "reward": "Shinedust ×2500",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -59,15 +60,16 @@
         "amount": 1
       },
       {
-        "options": ["A3a-19", "A3a-77", "A3a-84"],
+        "options": ["A4b-148", "A3a-77", "A3a-84", "B1-322", "P-A-84"],
         "amount": 1
       },
       {
-        "options": ["A3a-21"],
+        "options": ["A4b-149"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Extradimensional Crisis) ×11"
+    "reward": "Shinedust ×1100",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -82,30 +84,32 @@
         "amount": 1
       },
       {
-        "options": ["A3a-69", "A3a-83"],
+        "options": ["A4b-350", "A3a-83", "A4b-351", "A4b-375"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3a",
-    "name": "Type: Null's Bonds",
+    "name": "Type: Null’s Bonds",
     "requiredCards": [
       {
-        "options": ["A3a-60"],
-        "amount": 1
-      },
-      {
-        "options": ["A3a-61", "A3a-74"],
+        "options": ["A4b-302", "A3a-74", "A4b-303", "B1a-97"],
         "amount": 1
       },
       {
         "options": ["A3a-67", "A3a-81"],
         "amount": 1
+      },
+      {
+        "options": ["A4b-300"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Extradimensional Crisis) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -124,7 +128,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -151,7 +156,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -174,7 +180,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Extradimensional Crisis) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -201,7 +208,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -212,11 +220,12 @@
         "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3a",
-    "name": "Fur that's Pleasant to Touch",
+    "name": "Fur that’s Pleasant to Touch",
     "requiredCards": [
       {
         "options": ["A3a-38"],
@@ -227,7 +236,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Extradimensional Crisis) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3a",
@@ -238,7 +248,20 @@
         "amount": 5
       }
     ],
-    "reward": "Nihilego (profile icon)"
+    "reward": "Nihilego (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "A3a",
+    "name": "A Trio with Impressive Whiskers",
+    "requiredCards": [
+      {
+        "options": ["A3a-87"],
+        "amount": 3
+      }
+    ],
+    "reward": "Alolan Dugtrio (emblem)",
+    "secret": true
   },
   {
     "expansionId": "A3a",
@@ -269,7 +292,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3a",
@@ -292,17 +316,7 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
-  },
-  {
-    "expansionId": "A3a",
-    "name": "A Trio with Impressive Whiskers",
-    "requiredCards": [
-      {
-        "options": ["A3a-87"],
-        "amount": 3
-      }
-    ],
-    "reward": "Alolan Dugtrio (emblem)"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A3b-missions.json
+++ b/frontend/assets/themed-collections/A3b-missions.json
@@ -4,7 +4,11 @@
     "name": "Eevee and its Evolutions 1",
     "requiredCards": [
       {
-        "options": ["A3b-55", "A3b-56", "A3b-83"],
+        "options": ["A3b-2"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-64", "A3b-71", "A4-213", "A4b-65"],
         "amount": 1
       },
       {
@@ -12,11 +16,11 @@
         "amount": 1
       },
       {
-        "options": ["A3b-25"],
+        "options": ["A3b-17"],
         "amount": 1
       },
       {
-        "options": ["A3b-8", "A3b-9", "A3b-79"],
+        "options": ["A3b-25"],
         "amount": 1
       },
       {
@@ -24,30 +28,31 @@
         "amount": 1
       },
       {
+        "options": ["A3b-33", "A3b-76"],
+        "amount": 1
+      },
+      {
         "options": ["A3b-43"],
         "amount": 1
       },
       {
-        "options": ["A3b-2"],
-        "amount": 1
-      },
-      {
-        "options": ["A3b-17"],
-        "amount": 1
-      },
-      {
-        "options": ["A3b-33", "A3b-34", "A3b-81"],
+        "options": ["A4b-285", "A3b-78", "A4b-286"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Eevee Grove) ×13"
+    "reward": "Shinedust ×1300",
+    "secret": false
   },
   {
     "expansionId": "A3b",
     "name": "Eevee and its Evolutions 2",
     "requiredCards": [
       {
-        "options": ["A3b-78", "A3b-92"],
+        "options": ["A3b-70"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-64", "A3b-71", "A4-213", "A4b-65"],
         "amount": 1
       },
       {
@@ -55,11 +60,11 @@
         "amount": 1
       },
       {
-        "options": ["A3b-74"],
+        "options": ["A3b-73"],
         "amount": 1
       },
       {
-        "options": ["A3b-71", "A3b-87"],
+        "options": ["A3b-74"],
         "amount": 1
       },
       {
@@ -67,23 +72,20 @@
         "amount": 1
       },
       {
+        "options": ["A3b-33", "A3b-76"],
+        "amount": 1
+      },
+      {
         "options": ["A3b-77"],
         "amount": 1
       },
       {
-        "options": ["A3b-70"],
-        "amount": 1
-      },
-      {
-        "options": ["A3b-73"],
-        "amount": 1
-      },
-      {
-        "options": ["A3b-76", "A3b-89"],
+        "options": ["A4b-285", "A3b-78", "A4b-286"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Eevee Grove) ×26"
+    "reward": "Shinedust ×2600",
+    "secret": false
   },
   {
     "expansionId": "A3b",
@@ -98,7 +100,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Eevee Grove) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3b",
@@ -121,7 +124,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Eevee Grove) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3b",
@@ -144,7 +148,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Eevee Grove) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3b",
@@ -163,23 +168,24 @@
         "amount": 1
       },
       {
-        "options": ["A3b-31"],
+        "options": ["A4b-173"],
         "amount": 1
       },
       {
-        "options": ["A3b-32"],
+        "options": ["A4b-175"],
         "amount": 1
       },
       {
-        "options": ["A3b-36"],
+        "options": ["A4b-185"],
         "amount": 1
       },
       {
-        "options": ["A3b-37"],
+        "options": ["A4b-187"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Eevee Grove) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A3b",
@@ -198,14 +204,15 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Eevee Grove) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A3b",
     "name": "A Gluttonous Snorlax",
     "requiredCards": [
       {
-        "options": ["A3b-57", "A3b-84", "A3b-91"],
+        "options": ["A4b-288", "A3b-84", "A3b-91"],
         "amount": 1
       },
       {
@@ -213,18 +220,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Eevee Grove) ×5"
-  },
-  {
-    "expansionId": "A3b",
-    "name": "Collect 3 Alcremie cards",
-    "requiredCards": [
-      {
-        "options": ["A3b-37"],
-        "amount": 3
-      }
-    ],
-    "reward": "Alcremie (profile icon)"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "A3b",
@@ -251,7 +248,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3b",
@@ -278,17 +276,19 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A3b",
-    "name": "A Sweet Party of Epic Proportions",
+    "name": "A Sweets Party of Epic Proportions",
     "requiredCards": [
       {
-        "amount": "100",
-        "options": ["A3b-7", "A3b-18", "A3b-19", "A3b-31", "A3b-32", "A3b-36", "A3b-37"]
+        "options": ["A4b-185", "A4b-186"],
+        "amount": 100
       }
     ],
-    "reward": "Alcremie (emblem)"
+    "reward": "Alcremie (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A4-missions.json
+++ b/frontend/assets/themed-collections/A4-missions.json
@@ -8,11 +8,11 @@
         "amount": 1
       },
       {
-        "options": ["A4-34", "A4-187", "A4-210", "A4-240"],
+        "options": ["A4-63"],
         "amount": 1
       },
       {
-        "options": ["A4-63"],
+        "options": ["A4b-68", "A4-187", "A4-210", "A4-240", "A4b-362", "B2-226"],
         "amount": 1
       },
       {
@@ -24,24 +24,21 @@
         "amount": 1
       },
       {
-        "options": ["A4-124", "A4-194", "A4-209"],
+        "options": ["A4-130"],
         "amount": 1
       },
       {
-        "options": ["A4-130"],
+        "options": ["A4b-252", "A4-194", "A4-209"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×19"
+    "reward": "Shinedust ×1900",
+    "secret": false
   },
   {
     "expansionId": "A4",
     "name": "The Silvery Ocean, where Lugia Dwells",
     "requiredCards": [
-      {
-        "options": ["A4-43", "A4-188", "A4-203"],
-        "amount": 1
-      },
       {
         "options": ["A4-53", "A4-168"],
         "amount": 1
@@ -59,26 +56,31 @@
         "amount": 1
       },
       {
+        "options": ["A4b-92", "A4-188", "A4-203", "B2-227"],
+        "amount": 1
+      },
+      {
         "options": ["A4-106"],
         "amount": 1
       },
       {
-        "options": ["A4-149", "A4-195", "A4-211", "A4-241"],
+        "options": ["A4b-289", "A4-195", "A4-211", "A4-241", "A4b-371", "B2-232"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×20"
+    "reward": "Shinedust ×2000",
+    "secret": false
   },
   {
     "expansionId": "A4",
     "name": "Pokémon that can Use Attacks Immediately",
     "requiredCards": [
       {
-        "options": ["A4-32", "A4-166"],
+        "options": ["A4-32", "A4-166", "B2-206"],
         "amount": 1
       },
       {
-        "options": ["A4-66", "A4-171"],
+        "options": ["A4-66", "A4-171", "B2-213"],
         "amount": 1
       },
       {
@@ -98,7 +100,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -113,7 +116,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -132,24 +136,21 @@
         "amount": 1
       },
       {
-        "options": ["A4-121"],
+        "options": ["A4-110", "A4-177"],
         "amount": 1
       },
       {
-        "options": ["A4-110", "A4-177"],
+        "options": ["A4-121"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A4",
     "name": "The Man in the Mysterious Mask",
     "requiredCards": [
-      {
-        "options": ["A4-156", "A4-196"],
-        "amount": 1
-      },
       {
         "options": ["A4-76"],
         "amount": 1
@@ -157,28 +158,34 @@
       {
         "options": ["A4-82", "A4-174"],
         "amount": 1
+      },
+      {
+        "options": ["A4-156", "A4-196"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A4",
     "name": "The Steel-Clad-Defense Girl",
     "requiredCards": [
       {
+        "options": ["A4-122"],
+        "amount": 1
+      },
+      {
         "options": ["A4-160", "A4-200"],
         "amount": 1
       },
       {
-        "options": ["A4-124", "A4-194", "A4-209"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-122"],
+        "options": ["A4b-252", "A4-194", "A4-209"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×8"
+    "reward": "Shinedust ×800",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -193,7 +200,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×5"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -224,7 +232,8 @@
         "amount": 2
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -251,26 +260,28 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
     "name": "Journeying with a Partner and an Egg",
     "requiredCards": [
       {
+        "options": ["A4-8", "A4-162"],
+        "amount": 1
+      },
+      {
         "options": ["A4-78", "A4-173"],
         "amount": 1
       },
       {
-        "options": ["A4-157", "A4-197"],
+        "options": ["A4b-332", "A4-197", "A4b-333"],
         "amount": 1
-      },
-      {
-        "amount": "1",
-        "options": ["A4-8", "A4-162", "A4-27", "A4-165", "A4-46", "A4-167"]
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -293,7 +304,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -308,7 +320,7 @@
         "amount": 1
       },
       {
-        "options": ["A4-14"],
+        "options": ["A4b-16"],
         "amount": 1
       },
       {
@@ -316,7 +328,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -339,7 +352,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -358,18 +372,19 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
     "name": "Large Horns Brimming with Charm",
     "requiredCards": [
       {
-        "options": ["A4-118"],
+        "options": ["A4-22", "A4-164"],
         "amount": 1
       },
       {
-        "options": ["A4-22", "A4-164"],
+        "options": ["A4-118"],
         "amount": 1
       },
       {
@@ -377,7 +392,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Wisdom of Sea and Sky) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -392,7 +408,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -431,20 +448,13 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
     "name": "Fishing for a Big Catch",
     "requiredCards": [
-      {
-        "options": ["A4-41"],
-        "amount": 1
-      },
-      {
-        "options": ["A4-42"],
-        "amount": 1
-      },
       {
         "options": ["A4-44"],
         "amount": 1
@@ -462,7 +472,15 @@
         "amount": 1
       },
       {
-        "options": ["A4-60"],
+        "options": ["A4b-88"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-90"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-102"],
         "amount": 1
       },
       {
@@ -470,7 +488,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Wisdom of Sea and Sky) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -481,7 +500,8 @@
         "amount": 5
       }
     ],
-    "reward": "Meganium (icon)"
+    "reward": "Meganium (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -492,7 +512,8 @@
         "amount": 5
       }
     ],
-    "reward": "Typhlosion (icon)"
+    "reward": "Typhlosion (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -503,7 +524,8 @@
         "amount": 5
       }
     ],
-    "reward": "Feraligatr (icon)"
+    "reward": "Feraligatr (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A4",
@@ -518,7 +540,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4",
@@ -573,7 +596,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4",
@@ -628,7 +652,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4",
@@ -651,7 +676,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4",
@@ -674,46 +700,47 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4",
-    "name": "Smeargle's Colorful Collection",
+    "name": "Smeargle’s Colorful Collection",
     "requiredCards": [
       {
-        "options": ["A4-162", "A4-163", "A4-164", "A4-202"],
+        "options": ["A4-8", "A4-162"],
         "amount": 1
       },
       {
-        "options": ["A4-165", "A4-166"],
+        "options": ["A4-27", "A4-165"],
         "amount": 1
       },
       {
-        "options": ["A4-167", "A4-168", "A4-169", "A4-170", "A4-203"],
+        "options": ["A4-46", "A4-167"],
         "amount": 1
       },
       {
-        "options": ["A4-171", "A4-172", "A4-204"],
+        "options": ["A4-66", "A4-171", "B2-213"],
         "amount": 1
       },
       {
-        "options": ["A4-173", "A4-174", "A4-175", "A4-205"],
+        "options": ["A4-78", "A4-173"],
         "amount": 1
       },
       {
-        "options": ["A4-176", "A4-206"],
+        "options": ["A4-94", "A4-176"],
         "amount": 1
       },
       {
-        "options": ["A4-177", "A4-178", "A4-179", "A4-207", "A4-208"],
+        "options": ["A4-110", "A4-177"],
         "amount": 1
       },
       {
-        "options": ["A4-180", "A4-209"],
+        "options": ["A4-123", "A4-180"],
         "amount": 1
       },
       {
-        "options": ["A4-181", "A4-182", "A4-183", "A4-185"],
+        "options": ["A4-138", "A4-181"],
         "amount": 1
       },
       {
@@ -721,6 +748,7 @@
         "amount": 1
       }
     ],
-    "reward": "Smeargle"
+    "reward": "Smeargle (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A4a-missions.json
+++ b/frontend/assets/themed-collections/A4a-missions.json
@@ -8,11 +8,11 @@
         "amount": 1
       },
       {
-        "options": ["A4a-20", "A4a-80", "A4a-90"],
+        "options": ["A4a-20", "A4a-80", "A4a-90", "B2a-127"],
         "amount": 1
       },
       {
-        "options": ["A4a-22", "A4a-72"],
+        "options": ["A4a-22", "A4a-72", "P-A-104"],
         "amount": 1
       },
       {
@@ -24,7 +24,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Secluded Springs) ×10"
+    "reward": "Shinedust ×1000",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -35,7 +36,7 @@
         "amount": 1
       },
       {
-        "options": ["A4a-10", "A4a-79", "A4a-87"],
+        "options": ["A4a-10", "A4a-79", "A4a-87", "B2a-126", "P-A-110"],
         "amount": 1
       },
       {
@@ -51,26 +52,19 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Secluded Springs) ×10"
+    "reward": "Shinedust ×1000",
+    "secret": false
   },
   {
     "expansionId": "A4a",
     "name": "Raikou and Waterside Lightning-type Pokémon",
     "requiredCards": [
       {
-        "options": ["A4a-25", "A4a-81", "A4a-88"],
+        "options": ["A4a-25", "A4a-81", "A4a-88", "B2a-128"],
         "amount": 1
       },
       {
         "options": ["A4a-26"],
-        "amount": 1
-      },
-      {
-        "options": ["A4a-27"],
-        "amount": 1
-      },
-      {
-        "options": ["A4a-28"],
         "amount": 1
       },
       {
@@ -82,7 +76,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Secluded Springs) ×10"
+    "reward": "Shinedust ×1000",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -113,7 +108,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Secluded Springs) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -124,7 +120,7 @@
         "amount": 1
       },
       {
-        "options": ["A4a-11"],
+        "options": ["A4a-16"],
         "amount": 1
       },
       {
@@ -132,7 +128,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Secluded Springs) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -147,7 +144,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Secluded Springs) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -162,7 +160,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Secluded Springs) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -177,7 +176,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Secluded Springs) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -188,11 +188,12 @@
         "amount": 1
       },
       {
-        "options": ["A4a-37", "A4a-75"],
+        "options": ["A4a-37", "A4a-75", "B2-217"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Secluded Springs) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -203,14 +204,15 @@
         "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Secluded Springs) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4a",
     "name": "Pokémon that can Use Attacks Immediately",
     "requiredCards": [
       {
-        "options": ["A4a-23", "A4a-105"],
+        "options": ["A4a-23", "A4a-105", "B2-210"],
         "amount": 1
       },
       {
@@ -222,7 +224,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Secluded Springs) ×5"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -233,7 +236,8 @@
         "amount": 3
       }
     ],
-    "reward": "Igglybuff (profile icon)"
+    "reward": "Igglybuff (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "A4a",
@@ -252,7 +256,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4a",
@@ -271,7 +276,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4a",
@@ -302,7 +308,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4a",
@@ -325,7 +332,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4a",
@@ -352,6 +360,7 @@
         "amount": 1
       }
     ],
-    "reward": "Mantyke (emblem)"
+    "reward": "Mantyke (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/A4b-missions.json
+++ b/frontend/assets/themed-collections/A4b-missions.json
@@ -2,37 +2,53 @@
   {
     "expansionId": "A4b",
     "name": "ex Collection",
-    "requiredCards": [],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×16"
+    "requiredCards": [
+      {
+        "options": ["A4b-5", "A1-251", "A3-230"],
+        "amount": 15
+      }
+    ],
+    "reward": "Shinedust ×1600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Collect Parallel Foil Card Pokémon",
-    "requiredCards": [],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Deluxe Pack ex) ×16"
+    "requiredCards": [
+      {
+        "options": ["A4b-1", "A1-227", "A3-210", "A4b-2", "P-A-23"],
+        "amount": 5
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Pokémon with Impressive Shells",
     "requiredCards": [
       {
-        "options": ["A4b-23"],
-        "amount": 1
-      },
-      {
         "options": ["A4b-69", "A4b-70"],
         "amount": 1
       },
       {
-        "options": ["A4b-83", "A4b-84"],
+        "options": ["A4b-23"],
         "amount": 1
       },
       {
-        "options": ["A4b-85", "A4b-86"],
+        "options": ["A4b-85", "A3-216", "A4b-86"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-83", "A1-232", "A3-215", "A4b-84", "P-A-33"],
         "amount": 1
       },
       {
         "options": ["A4b-87"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-218", "A4b-219", "P-A-71"],
         "amount": 1
       },
       {
@@ -46,20 +62,29 @@
       {
         "options": ["A4b-121"],
         "amount": 1
-      },
-      {
-        "options": ["A4b-218", "A4b-219"],
-        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Pokémon That Hold Things",
     "requiredCards": [
       {
-        "options": ["A4b-194", "A4b-195"],
+        "options": ["A4b-262", "A4b-263"],
+        "amount": 1
+      },
+      {
+        "options": ["A2b-54"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-104"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-194", "A1-239", "A3-226", "A4b-195"],
         "amount": 1
       },
       {
@@ -67,38 +92,27 @@
         "amount": 1
       },
       {
-        "options": ["A4b-223"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-262", "A4b-263"],
-        "amount": 1
-      },
-      {
         "options": ["A4b-264", "A4b-265"],
         "amount": 1
       },
       {
-        "options": ["A4b-266"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-280", "A4b-281", "A4b-359"],
+        "options": ["A4b-280", "A3b-102", "A4b-281", "A4b-359", "P-A-62"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Pokémon with Cute Tongues",
     "requiredCards": [
       {
-        "options": ["A4b-153", "A4b-154"],
+        "options": ["A1-123"],
         "amount": 1
       },
       {
-        "options": ["A4b-155"],
+        "options": ["A4b-153", "A3-221", "A4b-154"],
         "amount": 1
       },
       {
@@ -110,7 +124,7 @@
         "amount": 1
       },
       {
-        "options": ["A4b-282", "A4b-283"],
+        "options": ["A4b-282", "A4-230", "A4b-283"],
         "amount": 1
       },
       {
@@ -118,29 +132,35 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Pokémon That Hide Their True Faces",
     "requiredCards": [
       {
-        "options": ["A4b-194", "A4b-195"],
+        "options": ["A4b-194", "A1-239", "A3-226", "A4b-195"],
         "amount": 1
       },
       {
-        "options": ["A4b-300", "A4b-301"],
+        "options": ["A4b-300", "A4b-301", "B1a-96"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Very Very Light Pokémon",
     "requiredCards": [
       {
-        "options": ["A4b-47", "A4b-48"],
+        "options": ["A4b-47", "A4b-48", "P-A-75"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-180", "A3-171", "A4b-181", "P-A-67"],
         "amount": 1
       },
       {
@@ -148,26 +168,23 @@
         "amount": 1
       },
       {
-        "options": ["A4b-153", "A4b-154"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-180", "A4b-181"],
+        "options": ["A4b-153", "A3-221", "A4b-154"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "A Kitty Get-Together",
     "requiredCards": [
       {
-        "options": ["A4b-49", "A4b-50"],
+        "options": ["A4b-49", "A4b-50", "P-A-52"],
         "amount": 1
       },
       {
-        "options": ["A4b-78", "A4b-79"],
+        "options": ["A4b-78", "A4b-79", "B1-293"],
         "amount": 1
       },
       {
@@ -175,18 +192,19 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Slithering About",
     "requiredCards": [
       {
-        "options": ["A4b-36", "A4b-37"],
+        "options": ["A4b-36", "A1a-70", "A4b-37"],
         "amount": 1
       },
       {
-        "options": ["A4b-125", "A4b-126"],
+        "options": ["A4b-125", "A2b-101", "A4b-126"],
         "amount": 1
       },
       {
@@ -194,14 +212,15 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×2"
+    "reward": "Shinedust ×200",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Fish Pokémon with 30 HP",
     "requiredCards": [
       {
-        "options": ["A4b-96", "A4b-97"],
+        "options": ["A4b-96", "A4-214", "A4b-97"],
         "amount": 1
       },
       {
@@ -209,14 +228,15 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Late Bloomers",
     "requiredCards": [
       {
-        "options": ["A4b-205", "A4b-206"],
+        "options": ["A4b-205", "A4a-98", "A4b-206", "P-A-46"],
         "amount": 1
       },
       {
@@ -224,67 +244,67 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "The Main Characters of the Kanto Region",
     "requiredCards": [
       {
-        "options": ["A4b-346", "A4b-347"],
+        "options": ["A4b-346", "A1a-82", "A4b-347"],
         "amount": 1
       },
       {
-        "options": ["A4b-352", "A4b-353"],
+        "options": ["A4b-352", "A2b-90", "A4b-353"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Father and Child",
     "requiredCards": [
       {
-        "options": ["A4b-334", "A4b-335"],
+        "options": ["A4b-334", "A1-270", "A4b-335"],
         "amount": 1
       },
       {
-        "options": ["A4b-336", "A4b-337"],
+        "options": ["A4b-336", "A4-198", "A4b-337"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Mother and Child",
     "requiredCards": [
       {
-        "options": ["A4b-348", "A4b-349", "A4b-374"],
+        "options": ["A4b-350", "A3a-83", "A4b-351", "A4b-375"],
         "amount": 1
       },
       {
-        "options": ["A4b-350", "A4b-351", "A4b-375"],
+        "options": ["A4b-348", "A3-197", "A3-209", "A4b-349", "A4b-374"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "Item Mania",
     "requiredCards": [
       {
-        "options": ["A4b-308", "A4b-309"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-310", "A4b-311"],
-        "amount": 1
-      },
-      {
         "options": ["A4b-312", "A4b-313"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-308", "A3b-107", "A4b-309"],
         "amount": 1
       },
       {
@@ -292,11 +312,16 @@
         "amount": 1
       },
       {
+        "options": ["A4b-310", "A4b-311"],
+        "amount": 1
+      },
+      {
         "options": ["A4b-316", "A4b-317"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
@@ -319,171 +344,436 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Deluxe Pack ex) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Grass",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-5", "A4b-10", "A4b-13", "A4b-22", "A4b-23", "A4b-24", "A4b-29", "A4b-42", "A4b-43", "A4b-44", "A4b-360"]
+        "options": ["A4b-5", "A1-251", "A3-230"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Fire",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-59", "A4b-361", "A4b-60", "A4b-63", "A4b-66", "A4b-67", "A4b-68", "A4b-36", "A4b-75", "A4b-82"]
+        "options": ["A4b-59", "A1-253", "A1-280", "A1-284", "A4b-361"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Water",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-87", "A4b-92", "A4b-95", "A4b-98", "A4b-101", "A4b-106", "A4b-107", "A4b-363", "A4b-120", "A4b-121", "A4b-124", "A4b-127"]
+        "options": ["A4b-87", "A1-256", "A3-232"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Lightning",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-130", "A4b-131", "A4b-364", "A4b-376", "A4b-132", "A4b-139", "A4b-142", "A4b-145", "A4b-148"]
+        "options": ["A4b-130", "A3-185", "A3-203"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Psychic",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-155", "A4b-158", "A4b-365", "A4b-159", "A4b-366", "A4b-160", "A4b-163", "A4b-172", "A4b-377", "A4b-177", "A4b-184", "A4b-367"]
+        "options": ["A4b-155", "A1-261", "A1-277", "A3-234"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Fighting",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-193", "A4b-196", "A4b-197", "A4b-202", "A4b-209", "A4b-214", "A4b-215", "A4b-222", "A4b-223"]
+        "options": ["A4b-193", "A1-263", "A1-278", "A3-235"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Darkness",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-232", "A4b-235", "A4b-238", "A4b-241", "A4b-244", "A4b-245", "A4b-378", "A4b-248"]
+        "options": ["A4b-232", "A4-192", "A4-207"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Metal",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-251", "A4b-252", "A4b-253", "A4b-254", "A4b-368", "A4b-259", "A4b-369", "A4b-266"]
+        "options": ["A4b-251", "A3a-80", "A3a-87", "B1-325"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
     "name": "ex Collection • Colorless",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["A4b-276", "A4b-279", "A4b-284", "A4b-287", "A4b-370", "A4b-288", "A4b-289", "A4b-371", "A4b-296", "A4b-299", "A4b-372"]
+        "options": ["A4b-276", "A1a-79", "A3a-102"],
+        "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Deluxe Pack ex) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "A4b",
-    "name": "Collect Special  Cards",
+    "name": "Collect Special ★★ Cards",
     "requiredCards": [
       {
-        "options": ["A4b-360"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-361"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-362"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-363"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-364"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-365"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-366"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-367"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-368"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-369"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-370"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-371"],
-        "amount": 1
-      },
-      {
-        "options": ["A4b-372"],
+        "options": ["A4b-131", "A1-259", "A1-281", "A1-285", "A4b-364", "A4b-376"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4b",
     "name": "ex Complete!",
-    "requiredCards": [],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "requiredCards": [
+      {
+        "options": ["A1-4"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-10"],
+        "amount": 1
+      },
+      {
+        "options": ["A2a-10"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-12"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-13"],
+        "amount": 1
+      },
+      {
+        "options": ["A2b-19"],
+        "amount": 1
+      },
+      {
+        "options": ["A3a-19"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-22"],
+        "amount": 1
+      },
+      {
+        "options": ["A2a-22"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-23"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-24"],
+        "amount": 1
+      },
+      {
+        "options": ["A2b-43"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-43"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-44"],
+        "amount": 1
+      },
+      {
+        "options": ["A2a-47"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-47"],
+        "amount": 1
+      },
+      {
+        "options": ["A2b-48"],
+        "amount": 1
+      },
+      {
+        "options": ["A2-49"],
+        "amount": 1
+      },
+      {
+        "options": ["A2b-54"],
+        "amount": 1
+      },
+      {
+        "options": ["A3b-56"],
+        "amount": 1
+      },
+      {
+        "options": ["A3b-57"],
+        "amount": 1
+      },
+      {
+        "options": ["A1a-59"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-59"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-60"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-63"],
+        "amount": 1
+      },
+      {
+        "options": ["A2b-65"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-66"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-68"],
+        "amount": 1
+      },
+      {
+        "options": ["A2a-71"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-75"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-82"],
+        "amount": 1
+      },
+      {
+        "options": ["A4-83"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-87"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-87"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-92"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-95"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-96"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-98"],
+        "amount": 1
+      },
+      {
+        "options": ["A2-99"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-101"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-104"],
+        "amount": 1
+      },
+      {
+        "options": ["A4-109"],
+        "amount": 1
+      },
+      {
+        "options": ["A2-110"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-111"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-120"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-121"],
+        "amount": 1
+      },
+      {
+        "options": ["A3-122"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-123"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-124"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-129"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-130"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-132"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-139"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-142"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-145"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-159"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-163"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-172"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-177"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-193"],
+        "amount": 1
+      },
+      {
+        "options": ["A1-195"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-196"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-197"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-202"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-215"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-222"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-241"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-248"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-251"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-252"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-253"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-254"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-271"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-284"],
+        "amount": 1
+      },
+      {
+        "options": ["A4b-289"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4b",
@@ -514,7 +804,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4b",
@@ -573,7 +864,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4b",
@@ -592,18 +884,19 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "A4b",
     "name": "Pikachu Museum",
     "requiredCards": [
       {
-        "options": ["A4b-128", "A4b-129"],
+        "options": ["A1-96"],
         "amount": 1
       },
       {
-        "options": ["A4b-131"],
+        "options": ["A4b-128", "A4b-129", "P-A-9", "P-A-15", "P-A-26"],
         "amount": 1
       },
       {
@@ -619,6 +912,7 @@
         "amount": 1
       }
     ],
-    "reward": "Pikachu (emblem)"
+    "reward": "Pikachu Ver. 2 (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/B1-missions.json
+++ b/frontend/assets/themed-collections/B1-missions.json
@@ -4,14 +4,6 @@
     "name": "A Journey of Evolution That Fires Up Your Fighting Spirit",
     "requiredCards": [
       {
-        "options": ["B1-36", "B1-254", "B1-284"],
-        "amount": 1
-      },
-      {
-        "options": ["B1-223", "B1-268"],
-        "amount": 1
-      },
-      {
         "options": ["B1-33"],
         "amount": 1
       },
@@ -22,9 +14,18 @@
       {
         "options": ["B1-35"],
         "amount": 1
+      },
+      {
+        "options": ["B1-36", "B1-254", "B1-284", "B3-226"],
+        "amount": 1
+      },
+      {
+        "options": ["B1-223", "B1-268"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×22"
+    "reward": "Shinedust ×2200",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -32,10 +33,6 @@
     "requiredCards": [
       {
         "options": ["B1-52", "B1-255", "B1-285"],
-        "amount": 1
-      },
-      {
-        "options": ["B1-148"],
         "amount": 1
       },
       {
@@ -49,16 +46,21 @@
       {
         "options": ["B1-76"],
         "amount": 1
+      },
+      {
+        "options": ["B1-148"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×11"
+    "reward": "Shinedust ×1100",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "Bodies of Tightly Packed Fluff",
     "requiredCards": [
       {
-        "options": ["B1-102", "B1-259", "B1-286"],
+        "options": ["B1-15"],
         "amount": 1
       },
       {
@@ -66,7 +68,7 @@
         "amount": 1
       },
       {
-        "options": ["B1-15"],
+        "options": ["B1-102", "B1-259", "B1-286"],
         "amount": 1
       },
       {
@@ -78,14 +80,15 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×11"
+    "reward": "Shinedust ×1100",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "Rhythmic Connections",
     "requiredCards": [
       {
-        "options": ["B1-233"],
+        "options": ["B1-19"],
         "amount": 1
       },
       {
@@ -93,15 +96,16 @@
         "amount": 1
       },
       {
-        "options": ["B1-19"],
+        "options": ["B1-198"],
         "amount": 1
       },
       {
-        "options": ["B1-198"],
+        "options": ["B1-233"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -120,18 +124,19 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "The Gallant Swords of Justice",
     "requiredCards": [
       {
-        "options": ["B1-70", "B1-235"],
+        "options": ["B1-20"],
         "amount": 1
       },
       {
-        "options": ["B1-169"],
+        "options": ["B1-70", "B1-235"],
         "amount": 1
       },
       {
@@ -139,20 +144,17 @@
         "amount": 1
       },
       {
-        "options": ["B1-20"],
+        "options": ["B1-169"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×22"
+    "reward": "Shinedust ×2200",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "Pokémon That Evolve from Fossils",
     "requiredCards": [
-      {
-        "options": ["B1-216"],
-        "amount": 1
-      },
       {
         "options": ["B1-66"],
         "amount": 1
@@ -162,34 +164,40 @@
         "amount": 1
       },
       {
-        "options": ["B1-214"],
-        "amount": 1
-      },
-      {
         "options": ["B1-133"],
         "amount": 1
       },
       {
         "options": ["B1-134", "B1-242"],
         "amount": 1
+      },
+      {
+        "options": ["B1-214"],
+        "amount": 1
+      },
+      {
+        "options": ["B1-216"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×14"
+    "reward": "Shinedust ×1400",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "Smallest Meets Largest",
     "requiredCards": [
       {
-        "options": ["B1-92"],
+        "options": ["B1-57"],
         "amount": 1
       },
       {
-        "options": ["B1-57"],
+        "options": ["B1-92"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -200,38 +208,40 @@
         "amount": 1
       },
       {
-        "options": ["B1-201"],
+        "options": ["B1-95"],
         "amount": 1
       },
       {
-        "options": ["B1-95"],
+        "options": ["B1-201"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×13<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×1300<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "Nice...Hat?",
     "requiredCards": [
       {
-        "options": ["B1-55", "B1-233"],
-        "amount": 1
-      },
-      {
         "options": ["B1-12"],
         "amount": 1
       },
       {
-        "options": ["B1-149", "B1-244"],
+        "options": ["B1-55", "B1-233"],
         "amount": 1
       },
       {
         "options": ["B1-100"],
         "amount": 1
+      },
+      {
+        "options": ["B1-149", "B1-244"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×3"
+    "reward": "Shinedust ×300",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -258,7 +268,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×2"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -273,15 +284,16 @@
         "amount": 1
       },
       {
-        "options": ["B1-173"],
+        "options": ["B1-145"],
         "amount": 1
       },
       {
-        "options": ["B1-145"],
+        "options": ["B1-173"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×7"
+    "reward": "Shinedust ×700",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -296,7 +308,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -315,7 +328,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -330,7 +344,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
@@ -345,31 +360,29 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "Distinctive Eyes",
     "requiredCards": [
       {
-        "options": ["B1-195"],
+        "options": ["B1-101"],
         "amount": 1
       },
       {
-        "options": ["B1-101"],
+        "options": ["B1-195"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "The Kahuna Stands Strong",
     "requiredCards": [
-      {
-        "options": ["B1-222", "B1-267"],
-        "amount": 1
-      },
       {
         "options": ["B1-127"],
         "amount": 1
@@ -377,35 +390,41 @@
       {
         "options": ["B1-140"],
         "amount": 1
+      },
+      {
+        "options": ["B1-222", "B1-267"],
+        "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×1<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "A Bigger Splash Than the Sea",
     "requiredCards": [
       {
-        "options": ["B1-221", "B1-266"],
-        "amount": 1
-      },
-      {
         "options": ["B1-67"],
         "amount": 1
       },
       {
-        "options": ["B1-69", "B1-234"],
+        "options": ["B1-69", "B1-234", "B3-210"],
+        "amount": 1
+      },
+      {
+        "options": ["B1-221", "B1-266"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Rising) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "The Alluring, Soulful Dancer",
     "requiredCards": [
       {
-        "options": ["B1-224", "B1-269"],
+        "options": ["B1-100"],
         "amount": 1
       },
       {
@@ -413,22 +432,83 @@
         "amount": 1
       },
       {
-        "options": ["B1-100"],
+        "options": ["B1-224", "B1-269"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Emblem Ticket (Mega Rising) ×2<br />Shop Ticket ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B1",
     "name": "Collect 1 Mega Evolution Pokémon ex Card",
     "requiredCards": [
       {
+        "options": ["B1-36", "B1-254", "B1-284", "B3-226"],
+        "amount": 1
+      }
+    ],
+    "reward": "Mega Evolution PokéMon Ex (backdrop)",
+    "secret": false
+  },
+  {
+    "expansionId": "B1",
+    "name": "Collect 3 Mega Evolution Pokémon ex Cards",
+    "requiredCards": [
+      {
+        "options": ["B1-36", "B1-254", "B1-284", "B3-226"],
+        "amount": 3
+      }
+    ],
+    "reward": "Mega Evolution PokéMon Ex (cover)",
+    "secret": false
+  },
+  {
+    "expansionId": "B1",
+    "name": "Collect 3 Froakie cards",
+    "requiredCards": [
+      {
+        "options": ["B1-71"],
+        "amount": 3
+      }
+    ],
+    "reward": "Froakie (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B1",
+    "name": "Collect 3 Yamper cards",
+    "requiredCards": [
+      {
+        "options": ["B1-95"],
+        "amount": 3
+      }
+    ],
+    "reward": "Yamper (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B1",
+    "name": "Collect 5 Darkrai cards",
+    "requiredCards": [
+      {
+        "options": ["B1-154"],
+        "amount": 5
+      }
+    ],
+    "reward": "Darkrai (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B1",
+    "name": "A Multitude of Mega Evolution Pokémon!",
+    "requiredCards": [
+      {
         "options": ["B1-2", "B1-251", "B1-272"],
         "amount": 1
       },
       {
-        "options": ["B1-36", "B1-254", "B1-284"],
+        "options": ["B1-36", "B1-254", "B1-284", "B3-226"],
         "amount": 1
       },
       {
@@ -444,74 +524,12 @@
         "amount": 1
       },
       {
-        "options": ["B1-151", "B1-262", "B1-280"],
+        "options": ["B1-151", "B1-262", "B1-280", "B3-230", "P-B-9"],
         "amount": 1
       }
     ],
-    "reward": "Mega Evolution Pokémon ex (backdrop)"
-  },
-  {
-    "expansionId": "B1",
-    "name": "Collect 3 Mega Evolution Pokémon ex Card",
-    "requiredCards": [
-      {
-        "amount": "3",
-        "options": [
-          "B1-2",
-          "B1-251",
-          "B1-272",
-          "B1-36",
-          "B1-254",
-          "B1-284",
-          "B1-52",
-          "B1-255",
-          "B1-285",
-          "B1-85",
-          "B1-258",
-          "B1-277",
-          "B1-102",
-          "B1-259",
-          "B1-286",
-          "B1-151",
-          "B1-262",
-          "B1-280"
-        ]
-      }
-    ],
-    "reward": "Mega Evolution Pokémon ex (cover)"
-  },
-  {
-    "expansionId": "B1",
-    "name": "Collect 3 Froakie cards",
-    "requiredCards": [
-      {
-        "options": ["B1-71"],
-        "amount": 3
-      }
-    ],
-    "reward": "Froakie (profile icon)"
-  },
-  {
-    "expansionId": "B1",
-    "name": "Collect 3 Yamper cards",
-    "requiredCards": [
-      {
-        "options": ["B1-95"],
-        "amount": 3
-      }
-    ],
-    "reward": "Yamper (profile icon)"
-  },
-  {
-    "expansionId": "B1",
-    "name": "Collect 5 Darkrai cards",
-    "requiredCards": [
-      {
-        "options": ["B1-154"],
-        "amount": 5
-      }
-    ],
-    "reward": "Darkrai (profile icon)"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1",
@@ -550,7 +568,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1",
@@ -589,7 +608,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1",
@@ -628,7 +648,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1",
@@ -651,7 +672,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1",
@@ -674,7 +696,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1",
@@ -697,38 +720,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
-  },
-  {
-    "expansionId": "B1",
-    "name": "A Multitude of Mega Evolution Pokémon!",
-    "requiredCards": [
-      {
-        "options": ["B1-2", "B1-251", "B1-272"],
-        "amount": 1
-      },
-      {
-        "options": ["B1-36", "B1-254", "B1-284"],
-        "amount": 1
-      },
-      {
-        "options": ["B1-52", "B1-255", "B1-285"],
-        "amount": 1
-      },
-      {
-        "options": ["B1-85", "B1-258", "B1-277"],
-        "amount": 1
-      },
-      {
-        "options": ["B1-102", "B1-259", "B1-286"],
-        "amount": 1
-      },
-      {
-        "options": ["B1-151", "B1-262", "B1-280"],
-        "amount": 1
-      }
-    ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1",
@@ -791,6 +784,7 @@
         "amount": 1
       }
     ],
-    "reward": "Mega Pinsir (emblem)"
+    "reward": "Mega Pinsir (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/B1a-missions.json
+++ b/frontend/assets/themed-collections/B1a-missions.json
@@ -20,7 +20,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×11"
+    "reward": "Shinedust ×1100",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -39,7 +40,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×8"
+    "reward": "Shinedust ×800",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -62,7 +64,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×8"
+    "reward": "Shinedust ×800",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -89,11 +92,12 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "B1a",
-    "name": "Sunkern's Growth Diary",
+    "name": "Sunkern’s Growth Diary",
     "requiredCards": [
       {
         "options": ["B1a-7"],
@@ -104,7 +108,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -127,7 +132,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -148,9 +154,14 @@
       {
         "options": ["B1a-41"],
         "amount": 1
+      },
+      {
+        "options": ["B1a-53"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -161,7 +172,8 @@
         "amount": 5
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -184,7 +196,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×1"
+    "reward": "Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -207,7 +220,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Crimson Blaze) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -218,7 +232,8 @@
         "amount": 3
       }
     ],
-    "reward": "Serena (profile icon)"
+    "reward": "Serena (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "B1a",
@@ -249,7 +264,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1a",
@@ -272,7 +288,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1a",
@@ -291,11 +308,12 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B1a",
-    "name": "Mega Venusaur's Evolution",
+    "name": "Mega Venusaur’s Evolution",
     "requiredCards": [
       {
         "options": ["B1a-1"],
@@ -322,7 +340,8 @@
         "amount": 1
       }
     ],
-    "reward": "Mega Venusaur (emblem)"
+    "reward": "Mega Venusaur (emblem)",
+    "secret": true
   },
   {
     "expansionId": "B1a",
@@ -345,10 +364,11 @@
         "amount": 1
       },
       {
-        "options": ["B1a-80", "B1a-86"],
+        "options": ["B1a-52", "B1a-80", "B1a-86", "B3-232"],
         "amount": 1
       }
     ],
-    "reward": "Mega Blastoise (emblem)"
+    "reward": "Mega Blastoise (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/B2-missions.json
+++ b/frontend/assets/themed-collections/B2-missions.json
@@ -20,7 +20,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Fantastical Parade) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -43,7 +44,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Fantastical Parade) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -70,7 +72,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Fantastical Parade) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -85,7 +88,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Fantastical Parade) ×9"
+    "reward": "Shinedust ×900",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -96,33 +100,16 @@
         "amount": 1
       },
       {
-        "amount": "5",
-        "options": [
-          "B2-2",
-          "B2-3",
-          "B2-18",
-          "B2-22",
-          "B2-32",
-          "B2-37",
-          "B2-61",
-          "B2-67",
-          "B2-71",
-          "B2-130",
-          "B2-134",
-          "B2-137",
-          "B2-143",
-          "B2-159",
-          "B2-172",
-          "B2-194",
-          "B2-204"
-        ]
+        "options": ["B2-2"],
+        "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
-    "name": "Pokémon that Dance in the Town",
+    "name": "Pokémon That Dance in the Town",
     "requiredCards": [
       {
         "options": ["B2-18"],
@@ -141,7 +128,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -160,7 +148,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -183,11 +172,12 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Shinedust ×1600",
+    "secret": false
   },
   {
     "expansionId": "B2",
-    "name": "Each Meowth is Different",
+    "name": "Each Meowth Is Different",
     "requiredCards": [
       {
         "options": ["B2-94"],
@@ -202,7 +192,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -217,7 +208,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -232,18 +224,20 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Fantastical Parade) ×5"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "B2",
     "name": "Warning: May Be Prickly",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["B2-6", "B2-156", "B2-7", "B2-8", "B2-9", "B2-10", "B2-78", "B2-115", "B2-116"]
+        "options": ["B2-6", "B2-156"],
+        "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -258,11 +252,12 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
-    "name": "Want Some... Ice Cream?",
+    "name": "Want Some...Ice Cream?",
     "requiredCards": [
       {
         "options": ["B2-37"],
@@ -281,7 +276,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -296,7 +292,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -315,29 +312,32 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Fantastical Parade) ×12"
+    "reward": "Shinedust ×1200",
+    "secret": false
   },
   {
     "expansionId": "B2",
     "name": "Alolan Form Pokémon",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["B2-18", "B2-28", "B2-29", "B2-182", "B2-196", "B2-50", "B2-94", "B2-95", "B2-96", "B2-97", "B2-173"]
+        "options": ["B2-28", "P-B-32"],
+        "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
     "name": "Galarian Form Pokémon",
     "requiredCards": [
       {
-        "amount": "5",
-        "options": ["B2-30", "B2-31", "B2-58", "B2-167", "B2-59", "B2-98", "B2-99", "B2-100", "B2-176", "B2-110", "B2-111", "B2-177", "B2-117"]
+        "options": ["B2-30"],
+        "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -368,12 +368,17 @@
         "amount": 1
       }
     ],
-    "reward": "Starting Plains Battle (cover)<br />Emblem Ticket (Fantastical Parade) ×1"
+    "reward": "Starting Plains Battle (cover)<br />Shinedust ×100",
+    "secret": false
   },
   {
     "expansionId": "B2",
     "name": "Peculiar Plaza and Psychic-type Pokémon",
     "requiredCards": [
+      {
+        "options": ["B2-58", "B2-167"],
+        "amount": 5
+      },
       {
         "options": ["B2-66", "B2-185", "B2-203"],
         "amount": 1
@@ -383,18 +388,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Fantastical Parade) ×9"
-  },
-  {
-    "expansionId": "B2",
-    "name": "Collect 3 Mudkip cards",
-    "requiredCards": [
-      {
-        "options": ["B2-33"],
-        "amount": 3
-      }
-    ],
-    "reward": "Mudkip (profile icon)"
+    "reward": "Shinedust ×900",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -405,7 +400,8 @@
         "amount": 3
       }
     ],
-    "reward": "Cramorant (profile icon)"
+    "reward": "Cramorant (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "B2",
@@ -416,7 +412,96 @@
         "amount": 3
       }
     ],
-    "reward": "Meloetta (profile icon)"
+    "reward": "Meloetta (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B2",
+    "name": "Collect 3 Mudkip cards",
+    "requiredCards": [
+      {
+        "options": ["B2-33"],
+        "amount": 3
+      }
+    ],
+    "reward": "Mudkip (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B2",
+    "name": "Pokémon and the Town Festival",
+    "requiredCards": [
+      {
+        "options": ["B2-2"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-3"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-18"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-22"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-32"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-37"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-61"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-67"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-71"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-130"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-134"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-137"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-143"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-159"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-172"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-194"],
+        "amount": 1
+      },
+      {
+        "options": ["B2-204"],
+        "amount": 1
+      }
+    ],
+    "reward": "Meowth (emblem)",
+    "secret": true
   },
   {
     "expansionId": "B2",
@@ -519,7 +604,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2",
@@ -562,7 +648,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2",
@@ -585,7 +672,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2",
@@ -600,81 +688,7 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
-  },
-  {
-    "expansionId": "B2",
-    "name": "Pokémon and the Town Festival",
-    "requiredCards": [
-      {
-        "options": ["B2-2"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-3"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-18"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-22"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-32"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-37"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-61"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-67"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-71"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-130"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-134"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-137"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-143"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-159"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-172"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-194"],
-        "amount": 1
-      },
-      {
-        "options": ["B2-204"],
-        "amount": 1
-      }
-    ],
-    "reward": "Meowth (emblem)"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/B2a-missions.json
+++ b/frontend/assets/themed-collections/B2a-missions.json
@@ -14,13 +14,10 @@
       {
         "options": ["B2a-3", "B2a-100", "B2a-110"],
         "amount": 1
-      },
-      {
-        "options": ["B2a-118"],
-        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Paldean Wonders) ×10"
+    "reward": "Shinedust ×1000",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -39,7 +36,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Paldean Wonders) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -58,7 +56,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Paldean Wonders) ×4"
+    "reward": "Shinedust ×400",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -73,7 +72,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Paldean Wonders) ×6"
+    "reward": "Shinedust ×600",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -88,7 +88,7 @@
         "amount": 1
       },
       {
-        "options": ["B2a-37", "B2a-102", "B2a-112"],
+        "options": ["B2a-37", "B2a-102", "B2a-112", "P-B-41"],
         "amount": 1
       },
       {
@@ -96,7 +96,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Paldean Wonders) ×19"
+    "reward": "Shinedust ×1900",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -111,7 +112,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Paldean Wonders) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -122,11 +124,12 @@
         "amount": 1
       },
       {
-        "options": ["B2a-91", "B2a-108"],
+        "options": ["B2a-91", "B2a-108", "B2a-115"],
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Paldean Wonders) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -145,7 +148,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Paldean Wonders) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -172,7 +176,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Paldean Wonders) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -187,7 +192,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Paldean Wonders) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -198,7 +204,8 @@
         "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Paldean Wonders) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2a",
@@ -209,7 +216,24 @@
         "amount": 5
       }
     ],
-    "reward": "Iono (profile icon)"
+    "reward": "Iono (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B2a",
+    "name": "Coin Collecting",
+    "requiredCards": [
+      {
+        "options": ["B2a-96"],
+        "amount": 1
+      },
+      {
+        "options": ["B2a-114"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2a",
@@ -240,7 +264,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2a",
@@ -267,22 +292,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
-  },
-  {
-    "expansionId": "B2a",
-    "name": "Coin Collecting",
-    "requiredCards": [
-      {
-        "options": ["B2a-96"],
-        "amount": 1
-      },
-      {
-        "options": ["B2a-114"],
-        "amount": 1
-      }
-    ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2a",
@@ -333,6 +344,7 @@
         "amount": 1
       }
     ],
-    "reward": "Mabosstiff (emblem)"
+    "reward": "Mabosstiff (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/B2b-missions.json
+++ b/frontend/assets/themed-collections/B2b-missions.json
@@ -12,11 +12,12 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Mega Shine) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2b",
-    "name": "Diglett on the Cliff's Edge",
+    "name": "Diglett on the Cliff’s Edge",
     "requiredCards": [
       {
         "options": ["B2b-33"],
@@ -27,7 +28,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Mega Shine) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2b",
@@ -46,7 +48,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Mega Shine) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2b",
@@ -61,7 +64,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Mega Shine) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2b",
@@ -76,7 +80,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Shine) ×5"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "B2b",
@@ -91,7 +96,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Mega Shine) ×1"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×100<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2b",
@@ -102,11 +108,12 @@
         "amount": 5
       }
     ],
-    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2<br />Emblem Ticket (Mega Shine) ×2"
+    "reward": "Wonder Hourglass ×12<br />Shinedust ×200<br />Shop Ticket ×2",
+    "secret": false
   },
   {
     "expansionId": "B2b",
-    "name": "Dratini's Evolution",
+    "name": "Dratini’s Evolution",
     "requiredCards": [
       {
         "options": ["B2b-51"],
@@ -121,7 +128,8 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Shine) ×5"
+    "reward": "Shinedust ×500",
+    "secret": false
   },
   {
     "expansionId": "B2b",
@@ -144,156 +152,48 @@
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Shine) ×13"
+    "reward": "Shinedust ×1300",
+    "secret": false
   },
   {
     "expansionId": "B2b",
     "name": "Seeking Prey from the Shadows",
     "requiredCards": [
       {
-        "options": ["B2b-39", "B2b-79", "B2b-114"],
-        "amount": 1
+        "options": ["B2b-37", "B2b-100", "P-B-47"],
+        "amount": 4
       },
       {
-        "amount": "4",
-        "options": ["B2b-37", "B2b-100", "B2b-38", "B2b-101"]
+        "options": ["B2b-39", "B2b-79", "B2b-114"],
+        "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Shine) ×13"
+    "reward": "Shinedust ×1300",
+    "secret": false
   },
   {
     "expansionId": "B2b",
     "name": "Shiny Radiance",
     "requiredCards": [
       {
-        "options": ["B2b-87"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-88"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-89"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-90"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-91"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-92"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-93"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-94"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-95"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-96"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-97"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-98"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-99"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-100"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-101"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-102"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-103"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-104"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-105"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-106"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-107"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-108"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-109"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-110"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-111"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-112"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-113"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-114"],
-        "amount": 1
-      },
-      {
-        "options": ["B2b-115"],
+        "options": ["B2b-1", "B2b-87"],
         "amount": 1
       }
     ],
-    "reward": "Emblem Ticket (Mega Shine) ×7"
+    "reward": "Shinedust ×700",
+    "secret": false
   },
   {
     "expansionId": "B2b",
-    "name": "Collect 3 Morpeko",
+    "name": "Collect 3 Morpeko cards",
     "requiredCards": [
       {
         "options": ["B2b-45"],
         "amount": 3
       }
     ],
-    "reward": "Morpeko (profile icon)"
+    "reward": "Morpeko (profile icon)",
+    "secret": false
   },
   {
     "expansionId": "B2b",
@@ -396,7 +296,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2b",
@@ -423,7 +324,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2b",
@@ -454,7 +356,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2b",
@@ -469,7 +372,8 @@
         "amount": 1
       }
     ],
-    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10"
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
   },
   {
     "expansionId": "B2b",
@@ -596,6 +500,7 @@
         "amount": 1
       }
     ],
-    "reward": "Shiny Mew (emblem)"
+    "reward": "Shiny Mew (emblem)",
+    "secret": true
   }
 ]

--- a/frontend/assets/themed-collections/B3-missions.json
+++ b/frontend/assets/themed-collections/B3-missions.json
@@ -1,1 +1,534 @@
-[]
+[
+  {
+    "expansionId": "B3",
+    "name": "Pokémon That Love Cleaning!",
+    "requiredCards": [
+      {
+        "options": ["B3-142"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-143", "B3-179"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-147"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": false
+  },
+  {
+    "expansionId": "B3",
+    "name": "Castform and the Weather",
+    "requiredCards": [
+      {
+        "options": ["B3-24"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-40"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-41"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-133", "B3-178"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": false
+  },
+  {
+    "expansionId": "B3",
+    "name": "Friendly...Bear Cubs?",
+    "requiredCards": [
+      {
+        "options": ["B3-46"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-90"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-97", "B3-172"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-131"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": false
+  },
+  {
+    "expansionId": "B3",
+    "name": "Collect 5 Victini cards",
+    "requiredCards": [
+      {
+        "options": ["B3-25"],
+        "amount": 5
+      }
+    ],
+    "reward": "Victini (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B3",
+    "name": "Collect 3 Sobble cards",
+    "requiredCards": [
+      {
+        "options": ["B3-48", "B3-203"],
+        "amount": 3
+      }
+    ],
+    "reward": "Sobble (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B3",
+    "name": "Collect 5 Gallade cards",
+    "requiredCards": [
+      {
+        "options": ["B3-84"],
+        "amount": 5
+      }
+    ],
+    "reward": "Gallade (profile icon)",
+    "secret": false
+  },
+  {
+    "expansionId": "B3",
+    "name": "Trading Punches with Mega Lucario",
+    "requiredCards": [
+      {
+        "options": ["B3-46"],
+        "amount": 5
+      },
+      {
+        "options": ["B3-81", "B3-184", "B3-204"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Mega Sceptile and the Power of Tails",
+    "requiredCards": [
+      {
+        "options": ["B3-5", "B3-156"],
+        "amount": 3
+      },
+      {
+        "options": ["B3-8", "B3-180", "B3-194"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Mega Camerupt and Explosive Eruptions",
+    "requiredCards": [
+      {
+        "options": ["B3-55"],
+        "amount": 3
+      },
+      {
+        "options": ["B3-23", "B3-181", "B3-195"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Mega Audino and the Power of Healing",
+    "requiredCards": [
+      {
+        "options": ["B3-19"],
+        "amount": 3
+      },
+      {
+        "options": ["B3-141", "B3-189", "B3-202"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "A Fight for Survival in the Arena!",
+    "requiredCards": [
+      {
+        "options": ["B3-74"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-84"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-85"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-86"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-91"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-154"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Life in the Rain",
+    "requiredCards": [
+      {
+        "options": ["B3-15"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-35"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-40"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-60"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-152"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-158"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-203"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Desert Ecosystem",
+    "requiredCards": [
+      {
+        "options": ["B3-76"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-95"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-96"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-125"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-126", "B3-188", "B3-201"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×12<br />Shop Ticket ×2",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Pulsing Aura Museum 1",
+    "requiredCards": [
+      {
+        "options": ["B3-156"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-157"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-158"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-159"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-160"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-161"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-162"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-163"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-164"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-165"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-166"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-167"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-168"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-169"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-170"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-171"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-172"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-173"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-174"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-175"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-176"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-177"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-178"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-179"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Pulsing Aura Museum 2",
+    "requiredCards": [
+      {
+        "options": ["B3-190"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-191"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-192"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-193"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Pulsing Aura Museum 3",
+    "requiredCards": [
+      {
+        "options": ["B3-194"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-195"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-196"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-197"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-198"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-199"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-200"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-201"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-202"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Pulsing Aura: Immersive Experience",
+    "requiredCards": [
+      {
+        "options": ["B3-203"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-204"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Mega Sceptile’s Evolution Journey",
+    "requiredCards": [
+      {
+        "options": ["B3-156"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-157"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-194"],
+        "amount": 1
+      }
+    ],
+    "reward": "Wonder Hourglass ×36<br />Pack Hourglass ×12<br />Shop Ticket ×10",
+    "secret": true
+  },
+  {
+    "expansionId": "B3",
+    "name": "Sobble and Rainy Scenery",
+    "requiredCards": [
+      {
+        "options": ["B3-9"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-14"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-15"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-19"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-21"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-33"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-35"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-37", "B3-182", "B3-196"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-38"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-40"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-60"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-158"],
+        "amount": 1
+      },
+      {
+        "options": ["B3-203"],
+        "amount": 1
+      }
+    ],
+    "reward": "Sobble (emblem)",
+    "secret": true
+  }
+]

--- a/frontend/assets/tools_translations.json
+++ b/frontend/assets/tools_translations.json
@@ -481,42 +481,42 @@
   },
   "field blower": {
     "en-US": "Field Blower",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Nettoyage de Terrain",
+    "es-ES": "Soplador de Campo",
+    "pt-BR": "Ventilador de Campo",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Feldgebläse"
   },
   "lucky egg": {
     "en-US": "Lucky Egg",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Œuf Chance",
+    "es-ES": "Huevo Suerte",
+    "pt-BR": "Ovo da Sorte",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Glücks-Ei"
   },
   "fragrant forest": {
     "en-US": "Fragrant Forest",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Forêt Parfumée",
+    "es-ES": "Bosque Aromático",
+    "pt-BR": "Floresta Perfumada",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Wohlriechender Wald"
   },
   "arena of antiquity": {
     "en-US": "Arena of Antiquity",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Colisée Antique",
+    "es-ES": "Arena Arcaica",
+    "pt-BR": "Arena da Antiguidade",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Arena des Altertums"
   },
   "bounded field": {
     "en-US": "Bounded Field",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Champ Barrière",
+    "es-ES": "Campo Delimitado",
+    "pt-BR": "Campo Demarcado",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Abgegrenztes Feld"
   }
 }

--- a/frontend/assets/trainers_translations.json
+++ b/frontend/assets/trainers_translations.json
@@ -521,34 +521,34 @@
   },
   "korrina": {
     "en-US": "Korrina",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Cornélia",
+    "es-ES": "Corelia",
+    "pt-BR": "Korrina",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Connie"
   },
   "cabbie": {
     "en-US": "Cabbie",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Chauffeur de Taxi",
+    "es-ES": "Aerotaxista",
+    "pt-BR": "Taxista",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Taxipilot"
   },
   "cheren": {
     "en-US": "Cheren",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Tcheren",
+    "es-ES": "Cheren",
+    "pt-BR": "Cheren",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Cheren"
   },
   "parasol lady": {
     "en-US": "Parasol Lady",
-    "fr-FR": null,
-    "es-ES": null,
-    "pt-BR": null,
+    "fr-FR": "Fille au Parapluie",
+    "es-ES": "Dama Parasol",
+    "pt-BR": "Dama de Sombrinha",
     "it-IT": null,
-    "de-DE": null
+    "de-DE": "Schirmdame"
   }
 }

--- a/frontend/src/components/Mission.tsx
+++ b/frontend/src/components/Mission.tsx
@@ -31,6 +31,8 @@ function parseRewards(rewardStr?: string): RewardItem[] {
       type = 'pack-hourglass'
     } else if (label === 'Shop Ticket') {
       type = 'shop-ticket'
+    } else if (label === 'Shinedust') {
+      type = 'shinedust'
     } else if (label.startsWith('Emblem Ticket')) {
       type = 'emblem-ticket'
     } else if (label.endsWith('(emblem)')) {
@@ -53,6 +55,7 @@ const rewardConfig: Record<string, { emoji: string; bg: string; short: (label: s
   'wonder-hourglass': { emoji: '⏳', bg: 'bg-yellow-600', short: () => 'Wonder Hourglass' },
   'pack-hourglass': { emoji: '⏳', bg: 'bg-orange-600', short: () => 'Pack Hourglass' },
   'shop-ticket': { emoji: '🎫', bg: 'bg-blue-600', short: () => 'Shop Ticket' },
+  shinedust: { emoji: '✨', bg: 'bg-rose-500', short: () => 'Shinedust' },
   'emblem-ticket': { emoji: '🎟️', bg: 'bg-purple-700', short: () => 'Emblem Ticket' },
   emblem: { emoji: '🏅', bg: 'bg-amber-600', short: (label) => label.replace(' (emblem)', '') },
   'profile-icon': { emoji: '👤', bg: 'bg-teal-600', short: (label) => label.replace(' (profile icon)', '') },

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -110,19 +110,8 @@ export type MissionType = 'all' | 'normal' | 'secret' | 'complete'
 
 export function getMissionType(mission: Mission): Exclude<MissionType, 'all'> {
   const name = mission.name.toLowerCase()
-  const reward = (mission.reward || '').toLowerCase()
   if (name.includes('complete') || name.includes('pokedex') || name.includes('pokédex') || name.endsWith('immersive experience')) {
     return 'complete'
   }
-  if (
-    name.includes('museum') ||
-    name.startsWith('collect ') ||
-    name.includes('immersive') ||
-    reward.includes('pack hourglass') ||
-    (reward.includes('(emblem)') && !reward.includes('emblem ticket')) ||
-    mission.requiredCards.some((card) => card.amount > 1)
-  ) {
-    return 'secret'
-  }
-  return 'normal'
+  return mission.secret ? 'secret' : 'normal'
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -185,6 +185,7 @@ export interface Mission {
   requiredCards: MissionCard[]
   expansionId: ExpansionId
   reward?: string
+  secret?: boolean
   completed?: boolean
 }
 

--- a/scripts/scrape-missions.js
+++ b/scripts/scrape-missions.js
@@ -1,147 +1,168 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
-import path from 'node:path'
 import * as cheerio from 'cheerio'
-import fetch from 'node-fetch'
 
-const BASE_URL = 'https://bulbapedia.bulbagarden.net/wiki'
-const targetDir = './frontend/assets/themed-collections/'
-const expansions = ['B1a', 'B2', 'B2a', 'B2b']
-// const expansions = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'A3a', 'A3b', 'A4', 'A4a']
-const expansionToName = {
-  A1: 'Genetic_Apex',
-  A1a: 'Mythical_Island',
-  A2: 'Space-Time_Smackdown',
-  A2a: 'Triumphant_Light',
-  A2b: 'Shining_Revelry',
-  A3: 'Celestial_Guardians',
-  A3a: 'Extradimensional_Crisis',
-  A3b: 'Eevee_Grove',
-  A4: 'Wisdom of Sea and Sky',
-  A4a: 'Secluded Springs',
-  A4b: 'Deluxe Pack: ex',
-  B1: 'Mega Rising',
-  B1a: 'Crimson Blaze',
-  B2: 'Fantastical Parade',
-  B2a: 'Paldean Wonders',
-  B2b: 'Mega Shine',
-}
+const BASE_URL = 'https://www.pokemon-zone.com/themed-collections'
+const TARGET_DIR = './frontend/assets/themed-collections/'
+const CARDS_PATH = './frontend/assets/cards.json'
+const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36'
 
-async function fetchHTML(url) {
-  const response = await fetch(url)
-  const text = await response.text()
+const expansions = ['A1', 'A1a', 'A2', 'A2a', 'A2b', 'A3', 'A3a', 'A3b', 'A4', 'A4a', 'A4b', 'B1', 'B1a', 'B2', 'B2a', 'B2b', 'B3']
+
+const allCards = JSON.parse(fs.readFileSync(CARDS_PATH, 'utf8'))
+const cardById = new Map(allCards.map((c) => [c.card_id, c]))
+const cardByInternalId = new Map(allCards.map((c) => [c.internal_id, c]))
+
+// pokemon-zone is behind Cloudflare and rejects node-fetch. Shell out to curl with full browser headers.
+function fetchHTML(url) {
+  const args = [
+    '-sL',
+    '--compressed',
+    '--fail',
+    '--retry',
+    '3',
+    '--retry-delay',
+    '5',
+    '-H',
+    `User-Agent: ${UA}`,
+    '-H',
+    'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+    '-H',
+    'Accept-Language: en-US,en;q=0.9',
+    '-H',
+    'Sec-Fetch-Dest: document',
+    '-H',
+    'Sec-Fetch-Mode: navigate',
+    '-H',
+    'Upgrade-Insecure-Requests: 1',
+    url,
+  ]
+  const text = execFileSync('curl', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })
   return cheerio.load(text)
 }
 
-function parseCards($, cards, expansion) {
-  const cardsList = []
-  let isOfTheFollowing = false
-  const combinationCard = {}
-  cards.contents().each((_i, elem) => {
-    const line = $(elem).text()
-    const numOfFollowing = line.match(/\d+ of the following:/)
-    const numOfCombination = line.match(/\d+ in any combination of:/)
-    if (numOfFollowing != null) {
-      isOfTheFollowing = true
-      combinationCard.amount = numOfFollowing[0].slice(0, -18)
-      combinationCard.options = []
-    } else if (numOfCombination != null) {
-      isOfTheFollowing = true
-      combinationCard.amount = numOfCombination[0].slice(0, -23)
-      combinationCard.options = []
-    } else {
-      const ids = line.match(/#\d\d\d/g)
-      if (ids != null) {
-        const options = ids.map((id) => `${expansion}-${Number.parseInt(id.slice(1), 10)}`)
-        if (isOfTheFollowing) {
-          combinationCard.options = combinationCard.options.concat(options)
-        } else {
-          const card = {}
-          card.options = options
-          const amount = line.match(/×\d+/g)
-          if (amount != null) {
-            card.amount = Number.parseInt(amount[0].slice(1), 10)
-          } else {
-            card.amount = 1
-          }
-          cardsList.push(card)
-        }
+// Pokemon-zone item titles like "Shop ticket" need normalizing to match the UI's expected labels.
+function normalizeRewardLabel(raw) {
+  // Title-case each word, but preserve parenthesized suffixes verbatim (lowercase inside).
+  const segs = raw.split(/(\s\([^)]+\))/)
+  return segs
+    .map((seg, i) => {
+      if (i % 2 === 1) {
+        return seg.toLowerCase()
       }
-    }
-  })
-  if (isOfTheFollowing) {
-    cardsList.push(combinationCard)
-  }
-  return cardsList
+      return seg.replace(/\b\w/g, (m) => m.toUpperCase())
+    })
+    .join('')
 }
 
-async function getExpansionMissions(expansion) {
-  const expansionUrl = `${BASE_URL}/${expansionToName[expansion]}_(TCG_Pocket)#Themed_Collections`
-  console.log(`Fetching details for ${expansionUrl}...`)
-  try {
-    const $ = await fetchHTML(expansionUrl)
-    const missions = []
-    $('table').each((_i, table) => {
-      if ($(table).text().includes('Required cards')) {
-        $(table)
-          .find('tr')
-          .each((_j, row) => {
-            const tableRow = $(row).find('td')
-            const mission = {}
-            mission.expansionId = expansion
-            mission.name = tableRow.eq(0).text()
-            // mission.requiredCards = tableRow.eq(1).text()
-            mission.requiredCards = parseCards($, tableRow.eq(1), expansion)
-            const rewardCell = tableRow.eq(2)
-            const rewardItems = []
+function formatReward(qty, label) {
+  let normalized = normalizeRewardLabel(label)
+  // Pokemon-zone uses "(icon)" for profile icons; legacy data uses "(profile icon)".
+  normalized = normalized.replace(/\s\(icon\)$/i, ' (profile icon)')
+  if (qty === '1' && /\(emblem\)|\(profile icon\)|\(icon\)|\(cover\)|\(backdrop\)$/i.test(normalized)) {
+    return normalized
+  }
+  return `${normalized} ×${qty}`
+}
 
-            // Get text content from each child node or text node, respecting <br> tags
-            rewardCell.contents().each((_k, node) => {
-              if (node.type === 'text') {
-                // Add text content to rewards array if it's not just whitespace
-                const text = $(node).text().trim()
-                if (text) {
-                  rewardItems.push(text)
-                }
-              } else if (node.name === 'br') {
-                // Don't need to do anything special for <br> tags as we're collecting items separately
-              } else if (node.name) {
-                // Handle other HTML elements (spans with images, etc.)
-                const text = $(node).text().trim()
-                if (text) {
-                  rewardItems.push(text)
-                }
-              }
-            })
-
-            // Join the reward items with newlines and remove extra spaces
-            mission.reward = rewardItems.map((item) => item.replace(/\s+/g, ' ').trim()).join('<br />')
-            if (mission.name !== '') {
-              missions.push(mission)
-            }
-          })
-      }
-    })
-    return missions
-  } catch (error) {
-    console.error(`Error fetching missions for ${expansionUrl}:`, error)
+function extractCardId(altText) {
+  const m = altText.match(/\(([A-Z]\d+[a-z]?)\)\s*#(\d+)/)
+  if (!m) {
     return null
   }
+  return `${m[1]}-${Number.parseInt(m[2], 10)}`
 }
 
-async function scrapeMissions() {
-  for (const expansion of expansions) {
-    try {
-      fs.mkdirSync(targetDir, { recursive: true })
+function resolveAlternates(cardId) {
+  const card = cardById.get(cardId)
+  if (!card) {
+    return [cardId]
+  }
+  const ids = card.alternate_versions
+    .map((iid) => cardByInternalId.get(iid))
+    .filter(Boolean)
+    .map((c) => c.card_id)
+  return ids.length > 0 ? ids : [cardId]
+}
 
-      const missions = await getExpansionMissions(expansion)
-      console.log(`Scraping completed. Found ${missions.length} missions for ${expansion}.`)
+function parseMissionCard($, $card) {
+  const title = $card.find('.theme-collection-mission-card__title').first().text().trim()
 
-      fs.writeFileSync(path.join(targetDir, `${expansion}-missions.json`), JSON.stringify(missions, null, 2))
-      console.log('Cards saved to %s-missions.json', expansion)
-    } catch (error) {
-      console.error('Error scraping missions:', error)
+  const rewards = []
+  $card.find('.theme-collection-mission-card__rewards .icon-list__item .common-item-icon').each((_i, el) => {
+    const titleAttr = $(el).attr('title') || ''
+    const m = titleAttr.match(/^(\d+)x\s+(.+)$/)
+    if (m) {
+      rewards.push(formatReward(m[1], m[2].trim()))
     }
+  })
+
+  const slots = []
+  $card.find('.theme-collection-mission-card__cards > figure').each((_i, fig) => {
+    const $fig = $(fig)
+    const altText = $fig.find('img').attr('alt') || ''
+    const cardId = extractCardId(altText)
+    if (!cardId) {
+      return
+    }
+    const countText = $fig.find('.theme-collection-mission-card__card-count').text().trim()
+    // "+N Card(s)" inside a figure indicates this slot has alternate-art versions; resolve via cards.json.
+    const hasAlternates = /\+\d+\s+Cards?/i.test(countText)
+    slots.push({ cardId, hasAlternates })
+  })
+
+  // Group consecutive identical slots into one requirement with amount = duplicate count.
+  const requiredCards = []
+  for (const slot of slots) {
+    const options = slot.hasAlternates ? resolveAlternates(slot.cardId) : [slot.cardId]
+    const last = requiredCards[requiredCards.length - 1]
+    if (last && JSON.stringify(last.options) === JSON.stringify(options)) {
+      last.amount += 1
+    } else {
+      requiredCards.push({ options, amount: 1 })
+    }
+  }
+
+  return { name: title, requiredCards, reward: rewards.join('<br />') }
+}
+
+function scrapeExpansion(expansionId) {
+  const url = `${BASE_URL}/${expansionId.toLowerCase()}`
+  console.log(`Fetching ${url}`)
+  const $ = fetchHTML(url)
+
+  const missions = []
+  const headers = $('.themed-collection-detail__category_header').toArray()
+  for (const h of headers) {
+    const $h = $(h)
+    const headerText = $h.text().trim()
+    const isSecret = /secret/i.test(headerText)
+    let $node = $h.next()
+    while ($node.length && !$node.hasClass('themed-collection-detail__category_header')) {
+      $node.find('.theme-collection-mission-card').each((_i, el) => {
+        const m = parseMissionCard($, $(el))
+        missions.push({ expansionId, name: m.name, requiredCards: m.requiredCards, reward: m.reward, secret: isSecret })
+      })
+      $node = $node.next()
+    }
+  }
+  return missions
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+function main() {
+  for (const [i, exp] of expansions.entries()) {
+    if (i > 0) {
+      sleep(1500)
+    }
+    const missions = scrapeExpansion(exp)
+    const outPath = `${TARGET_DIR}${exp}-missions.json`
+    fs.writeFileSync(outPath, `${JSON.stringify(missions, null, 2)}\n`)
+    console.log(`  → ${exp}: ${missions.length} missions written`)
   }
 }
 
-scrapeMissions().catch(console.error)
+main()


### PR DESCRIPTION
 ## Summary

  Two related follow-ups after the Pulsing Aura (B3) launch:

  1. **B3 translations.** Filled 232 `null` entries in `pokemon_translations.json`, `tools_translations.json` and
  `trainers_translations.json` for fr-FR, es-ES, pt-BR and de-DE. Sourced from pocket.pokemongohub.net once the Pulsing
  Aura set was published there. it-IT remains `null` (no source available — the app falls back to en-US).

  2. **Themed collections refresh.** The in-game rewards for themed collection missions changed across every set (Emblem
   Tickets → Shinedust, etc.) and the existing data was stale. Rewrote `scripts/scrape-missions.js` to source from
  `pokemon-zone.com` instead of bulbapedia (which doesn't publish the post-update rewards) and regenerated all 17
  mission JSONs.

  ## Mission classification fix

  Pokemon-zone exposes an explicit "Normal Missions" / "Secret Missions" split, so the data now carries a `secret:
  boolean` field per mission. `getMissionType` reads it directly instead of relying on heuristics that misclassified
  some missions:

  - `Collect 3 Cramorant cards` (B2) was being shown as **secret** (heuristic matched `startsWith('collect ')`) — the
  game lists it as **normal**.
  - `Pokémon and the Town Festival` (B2) was being shown as **normal** — the game lists it as **secret**.

  The `complete` classification (Pokedex / Immersive Experience) stays as a UI-side name match.

  ## UI

  Added a `shinedust` reward type (✨, rose) in `Mission.tsx` since most refreshed rewards include it; previously they
  would have rendered as the generic `special` pink badge.

  ## Type change

  `Mission.secret?: boolean` added to `frontend/src/types/index.ts`. Optional for backwards compatibility, but every
  mission generated by the new scraper carries it.

  ## Out of scope

  - it-IT translations (no published source).
  - Localized banners for non-en-US.
  - Promo cards beyond P-B #48.

  ## Test plan

  - [ ] Open `/#/collection`, select Pulsing Aura → no fallback-to-English Pokémon names in fr/es/pt/de tabs.
  - [ ] Open Missions page, switch type filter between `normal`, `secret`, `complete`, `all` for several sets and
  confirm the listed missions match the in-game theme collection screen.
  - [ ] Spot-check the rewards on a few missions match the in-game rewards (e.g., B2 "Mega Gardevoir and a Magnificent
  Evolution" → `1200x Shinedust`).
  - [ ] Re-run `node scripts/scrape-missions.js` from a clean tree → no diffs.