### PR TITLE
Add margins to TradeWith header

### DIFF
--- a/frontend/src/pages/trade/TradeWith.tsx
+++ b/frontend/src/pages/trade/TradeWith.tsx
@@ -80,32 +80,36 @@ function TradeWith() {
     <>
       <title>{`Trade with ${friendAccount.username} – TCG Pocket Collection Tracker`}</title>
       <div className="flex flex-col gap-4 w-full mb-4">
-        <div className="rounded-lg border border-neutral-700 bg-neutral-800 p-1">
-          <div className="flex justify-between">
-            <h1>
-              <span className="text-2xl font-light">{t('tradingWith')}</span>
-              <span className="text-2xl font-bold"> {friendAccount.username}</span>
-              {friendAccount.language && <span className="text-lg bg-neutral-800 px-2 rounded-full ml-1">{friendAccount.language}</span>}
-              <span className="block sm:inline text-sm sm:ml-1">
+        <div className="rounded-lg border border-neutral-700 bg-neutral-800 p-2 md:p-4">
+          <div className="flex flex-col md:flex-row gap-2 justify-between">
+            <div>
+              <h1>
+                <span className="text-2xl font-light">{t('tradingWith')}</span>
+                <span className="text-2xl font-bold"> {friendAccount.username}</span>
+                {friendAccount.language && <span className="text-lg bg-neutral-800 px-2 rounded-full ml-1">{friendAccount.language}</span>}
+              </h1>
+              <p>
                 <FriendIdDisplay
                   friendId={friendAccount.friend_id}
                   onChat={isAlreadyFriend ? () => openChat(friendAccount.friend_id, friendAccount.username || friendAccount.friend_id) : undefined}
                 />
-              </span>
-            </h1>
-            <div className="flex flex-col-reverse sm:flex-row gap-2">
-              <label htmlFor={`history-${friendId}`} className="my-auto flex items-center">
-                {t('viewHistory')}
+              </p>
+            </div>
+            <div className="flex flex-col md:flex-row items-center gap-2 [&>*]:w-full">
+              <div className="flex items-center">
+                <label htmlFor={`history-${friendId}`} className="whitespace-nowrap">
+                  {t('viewHistory')}
+                </label>
                 <Switch
                   id={`history-${friendId}`}
-                  className="ml-2 my-auto"
+                  className="ml-2"
                   checked={viewHistory}
                   onCheckedChange={(x) => {
                     setViewHistory(x)
                     setPageHistory(0)
                   }}
                 />
-              </label>
+              </div>
               {!isAlreadyFriend && (
                 <Button
                   variant="outline"
@@ -118,13 +122,14 @@ function TradeWith() {
                 </Button>
               )}
               <Link to={`/collection/${friendId}`}>
-                <Button variant="outline">
+                <Button variant="outline" className="w-full">
                   Collection
                   <ChevronRight />
                 </Button>
               </Link>
             </div>
           </div>
+          <hr className="border-neutral-700 my-2" />
           {allTrades.isLoading ? (
             <Spinner size="md" />
           ) : (

--- a/frontend/src/pages/trade/components/TradeListRow.tsx
+++ b/frontend/src/pages/trade/components/TradeListRow.tsx
@@ -48,7 +48,7 @@ export const TradeListRow: FC<Props> = ({ row, selectedTradeId, setSelectedTrade
     return (
       <>
         <Tooltip id={`status-${row.id}`} />
-        <Slot className="rounded-full p-[3px] my-auto" data-tooltip-id={`status-${row.id}`} data-tooltip-content={t(`status.${row.status}`)}>
+        <Slot className="shrink-0 rounded-full p-[3px] my-auto" data-tooltip-id={`status-${row.id}`} data-tooltip-content={t(`status.${row.status}`)}>
           {style[row.status]}
         </Slot>
       </>


### PR DESCRIPTION
Adds some breathing room in the TradeWith header.

## Desktop

#### Before

<img width="916" height="198" alt="image" src="https://github.com/user-attachments/assets/364bf391-c0e1-456d-b8f1-b3eae54805f0" />

#### After

<img width="932" height="271" alt="image" src="https://github.com/user-attachments/assets/524ff0ad-1b22-4ebf-bf0f-4bb856ad5acc" />

## Mobile

#### Before

<img width="408" height="309" alt="image" src="https://github.com/user-attachments/assets/797e1fb8-a579-4a89-9d2d-3b9acced2500" />

#### After

<img width="405" height="392" alt="image" src="https://github.com/user-attachments/assets/ee8768f0-0929-4279-8f5f-1f626eba3371" />
