### PR TITLE
Redesign trade offers

### DIFF
--- a/frontend/src/pages/trade/TradeOffers.tsx
+++ b/frontend/src/pages/trade/TradeOffers.tsx
@@ -38,7 +38,7 @@ function TradeOffers() {
   })
 
   return (
-    <div className="flex flex-col items-center mx-auto gap-6 sm:px-4 mb-12 w-full">
+    <div className="flex flex-col items-center mx-auto gap-4 sm:px-4 mb-12 w-full">
       {friendIds.map((friend_id) => (
         <TradePartner key={friend_id} friendId={friend_id} activeTrades={friends[friend_id] as TradeRow[]} />
       ))}

--- a/frontend/src/pages/trade/components/TradeList.tsx
+++ b/frontend/src/pages/trade/components/TradeList.tsx
@@ -17,7 +17,7 @@ function TradeList({ children, trades }: Props) {
   }
 
   return (
-    <div className="rounded-lg border-1 border-neutral-700 border-solid p-1 md:p-2">
+    <div>
       <ul className="flex flex-col gap-2 md:gap-0">
         {trades
           .toSorted((a, b) => (a.created_at > b.created_at ? -1 : 1))

--- a/frontend/src/pages/trade/components/TradeListRow.tsx
+++ b/frontend/src/pages/trade/components/TradeListRow.tsx
@@ -56,18 +56,18 @@ export const TradeListRow: FC<Props> = ({ row, selectedTradeId, setSelectedTrade
 
   return (
     <li
-      className={`flex cursor-pointer rounded gap-1 md:gap-2 p-1 ${selectedTradeId === row.id && 'bg-green-900'} hover:bg-neutral-500`}
+      className={`flex cursor-pointer rounded gap-1 md:gap-2 p-1 ${selectedTradeId === row.id && 'bg-green-800/75'} hover:bg-neutral-700`}
       onClick={() => onClick(row)}
     >
       {status(row)}
       <div className="flex flex-col-reverse md:flex-row grow-1 justify-between gap-1 md:gap-2">
         <div className="flex flex-1">
           <ChevronsUp />
-          <CardLine className="flex-1" card_id={yourCard} increment={-1} />
+          <CardLine className="flex-1 bg-neutral-900" card_id={yourCard} increment={-1} />
         </div>
         <div className="flex flex-1">
           <ChevronsDown />
-          <CardLine className="flex-1" card_id={friendCard} increment={1} />
+          <CardLine className="flex-1 bg-neutral-900" card_id={friendCard} increment={1} />
         </div>
       </div>
     </li>

--- a/frontend/src/pages/trade/components/TradePartner.tsx
+++ b/frontend/src/pages/trade/components/TradePartner.tsx
@@ -35,8 +35,8 @@ function TradePartner({ friendId, activeTrades }: TradePartnerProps) {
   }
 
   return (
-    <div className="w-full">
-      <div className="flex justify-between items-center mb-1 mx-1">
+    <div className="w-full p-2 rounded-md border border-neutral-700 bg-neutral-800">
+      <div className="flex justify-between items-center my-1 mx-1">
         <p>
           <span className="text-md">{t('tradingWith')}</span>
           <span className="text-md font-bold"> {friendAccount?.username || friendId} </span>
@@ -63,6 +63,7 @@ function TradePartner({ friendId, activeTrades }: TradePartnerProps) {
           </Link>
         </span>
       </div>
+      <hr className="border-neutral-700 my-2" />
       {viewHistory ? (
         allTrades.isLoading ? (
           <Spinner size="md" />


### PR DESCRIPTION
Redesigns the trade offers page to look more in-line with the rest of the site.

### After

<img width="934" height="502" alt="image" src="https://github.com/user-attachments/assets/1222d530-15d1-44ef-ac6f-1f255db4facb" />

### Before

<img width="909" height="459" alt="image" src="https://github.com/user-attachments/assets/34cf3b05-76aa-4c5e-9f81-3f710a38aef1" />

### Consistency

The `border-neutral-700 bg-neutral-800 hover:bg-neutral-700` boxes are more consistent with the other widgets:

<img width="639" height="321" alt="image" src="https://github.com/user-attachments/assets/7c06be5b-c7ba-49e4-9bbf-cc95177881d4" />

<img width="1316" height="628" alt="image" src="https://github.com/user-attachments/assets/ca6110ff-8313-4d8f-9e22-1d67fcebd6f2" />
