### PR TITLE
Complete French translations (fr-FR)

### DIFF
--- a/frontend/public/locales/fr-FR/common/packs.json
+++ b/frontend/public/locales/fr-FR/common/packs.json
@@ -25,5 +25,5 @@
   "megagardevoirpack": "Méga-Gardevoir",
   "paldeanwonderspack": "Merveilles de Paldea",
   "megashinepack": "Méga-Rayonnement",
-  "pulsingaurapack": "Pulsing Aura"
+  "pulsingaurapack": "Aura Palpitante"
 }

--- a/frontend/public/locales/fr-FR/common/sets.json
+++ b/frontend/public/locales/fr-FR/common/sets.json
@@ -37,6 +37,6 @@
   "paldeanwonders(b2a)": "Merveilles de Paldea (B2a)",
   "megashine": "Méga-Rayonnement",
   "megashine(b2b)": "Méga-Rayonnement (B2b)",
-  "pulsingaura": "Pulsing Aura",
-  "pulsingaura(b3)": "Pulsing Aura (B3)"
+  "pulsingaura": "Aura Palpitante",
+  "pulsingaura(b3)": "Aura Palpitante (B3)"
 }

--- a/frontend/public/locales/fr-FR/filters.json
+++ b/frontend/public/locales/fr-FR/filters.json
@@ -5,7 +5,7 @@
     "default": "ID de carte",
     "recent": "Mise à jour récemment",
     "expansion-newest": "Plus récent en premier",
-    "rarity": "Rarity",
+    "rarity": "Rareté",
     "type": "Type"
   },
   "f-number": {
@@ -26,9 +26,9 @@
   "carddex": "Card Dex",
   "trading": "Échanges",
   "f-owned": {
-    "all": "All",
-    "owned": "Owned",
-    "missing": "Missing"
+    "all": "Toutes",
+    "owned": "Possédées",
+    "missing": "Manquantes"
   },
   "f-missiontype": {
     "all": "Toutes",

--- a/frontend/public/locales/fr-FR/pages/collection.json
+++ b/frontend/public/locales/fr-FR/pages/collection.json
@@ -6,8 +6,8 @@
     "eligibleCards-singular": "Liste des cartes éligibles : {{options}} option",
     "eligibleCards-plural": "Liste des cartes éligibles : {{options}} options",
     "chanceFrom": "Chance dans {{pack}} : {{chance}}%",
-    "manuallyMarkedComplete": "Manually marked as completed",
-    "manuallyMarkComplete": "Manually mark as complete"
+    "manuallyMarkedComplete": "Marquée manuellement comme terminée",
+    "manuallyMarkComplete": "Marquer manuellement comme terminée"
   },
   "filters": {
     "allFilters": "Tous les filtres",
@@ -19,7 +19,7 @@
     "summary": "{{selected}} sélectionnée(s), {{uniquesOwned}} unique(s) possédée(s), {{totalOwned}} total possédée(s)",
     "mewCardOwned": "Vous avez débloqué la carte spéciale de Mew ! Elle est incluse dans votre total de carte, mais le total dans le jeu n'inclus pas la carte."
   },
-  "collectionOf": "Collection of",
+  "collectionOf": "Collection de",
   "trade": {
     "button": "Copier le message d'échange",
     "publicTradePage": "Page d'échange publique ",

--- a/frontend/public/locales/fr-FR/search-input copy.json
+++ b/frontend/public/locales/fr-FR/search-input copy.json
@@ -1,5 +1,0 @@
-{
-  "search": "Rechercher...",
-  "allTextLabel": "Tous les textes",
-  "allTextTooltip": "À l'exception des noms des cartes, la recherche est effectuée sur les textes de la version anglaise"
-}

--- a/frontend/public/locales/fr-FR/search-input.json
+++ b/frontend/public/locales/fr-FR/search-input.json
@@ -1,5 +1,5 @@
 {
   "search": "Rechercher...",
   "allTextLabel": "Tous les textes",
-  "allTextTooltip": "À l'exception des noms de carte, la recherche se fait sur les textes de la version anglaise"
+  "allTextTooltip": "À l'exception des noms des cartes, la recherche est effectuée sur les textes de la version anglaise"
 }


### PR DESCRIPTION
  ## Complete French translations (fr-FR)

  ### Summary
  Fills in the remaining untranslated strings in the `fr-FR` locale. Every key already existed but a handful had been left in English; this PR translates them and cleans up a stray duplicate file.

  ### Changes

  **`filters.json`**                                                                                                                                                                      
  - `f-sortBy.rarity`: `Rarity` → `Rareté`
  - `f-owned.all`: `All` → `Toutes`
  - `f-owned.owned`: `Owned` → `Possédées`
  - `f-owned.missing`: `Missing` → `Manquantes`

  **`pages/collection.json`**
  - `collectionOf`: `Collection of` → `Collection de`
  - `missionDetail.manuallyMarkedComplete`: → `Marquée manuellement comme terminée`
  - `missionDetail.manuallyMarkComplete`: → `Marquer manuellement comme terminée`

  **`common/packs.json` & `common/sets.json`**
  - `Pulsing Aura` (set B3 + pack) → `Aura Palpitante`

  **`search-input.json`**
  - Refined `allTextTooltip` wording for clarity

  **Cleanup**
  - Removed the stray `search-input copy.json` duplicate file