### PR TITLE
Redesign find matches form

### DIFF
--- a/frontend/src/components/SelectCard.tsx
+++ b/frontend/src/components/SelectCard.tsx
@@ -1,7 +1,9 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { createContext, useEffect, useState } from 'react'
+import { searchPredicate } from '@/lib/filters'
 import type { Card } from '@/types'
 import { CardLine } from './CardLine'
+import SearchInput from './filters/SearchInput'
 import { Button } from './ui/button'
 import { Dialog, DialogContent, DialogTitle } from './ui/dialog'
 
@@ -16,7 +18,7 @@ export interface ISelectCardContext {
 
 export const SelectCardContext = createContext<ISelectCardContext>({
   selectCard: () => {
-    throw Error("Can't open SelectCardDialog: not in SelectCardContext")
+    throw new Error("Can't open SelectCardDialog: not in SelectCardContext")
   },
 })
 
@@ -27,33 +29,38 @@ export interface Props {
 
 export function SelectCardDialog({ request, onClose }: Props) {
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
+  const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<Card | undefined>(undefined)
   const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     if (!request) {
+      setSearch('')
       setSelected(undefined)
       setSubmitting(false)
     }
   }, [request])
 
   const onSubmit = async () => {
-    if (!selected || submitting) {
+    if (!request || !selected || submitting) {
       return
     }
     setSubmitting(true)
     try {
-      await request?.callback(selected.internal_id)
+      await request.callback(selected.internal_id)
+      setSearch('')
       onClose()
     } finally {
       setSubmitting(false)
     }
   }
 
+  const filteredCards = request?.cards.filter(searchPredicate(search))
+
   const virtualizer = useVirtualizer({
     getScrollElement: () => scrollElement,
-    count: request?.cards.length ?? 0,
-    getItemKey: (index) => request?.cards[index].card_id ?? '',
+    count: filteredCards?.length ?? 0,
+    getItemKey: (index) => filteredCards?.[index].card_id ?? '',
     estimateSize: () => 32,
   })
 
@@ -61,10 +68,11 @@ export function SelectCardDialog({ request, onClose }: Props) {
     <Dialog open={!!request} onOpenChange={(open) => open || onClose()}>
       <DialogContent>
         <DialogTitle>Select a card</DialogTitle>
-        <div ref={setScrollElement} className="mt-2 h-72 rounded-md border border-neutral-700 px-1 overflow-y-auto">
+        <SearchInput setValue={setSearch} />
+        <div ref={setScrollElement} className="h-72 rounded-md border border-neutral-700 px-1 overflow-y-auto">
           <ul style={{ height: `${virtualizer.getTotalSize()}px` }} className="relative">
             {virtualizer.getVirtualItems().map((row) => {
-              const c = request?.cards[row.index] as Card
+              const c = filteredCards?.[row.index] as Card
               return (
                 <button
                   type="button"

--- a/frontend/src/lib/filters.ts
+++ b/frontend/src/lib/filters.ts
@@ -86,27 +86,7 @@ export function getFilteredCards(filters: Filters, cards: Collection, tradingSet
   }
 
   if (filters.search) {
-    const query = filters.search.toLowerCase()
-    const threshold = 2 // tweak if needed
-
-    filteredCards = filteredCards.filter((card) => {
-      const name = getCardNameByLang(card, i18n.language).toLowerCase()
-
-      let filterAllText = false
-      if (filters.allTextSearch) {
-        filterAllText =
-          (card.ability && (card.ability.name.toLowerCase().includes(query) || card.ability.effect.toLowerCase().includes(query))) ||
-          card.attacks.some(
-            (attack) =>
-              attack.name?.toLowerCase().includes(query) || (attack.effect?.toLowerCase() !== 'no effect' && attack.effect?.toLowerCase()?.includes(query)),
-          )
-      }
-      const isExactMatch = name.includes(query)
-      const isFuzzyMatch = levenshtein(name, query) <= threshold
-      const isIdMatch = card.card_id.toLowerCase().includes(query)
-
-      return filterAllText || isExactMatch || isFuzzyMatch || isIdMatch
-    })
+    filteredCards = filteredCards.filter(searchPredicate(filters.search, filters.allTextSearch))
   }
 
   // Fill up `collected` and `updated at`
@@ -142,4 +122,27 @@ export function getFilteredCards(filters: Filters, cards: Collection, tradingSet
   }
 
   return filteredCards
+}
+
+export function searchPredicate(search: string, allTextSearch?: boolean) {
+  const query = search.toLowerCase()
+  const threshold = 2 // tweak if needed
+  return (card: Card) => {
+    const name = getCardNameByLang(card, i18n.language).toLowerCase()
+
+    let filterAllText = false
+    if (allTextSearch) {
+      filterAllText =
+        (card.ability && (card.ability.name.toLowerCase().includes(query) || card.ability.effect.toLowerCase().includes(query))) ||
+        card.attacks.some(
+          (attack) =>
+            attack.name?.toLowerCase().includes(query) || (attack.effect?.toLowerCase() !== 'no effect' && attack.effect?.toLowerCase()?.includes(query)),
+        )
+    }
+    const isExactMatch = name.includes(query)
+    const isFuzzyMatch = levenshtein(name, query) <= threshold
+    const isIdMatch = card.card_id.toLowerCase().includes(query)
+
+    return filterAllText || isExactMatch || isFuzzyMatch || isIdMatch
+  }
 }

--- a/frontend/src/pages/trade/TradeMatches.tsx
+++ b/frontend/src/pages/trade/TradeMatches.tsx
@@ -1,11 +1,10 @@
-import { useVirtualizer } from '@tanstack/react-virtual'
 import i18n from 'i18next'
-import { useEffect, useRef, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
-import { CardLine } from '@/components/CardLine'
 import { DropdownFilter } from '@/components/Filters'
-import SearchInput from '@/components/filters/SearchInput'
+import { SelectCardContext } from '@/components/SelectCard'
 import { Button } from '@/components/ui/button'
 import { getCardByInternalId } from '@/lib/CardsDB'
 import { getFilteredCards } from '@/lib/filters'
@@ -31,9 +30,9 @@ export default function TradeMatches() {
   const { t } = useTranslation(['trade-matches', 'common'])
   const navigate = useNavigate()
 
-  const scrollRef = useRef(null)
-  const [search, setSearch] = useState('')
-  const [selectedCard, setSelectedCard] = useState<number>()
+  const { selectCard } = useContext(SelectCardContext)
+
+  const [selectedCard, setSelectedCard] = useState<number | undefined>(undefined)
   const { data: account } = useAccount()
   const [selectedLanguage, setSelectedLanguage] = useState<GameLanguage | ''>('')
   useEffect(() => {
@@ -41,49 +40,32 @@ export default function TradeMatches() {
       setSelectedLanguage(account.language as GameLanguage)
     }
   }, [account?.language])
-  const cards = getFilteredCards({ search, rarity: [...tradableRarities] }, new Map())
+  const cards = getFilteredCards({ rarity: [...tradableRarities] }, new Map())
   const card = selectedCard && getCardByInternalId(selectedCard)
-
-  const virtualizer = useVirtualizer({
-    getScrollElement: () => scrollRef.current,
-    count: cards.length,
-    getItemKey: (index) => cards[index].card_id,
-    estimateSize: () => 32,
-  })
 
   if (selectedCard && !card) {
     throw new Error('Selected card was not found in the database')
   }
 
   return (
-    <div className="sm:w-sm mx-auto">
-      <SearchInput setValue={setSearch} />
-      <div ref={scrollRef} className="mt-2 h-72 rounded-md border border-neutral-700 px-1 overflow-y-auto">
-        <ul style={{ height: `${virtualizer.getTotalSize()}px` }} className="relative">
-          {virtualizer.getVirtualItems().map((row) => {
-            const c = cards[row.index]
-            return (
-              <button
-                type="button"
-                key={row.key}
-                className="absolute top-0 left-0 w-full cursor-pointer"
-                style={{ height: `${row.size}px`, transform: `translateY(${row.start}px)` }}
-                onClick={() => setSelectedCard((prev) => (prev === c.internal_id ? undefined : c.internal_id))}
-              >
-                <CardLine className={`w-full ${selectedCard === c.internal_id && 'bg-green-900'} hover:bg-neutral-600`} card_id={c.card_id} />
-              </button>
-            )
-          })}
-        </ul>
-      </div>
+    <div className="max-w-xs w-full mx-auto p-4 rounded-md border bg-neutral-800 border-neutral-700">
+      <h1 className="text-lg mb-4">Find trades</h1>
       <DropdownFilter
-        className="mt-2"
+        className="mt-2 bg-neutral-900"
         label="Card language"
         options={['', ...gameLanguages]}
         value={selectedLanguage}
         onChange={setSelectedLanguage}
         show={(x) => (x === '' ? 'Any language' : formatLanguage[x])}
       />
+      <div className="mt-2 flex gap-2">
+        <Button variant="outline" className="flex-1" onClick={() => selectCard({ cards, callback: setSelectedCard })}>
+          {card ? getCardNameByLang(card, i18n.language) : 'Select wanted card'}
+        </Button>
+        <Button variant="outline" className="flex-0" onClick={() => setSelectedCard(undefined)} disabled={selectedCard === undefined}>
+          <Trash2 />
+        </Button>
+      </div>
       <div className="flex gap-2 mt-4">
         <Button className="w-full" onClick={() => navigate(buildUrl(selectedCard, selectedLanguage))}>
           {card ? t('search.byCard', { cardName: getCardNameByLang(card, i18n.language) }) : t('search.allCards')}

--- a/frontend/src/pages/trade/TradeMatches.tsx
+++ b/frontend/src/pages/trade/TradeMatches.tsx
@@ -58,13 +58,13 @@ export default function TradeMatches() {
         onChange={setSelectedLanguage}
         show={(x) => (x === '' ? 'Any language' : formatLanguage[x])}
       />
-      <div className="mt-2 flex gap-2">
-        <Button variant="outline" className="flex-1" onClick={() => selectCard({ cards, callback: setSelectedCard })}>
+      <div className="h-9 mt-2 flex rounded border border-neutral-700 divide-x divide-neutral-700 bg-neutral-900 [&>*:enabled]:hover:bg-neutral-600 [&>*:disabled]:opacity-50">
+        <button className="flex-1" onClick={() => selectCard({ cards, callback: setSelectedCard })} type="button">
           {card ? getCardNameByLang(card, i18n.language) : 'Select wanted card'}
-        </Button>
-        <Button variant="outline" className="flex-0" onClick={() => setSelectedCard(undefined)} disabled={selectedCard === undefined}>
-          <Trash2 />
-        </Button>
+        </button>
+        <button className="flex-0" onClick={() => setSelectedCard(undefined)} disabled={selectedCard === undefined} type="button">
+          <Trash2 className="mx-2 size-5" />
+        </button>
       </div>
       <div className="flex gap-2 mt-4">
         <Button className="w-full" onClick={() => navigate(buildUrl(selectedCard, selectedLanguage))}>


### PR DESCRIPTION
The rationale for this is that most people will most often search for all cards, so decluttering the UI from this less popular option makes sense.

### Before

<img width="929" height="555" alt="image" src="https://github.com/user-attachments/assets/d8db2035-71dd-434a-b916-84b46bcaea86" />

### After

<img width="949" height="343" alt="image" src="https://github.com/user-attachments/assets/075980eb-8438-4887-b18c-78b2127982f3" />
