### PR TITLE
fix: resolve TypeScript errors blocking number field search feature (fixes #912)

### DIFF
--- a/frontend/src/hooks/use-search-state.ts
+++ b/frontend/src/hooks/use-search-state.ts
@@ -12,9 +12,9 @@ function tryParseJson(val: string): unknown {
 
 function getFieldType(field: z.ZodType): 'array' | 'boolean' | 'number' | 'string' | 'unknown' {
   // Unwrap ZodDefault
-  let unwrapped = field
+  let unwrapped: z.ZodTypeAny = field as z.ZodTypeAny
   if (unwrapped instanceof z.ZodDefault) {
-    unwrapped = unwrapped.unwrap()
+    unwrapped = unwrapped.unwrap() as z.ZodTypeAny
   }
 
   // Check for array
@@ -28,12 +28,12 @@ function getFieldType(field: z.ZodType): 'array' | 'boolean' | 'number' | 'strin
   }
 
   // Check for number types
-  if (unwrapped instanceof z.ZodNumber || (unwrapped instanceof z.ZodUnion && unwrapped.options.some((opt: z.ZodType) => opt instanceof z.ZodNumber))) {
+  if (unwrapped instanceof z.ZodNumber || (unwrapped instanceof z.ZodUnion && unwrapped.options.some((opt) => opt instanceof z.ZodNumber))) {
     return 'number'
   }
 
   // Check for string types
-  if (unwrapped instanceof z.ZodString || (unwrapped instanceof z.ZodUnion && unwrapped.options.some((opt: z.ZodType) => opt instanceof z.ZodString))) {
+  if (unwrapped instanceof z.ZodString || (unwrapped instanceof z.ZodUnion && unwrapped.options.some((opt) => opt instanceof z.ZodString))) {
     return 'string'
   }
 
@@ -41,9 +41,9 @@ function getFieldType(field: z.ZodType): 'array' | 'boolean' | 'number' | 'strin
 }
 
 function getArrayElementType(field: z.ZodType): 'string' | 'number' | 'unknown' {
-  let unwrapped = field
+  let unwrapped: z.ZodTypeAny = field as z.ZodTypeAny
   if (unwrapped instanceof z.ZodDefault) {
-    unwrapped = unwrapped.unwrap()
+    unwrapped = unwrapped.unwrap() as z.ZodTypeAny
   }
 
   if (unwrapped instanceof z.ZodArray) {

--- a/frontend/src/hooks/use-search-state.ts
+++ b/frontend/src/hooks/use-search-state.ts
@@ -1,13 +1,67 @@
 import { useSearchParams } from 'react-router'
 import { z } from 'zod'
 
-function safeJson(val: string) {
+function tryParseJson(val: string): unknown {
   try {
     const parsed = JSON.parse(val)
     return parsed === null ? val : parsed
   } catch {
     return val
   }
+}
+
+function getFieldType(field: z.ZodType): 'array' | 'boolean' | 'number' | 'string' | 'unknown' {
+  // Unwrap ZodDefault
+  let unwrapped = field
+  if (unwrapped instanceof z.ZodDefault) {
+    unwrapped = unwrapped.unwrap()
+  }
+
+  // Check for array
+  if (unwrapped instanceof z.ZodArray) {
+    return 'array'
+  }
+
+  // Check for boolean
+  if (unwrapped instanceof z.ZodBoolean) {
+    return 'boolean'
+  }
+
+  // Check for number types
+  if (unwrapped instanceof z.ZodNumber || (unwrapped instanceof z.ZodUnion && unwrapped.options.some((opt: z.ZodType) => opt instanceof z.ZodNumber))) {
+    return 'number'
+  }
+
+  // Check for string types
+  if (unwrapped instanceof z.ZodString || (unwrapped instanceof z.ZodUnion && unwrapped.options.some((opt: z.ZodType) => opt instanceof z.ZodString))) {
+    return 'string'
+  }
+
+  return 'unknown'
+}
+
+function getArrayElementType(field: z.ZodType): 'string' | 'number' | 'unknown' {
+  let unwrapped = field
+  if (unwrapped instanceof z.ZodDefault) {
+    unwrapped = unwrapped.unwrap()
+  }
+
+  if (unwrapped instanceof z.ZodArray) {
+    const elementType = unwrapped.element
+
+    if (elementType instanceof z.ZodString) {
+      return 'string'
+    }
+    if (elementType instanceof z.ZodNumber) {
+      return 'number'
+    }
+    if (elementType instanceof z.ZodEnum || elementType instanceof z.ZodLiteral || elementType instanceof z.ZodUnion) {
+      // Enums and unions typically contain strings
+      return 'string'
+    }
+  }
+
+  return 'unknown'
 }
 
 export default function useSearchState<T extends z.ZodObject>(schema: T): [z.infer<T>, (updates: Partial<z.infer<T>>) => void, number] {
@@ -24,7 +78,9 @@ export default function useSearchState<T extends z.ZodObject>(schema: T): [z.inf
         continue
       }
 
-      if (field instanceof z.ZodArray || (field instanceof z.ZodDefault && field.unwrap() instanceof z.ZodArray)) {
+      const fieldType = getFieldType(field)
+
+      if (fieldType === 'array') {
         if (!Array.isArray(val)) {
           console.warn(`useSearchState(): ${key} should be an array`)
           continue
@@ -50,10 +106,31 @@ export default function useSearchState<T extends z.ZodObject>(schema: T): [z.inf
       if (!searchParams.has(key)) {
         return [key, undefined]
       }
-      if (field instanceof z.ZodArray || (field instanceof z.ZodDefault && field.unwrap() instanceof z.ZodArray)) {
-        return [key, searchParams.get(key)?.split(',').map(safeJson)]
+
+      const fieldType = getFieldType(field)
+      const paramValue = searchParams.get(key) as string
+
+      if (fieldType === 'array') {
+        const elementType = getArrayElementType(field)
+        const elements = paramValue.split(',')
+
+        if (elementType === 'string') {
+          // For string arrays, keep elements as strings
+          return [key, elements]
+        } else if (elementType === 'number') {
+          // For number arrays, parse each element as number
+          return [key, elements.map(tryParseJson)]
+        } else {
+          // For unknown element types, try to parse
+          return [key, elements.map(tryParseJson)]
+        }
+      } else if (fieldType === 'boolean') {
+        return [key, paramValue === 'true']
+      } else if (fieldType === 'number') {
+        return [key, tryParseJson(paramValue)]
       } else {
-        return [key, safeJson(searchParams.get(key) as string)]
+        // For strings and unknown types, keep as string
+        return [key, paramValue]
       }
     }),
   )


### PR DESCRIPTION
## Problem
Searching by numbers was broken: entering "123" in a string field would be parsed as the number 123, causing schema validation to fail.

## Root Cause
The search hook was blindly parsing all URL parameters through JSON, converting string numbers like "123" to actual numbers.

## Solution
Smart type inspection of Zod schemas:
1. Unwrap Zod schemas to see the actual expected type (since schemas can be nested like `z.default('value')`)
2. Only parse numbers when the schema expects a number
3. Keep strings as strings when the schema expects strings

This required proper TypeScript typing using `z.ZodTypeAny` and type assertions to handle the unwrapping correctly.

## Result
- "123" in a card name field → stays "123" (string) ✓
- "123" in a count field → becomes 123 (number) ✓
- Build passes cleanly

Fixes #912