### PR TITLE
Order liked decks

### DIFF
--- a/frontend/src/pages/decks/Decks.tsx
+++ b/frontend/src/pages/decks/Decks.tsx
@@ -37,7 +37,7 @@ export default function Decks() {
           className="w-full"
           options={deckKinds}
           value={filters.from}
-          onChange={(from) => setFilters({ from })}
+          onChange={(from) => setFilters({ from, page: 0 })}
           show={(from) => `${capitalize(from)} decks`}
         />
         {filters.from === 'community' && (

--- a/frontend/src/services/decks/deckService.ts
+++ b/frontend/src/services/decks/deckService.ts
@@ -44,7 +44,7 @@ export async function getDecks(filters: DeckFilters) {
   if (filters.from === 'my') {
     tbl = tbl.from('decks').select('*', { count: 'exact' }).order('updated_at', { ascending: false })
   } else if (filters.from === 'liked') {
-    tbl = tbl.from('deck_likes').select('*, public_decks!id(*)', { count: 'exact' })
+    tbl = tbl.from('deck_likes').select('*, public_decks!id(*)', { count: 'exact' }).order('created_at', { ascending: false })
   } else if (filters.from === 'community') {
     tbl = tbl.from('public_decks').select('*', { count: 'exact' })
     if (filters.orderby === 'popular') {


### PR DESCRIPTION
Closes #835. Now most recently liked decks are on top.

Also fixes a bug where switching to a different kind of decks (e.g. community -> liked) with page that was out of bounds for the new kind threw an exception (e.g. when on 4th page of community, but liked decks had only one page).