### PR TITLE
Fix doubled /trade history entry

### DIFF
--- a/frontend/src/pages/trade/Trade.tsx
+++ b/frontend/src/pages/trade/Trade.tsx
@@ -17,7 +17,7 @@ function Trade() {
   useEffect(() => {
     // Redirect to offers if at /trade
     if (location.pathname === '/trade') {
-      navigate('/trade/offers')
+      navigate('/trade/offers', { replace: true })
     }
   }, [location.pathname, navigate])
 


### PR DESCRIPTION
Navigating to `/trade` created two history entries, so you had to press the back button twice for it to work, which is annoying.