### PR TITLE
Tweak trade matches algorithm

### DIFF
--- a/frontend/src/pages/trade/TradeMatchesResults.tsx
+++ b/frontend/src/pages/trade/TradeMatchesResults.tsx
@@ -64,7 +64,7 @@ export default function TradeMatchesResults() {
   }
 
   if (data.length === 0) {
-    return <p className="text-xl text-center py-8">{t('noTradePartners')}</p>
+    return <p className="text-lg text-center px-2 py-8">{t('noTradePartners')}</p>
   }
 
   const friendIdSet = new Set(friends.filter((f) => f.state === 'accepted').map((f) => f.friend_id))

--- a/scripts/sql/trade-partners.sql
+++ b/scripts/sql/trade-partners.sql
@@ -9,6 +9,9 @@ WITH recent_accounts AS (
       AND username IS NOT NULL
       AND collection_last_updated IS NOT NULL
       AND ($2::text IS NULL OR language = $2::text)
+      AND collection_last_updated >= now() - interval '4 days'
+      AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
+      AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
     ORDER BY collection_last_updated DESC
     LIMIT 50
 )
@@ -96,6 +99,9 @@ WITH recent_accounts AS (
                 AND ca.amount_owned > COALESCE(ca.amount_wanted, t.to_keep)
         )
         AND ($3::text IS NULL OR language = $3::text)
+        AND collection_last_updated >= now() - interval '4 days'
+        AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
+        AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
     ORDER BY collection_last_updated DESC
     LIMIT 50
 )

--- a/supabase/functions/get-trading-partners/index.ts
+++ b/supabase/functions/get-trading-partners/index.ts
@@ -22,6 +22,9 @@ WITH recent_accounts AS (
       AND username IS NOT NULL
       AND collection_last_updated IS NOT NULL
       AND ($2::text IS NULL OR language = $2::text)
+      AND collection_last_updated >= now() - interval '4 days'
+      AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
+      AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
     ORDER BY collection_last_updated DESC
     LIMIT 50
 )
@@ -110,6 +113,9 @@ WITH recent_accounts AS (
                 AND ca.amount_owned > COALESCE(ca.amount_wanted, t.to_keep)
         )
         AND ($3::text IS NULL OR language = $3::text)
+        AND collection_last_updated >= now() - interval '4 days'
+        AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
+        AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
     ORDER BY collection_last_updated DESC
     LIMIT 50
 )


### PR DESCRIPTION
There is a big problem that people do not accept pending trades (I didn't dig too deep for the reason, but my guess is because they just don't log in to the site). I added a few additional conditions trying to improve this.

1. `collection_last_updated >= now() - interval '4 days'`. Additional safe guard to filter inactive users. Mostly applicable to single card query, which can have significantly lower base number of users. But can also affect less popular languages.
2. `accepted trades < 8`. Give the other person some breathing room to complete their accepted trades. If they have a lot of them, it's rather unlikely that you will make the trade anytime soon. Even if they accept, you will just see a permanent "Trade in progress" in the app.
3. `received trades < 3`. First reason, do not overflow the person with too many requests when they next log in, and possibly route the requests to the next person on the list, resulting in more balanced distribution of pending trades. Second, they might be not accepting their requests because they might be in fact inactive (which should be caught by the condition 1. soon, but this condition might be quicker).

For a reference, there are about 230 users which updated their collection within last 24 hours. The `LIMIT 50` captures only those who did in the last 3 hours. Out of the 230 users, 10 had `accepted trades >= 8`, with the highest being 35. Out of the 230 users, 25 had `received trades >= 3`, with the highest being 48 (!).