### PR TITLE
Last active time

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { createHashRouter, Navigate, Outlet, RouterProvider, useLocation, useParams } from 'react-router'
 import DonationPopup from '@/components/DonationPopup.tsx'
@@ -17,6 +17,7 @@ import { Toaster } from './components/ui/toaster.tsx'
 import { ChatProvider } from './context/ChatProvider.tsx'
 import { DialogContext } from './context/DialogContext.ts'
 import DeckView from './pages/decks/DeckView.tsx'
+import { accountQuery, useUpdateAccount } from './services/account/useAccount.ts'
 
 // Lazy import for chunking
 const Overview = lazy(() => import('./pages/overview/Overview.tsx'))
@@ -48,8 +49,13 @@ function Analytics() {
 
 function App() {
   const { toast } = useToast()
-  const { data: user } = useQuery(userQuery)
   const authSSOQuery = useAuthSSO()
+
+  const { data: user } = useQuery(userQuery)
+  const { data: account } = useQuery(accountQuery(user?.user.email))
+  const updateAccountMutation = useUpdateAccount()
+  const lastLoggedInAs = useRef<string | null>(null)
+
   const [isLoginDialogOpen, setIsLoginDialogOpen] = useState(false)
   const [isProfileDialogOpen, setIsProfileDialogOpen] = useState(false)
   const [selectedCardId, setSelectedCardId] = useState<number | undefined>(undefined)
@@ -70,6 +76,24 @@ function App() {
       }
     }
   }, [user])
+
+  useEffect(() => {
+    console.log(account)
+    if (!account) {
+      lastLoggedInAs.current = null
+      return
+    }
+    if (lastLoggedInAs.current === account.email) {
+      return
+    }
+    lastLoggedInAs.current = account.email
+    updateAccountMutation.mutate(
+      { ...account, last_active: new Date() },
+      {
+        onError: (error) => console.error('Failed registering login\n', error),
+      },
+    )
+  }, [account])
 
   const router = createHashRouter([
     {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import { Toaster } from './components/ui/toaster.tsx'
 import { ChatProvider } from './context/ChatProvider.tsx'
 import { DialogContext } from './context/DialogContext.ts'
 import DeckView from './pages/decks/DeckView.tsx'
-import { accountQuery, useUpdateAccount } from './services/account/useAccount.ts'
+import { accountQuery, useUpdateLastActive } from './services/account/useAccount.ts'
 
 // Lazy import for chunking
 const Overview = lazy(() => import('./pages/overview/Overview.tsx'))
@@ -53,7 +53,7 @@ function App() {
 
   const { data: user } = useQuery(userQuery)
   const { data: account } = useQuery(accountQuery(user?.user.email))
-  const updateAccountMutation = useUpdateAccount()
+  const updateLastActiveMutation = useUpdateLastActive()
   const lastLoggedInAs = useRef<string | null>(null)
 
   const [isLoginDialogOpen, setIsLoginDialogOpen] = useState(false)
@@ -78,7 +78,6 @@ function App() {
   }, [user])
 
   useEffect(() => {
-    console.log(account)
     if (!account) {
       lastLoggedInAs.current = null
       return
@@ -87,8 +86,8 @@ function App() {
       return
     }
     lastLoggedInAs.current = account.email
-    updateAccountMutation.mutate(
-      { ...account, last_active: new Date() },
+    updateLastActiveMutation.mutate(
+      { email: account.email, now: new Date() },
       {
         onError: (error) => console.error('Failed registering login\n', error),
       },

--- a/frontend/src/components/EditProfile.tsx
+++ b/frontend/src/components/EditProfile.tsx
@@ -15,7 +15,7 @@ import { Switch } from '@/components/ui/switch.tsx'
 import { useToast } from '@/hooks/use-toast.ts'
 import { useAccount, useProfileDialog, useUpdateAccount } from '@/services/account/useAccount'
 import { userQuery } from '@/services/auth/useAuth'
-import type { AccountRow } from '@/types'
+import type { UserAccountRow } from '@/types'
 import { SocialShareButtons } from './SocialShareButtons'
 
 const EditProfile: FC = () => {
@@ -50,7 +50,7 @@ const EditProfile: FC = () => {
         friend_id: values.friend_id,
         is_public: values.is_public,
         is_active_trading: values.is_public === false ? false : account?.is_active_trading,
-      } as AccountRow,
+      } as UserAccountRow,
       {
         onSuccess: () => toast({ title: t('accountSaved'), variant: 'default' }),
         onError: (e) => {

--- a/frontend/src/components/Mission.tsx
+++ b/frontend/src/components/Mission.tsx
@@ -168,7 +168,6 @@ export const Mission: FC<Props> = ({ mission, setSelectedMissionCardOptions }) =
       ...account,
       completed_missions: updatedMissions,
     }
-    delete mergedAccount.trade_rarity_settings
     updateAccount(mergedAccount)
   }
 

--- a/frontend/src/pages/collection/CollectionCards.tsx
+++ b/frontend/src/pages/collection/CollectionCards.tsx
@@ -15,7 +15,7 @@ import { toast } from '@/hooks/use-toast'
 import { getFilteredCards, ownershipOptions, sortByOptions, tradingOptions } from '@/lib/filters'
 import { getCardNameByLang } from '@/lib/utils.ts'
 import { useProfileDialog } from '@/services/account/useAccount'
-import { type AccountRow, type Card as CardType, type Collection, cardTypes, expansionIds, rarities } from '@/types'
+import { type Card as CardType, type Collection, cardTypes, expansionIds, type PublicAccountRow, rarities, type UserAccountRow } from '@/types'
 
 const schema = z.object({
   search: z.string().default(''),
@@ -36,7 +36,7 @@ const schema = z.object({
 interface Props {
   children?: ReactNode
   cards: Collection
-  account: AccountRow | undefined
+  account: PublicAccountRow | UserAccountRow | undefined
 }
 
 export default function CollectionCards({ children, cards, account }: Props) {
@@ -45,7 +45,7 @@ export default function CollectionCards({ children, cards, account }: Props) {
 
   const { setIsProfileDialogOpen } = useProfileDialog()
   const [isFiltersSheetOpen, setIsFiltersSheetOpen] = useState(false) // used only on mobile
-  const isPublic = account?.email === undefined
+  const isPublic = account !== undefined && !('email' in account)
 
   const [filters, setFilters, activeFilters] = useSearchState(schema)
   const [_, setSearchParams] = useSearchParams()
@@ -54,8 +54,8 @@ export default function CollectionCards({ children, cards, account }: Props) {
   const filteredCards = getFilteredCards(filters, cards, account?.trade_rarity_settings)
 
   const getTradingMessage = () => {
-    if (!account) {
-      throw new Error('Cannot copy trade message without account')
+    if (!account || isPublic) {
+      throw new Error('Cannot copy trade message without account or of public accounts')
     }
     let cardValues = ''
 
@@ -94,7 +94,7 @@ export default function CollectionCards({ children, cards, account }: Props) {
   }
 
   async function onShare() {
-    if (account?.email === undefined) {
+    if (!account || isPublic) {
       throw new Error("Can't share collection: not logged in or not on own collection")
     }
     if (account.friend_id === '' || !account.is_public) {

--- a/frontend/src/pages/trade/components/TradeWithTable.tsx
+++ b/frontend/src/pages/trade/components/TradeWithTable.tsx
@@ -7,13 +7,13 @@ import { Spinner } from '@/components/Spinner'
 import { getCardByInternalId } from '@/lib/CardsDB'
 import { getExtraCards, getNeededCards, getTradeCards } from '@/lib/utils'
 import { publicCollectionQuery, useCollection } from '@/services/collection/useCollection'
-import { type AccountRow, type Card, tradableRarities } from '@/types'
+import { type Card, type PublicAccountRow, tradableRarities } from '@/types'
 import { CardList } from './CardList'
 import { TradeOffer } from './TradeOffer'
 
 interface Props {
-  ownAccount: AccountRow
-  friendAccount: AccountRow
+  ownAccount: PublicAccountRow
+  friendAccount: PublicAccountRow
 }
 
 export default function TradeWithTable({ ownAccount, friendAccount }: Props) {

--- a/frontend/src/services/account/accountService.ts
+++ b/frontend/src/services/account/accountService.ts
@@ -112,6 +112,19 @@ export const updateAccountTradingFields = async ({
   return transformUserAccount(data as UserAccountRow)
 }
 
+export async function updateLastActive(email: string, now: Date) {
+  const { error, data } = await supabase
+    .from('accounts')
+    .update({ last_active: now })
+    .eq('email', email)
+    .select('*, trade_rarity_settings:trade_rarity_settings!email(*)')
+    .single()
+  if (error) {
+    throw new Error(`Failed updating last active: ${error.message}`)
+  }
+  return transformUserAccount(data as UserAccountRow)
+}
+
 export async function updateCollectionTimestamp(email: string, now: Date) {
   const { error, data } = await supabase
     .from('accounts')

--- a/frontend/src/services/account/accountService.ts
+++ b/frontend/src/services/account/accountService.ts
@@ -65,7 +65,7 @@ export const updateAccount = async (account: UserAccountRow) => {
   }
   const { data, error } = await supabase
     .from('accounts')
-    .upsert({ ...account, trade_rarity_settings: undefined, last_active: undefined })
+    .upsert({ ...account, trade_rarity_settings: undefined })
     .select('*, trade_rarity_settings:trade_rarity_settings!email(*)')
     .single()
 

--- a/frontend/src/services/account/accountService.ts
+++ b/frontend/src/services/account/accountService.ts
@@ -1,35 +1,41 @@
 import { supabase } from '@/lib/supabase'
 import { type PublicAccountRow, tradableRarities, type UserAccountRow } from '@/types'
 
+function transformUserAccount(account: UserAccountRow) {
+  account.collection_last_updated = new Date(account.collection_last_updated)
+  account.last_active = new Date(account.last_active)
+
+  for (const rarity of tradableRarities) {
+    // set default values for each rarity that we don't have a setting for yet.
+    if (!account.trade_rarity_settings.find((r) => r.rarity === rarity)) {
+      account.trade_rarity_settings.push({ rarity, to_collect: 1, to_keep: 1 })
+    }
+  }
+
+  return account as UserAccountRow
+}
+
 export const getUserAccount = async (email: string) => {
   if (!email) {
     throw new Error('Email is required to fetch account')
   }
 
   const { data, error } = await supabase.from('accounts').select('*, trade_rarity_settings:trade_rarity_settings!email(*)').eq('email', email).maybeSingle()
-
   if (error) {
     throw new Error(`Error fetching account: ${error.message}`)
   }
 
   if (data) {
-    const accountRow = data as UserAccountRow
-
-    for (const rarity of tradableRarities) {
-      //set default values for each rarity that we don't have a setting for yet.
-      if (!accountRow.trade_rarity_settings.find((r) => r.rarity === rarity)) {
-        accountRow.trade_rarity_settings.push({ rarity, to_collect: 1, to_keep: 1 })
-      }
-    }
-
-    return accountRow
+    return transformUserAccount(data as UserAccountRow)
   }
 
   // no account exists yet, create one
-  return await updateAccount({
-    email,
-    username: null,
-  } as UserAccountRow)
+  return transformUserAccount(
+    await updateAccount({
+      email,
+      username: null,
+    } as UserAccountRow),
+  )
 }
 
 export const getPublicAccount = async (friendId: string) => {
@@ -57,11 +63,9 @@ export const updateAccount = async (account: UserAccountRow) => {
   if (!account.email) {
     throw new Error('Email is required to update account')
   }
-
   const { data, error } = await supabase
     .from('accounts')
-    .upsert(account)
-    .eq('email', account.email)
+    .upsert({ ...account, trade_rarity_settings: undefined, last_active: undefined })
     .select('*, trade_rarity_settings:trade_rarity_settings!email(*)')
     .single()
 
@@ -69,7 +73,7 @@ export const updateAccount = async (account: UserAccountRow) => {
     throw new Error(`Error updating account: ${error.message}`)
   }
 
-  return data as UserAccountRow
+  return transformUserAccount(data as UserAccountRow)
 }
 
 export const updateAccountTradingFields = async ({
@@ -105,5 +109,18 @@ export const updateAccountTradingFields = async ({
   }
 
   console.log('updated account', data)
-  return data as UserAccountRow
+  return transformUserAccount(data as UserAccountRow)
+}
+
+export async function updateCollectionTimestamp(email: string, now: Date) {
+  const { error, data } = await supabase
+    .from('accounts')
+    .update({ collection_last_updated: now })
+    .eq('email', email)
+    .select('*, trade_rarity_settings:trade_rarity_settings!email(*)')
+    .single()
+  if (error) {
+    throw new Error(`Failed updating account: ${error.message}`)
+  }
+  return transformUserAccount(data as UserAccountRow)
 }

--- a/frontend/src/services/account/accountService.ts
+++ b/frontend/src/services/account/accountService.ts
@@ -1,38 +1,27 @@
 import { supabase } from '@/lib/supabase'
-import { type AccountRow, tradableRarities } from '@/types'
+import { type PublicAccountRow, tradableRarities, type UserAccountRow } from '@/types'
 
-export const getAccount = async (email: string) => {
+export const getUserAccount = async (email: string) => {
   if (!email) {
     throw new Error('Email is required to fetch account')
   }
 
-  const { data, error } = await supabase
-    .from('accounts')
-    .select(`
-    *,
-    trade_rarity_settings:trade_rarity_settings!email(*)
-  `)
-    .eq('email', email)
-    .maybeSingle()
+  const { data, error } = await supabase.from('accounts').select('*, trade_rarity_settings:trade_rarity_settings!email(*)').eq('email', email).maybeSingle()
 
   if (error) {
-    console.log('supa error', error)
-    throw new Error('Error fetching account')
+    throw new Error(`Error fetching account: ${error.message}`)
   }
 
-  console.log('fetched account', data)
-
   if (data) {
-    const accountRow = data as AccountRow
+    const accountRow = data as UserAccountRow
 
     for (const rarity of tradableRarities) {
       //set default values for each rarity that we don't have a setting for yet.
-      if (!accountRow.trade_rarity_settings?.find((r) => r.rarity === rarity)) {
-        accountRow.trade_rarity_settings?.push({ rarity, to_collect: 1, to_keep: 1 })
+      if (!accountRow.trade_rarity_settings.find((r) => r.rarity === rarity)) {
+        accountRow.trade_rarity_settings.push({ rarity, to_collect: 1, to_keep: 1 })
       }
     }
 
-    console.log('returning account', accountRow)
     return accountRow
   }
 
@@ -40,7 +29,7 @@ export const getAccount = async (email: string) => {
   return await updateAccount({
     email,
     username: null,
-  } as AccountRow)
+  } as UserAccountRow)
 }
 
 export const getPublicAccount = async (friendId: string) => {
@@ -58,24 +47,29 @@ export const getPublicAccount = async (friendId: string) => {
   console.log('fetched public account', data)
 
   if (data) {
-    return data as AccountRow
+    return data as PublicAccountRow
   }
 
   return null
 }
 
-export const updateAccount = async (account: AccountRow) => {
+export const updateAccount = async (account: UserAccountRow) => {
   if (!account.email) {
     throw new Error('Email is required to update account')
   }
 
-  const { data, error } = await supabase.from('accounts').upsert(account).select().single()
+  const { data, error } = await supabase
+    .from('accounts')
+    .upsert(account)
+    .eq('email', account.email)
+    .select('*, trade_rarity_settings:trade_rarity_settings!email(*)')
+    .single()
 
   if (error) {
     throw new Error(`Error updating account: ${error.message}`)
   }
 
-  return data as AccountRow
+  return data as UserAccountRow
 }
 
 export const updateAccountTradingFields = async ({
@@ -88,10 +82,10 @@ export const updateAccountTradingFields = async ({
   email: string
   username: string
   is_active_trading: boolean
-  language: AccountRow['language']
-  trade_rarity_settings: AccountRow['trade_rarity_settings']
+  language: UserAccountRow['language']
+  trade_rarity_settings: UserAccountRow['trade_rarity_settings']
 }) => {
-  const { data: rarityData, error: rarityError } = await supabase
+  const { error: rarityError } = await supabase
     .from('trade_rarity_settings')
     .upsert(trade_rarity_settings?.map((r) => ({ email, ...r })) ?? [])
     .select()
@@ -100,14 +94,16 @@ export const updateAccountTradingFields = async ({
     throw new Error(`Error updating trade rarity settings: ${rarityError.message}`)
   }
 
-  const { data, error } = await supabase.from('accounts').upsert({ email, username, is_active_trading, language: language }).select().single()
+  const { data, error } = await supabase
+    .from('accounts')
+    .upsert({ email, username, is_active_trading, language: language })
+    .select('*, trade_rarity_settings:trade_rarity_settings!email(*)')
+    .single()
 
   if (error) {
     throw new Error(`Error updating account: ${error.message}`)
   }
 
-  data.trade_rarity_settings = rarityData
-
   console.log('updated account', data)
-  return data as AccountRow
+  return data as UserAccountRow
 }

--- a/frontend/src/services/account/useAccount.ts
+++ b/frontend/src/services/account/useAccount.ts
@@ -2,13 +2,13 @@ import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/r
 import { useContext } from 'react'
 import { DialogContext } from '@/context/DialogContext.ts'
 import { userQuery } from '@/services/auth/useAuth.ts'
-import type { AccountRow } from '@/types'
-import { getAccount, getPublicAccount, updateAccount, updateAccountTradingFields } from './accountService'
+import type { UserAccountRow } from '@/types'
+import { getPublicAccount, getUserAccount, updateAccount, updateAccountTradingFields } from './accountService'
 
 export function accountQuery(email: string | undefined) {
   return queryOptions({
     queryKey: ['account', email],
-    queryFn: () => getAccount(email as string),
+    queryFn: () => getUserAccount(email as string),
     enabled: !!email,
     throwOnError: true,
   })
@@ -32,7 +32,7 @@ export function useUpdateAccount() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (account: AccountRow) => updateAccount(account),
+    mutationFn: updateAccount,
     onSuccess: (updatedAccount) => {
       queryClient.setQueryData(['account', updatedAccount.email], updatedAccount)
     },
@@ -53,8 +53,8 @@ export function useUpdateAccountTradingFields() {
     }: {
       username: string
       is_active_trading: boolean
-      language: AccountRow['language']
-      trade_rarity_settings: AccountRow['trade_rarity_settings']
+      language: UserAccountRow['language']
+      trade_rarity_settings: UserAccountRow['trade_rarity_settings']
     }) => {
       if (!email) {
         throw new Error('Email is required to update account')

--- a/frontend/src/services/account/useAccount.ts
+++ b/frontend/src/services/account/useAccount.ts
@@ -3,7 +3,7 @@ import { useContext } from 'react'
 import { DialogContext } from '@/context/DialogContext.ts'
 import { userQuery } from '@/services/auth/useAuth.ts'
 import type { UserAccountRow } from '@/types'
-import { getPublicAccount, getUserAccount, updateAccount, updateAccountTradingFields } from './accountService'
+import { getPublicAccount, getUserAccount, updateAccount, updateAccountTradingFields, updateLastActive } from './accountService'
 
 export function accountQuery(email: string | undefined) {
   return queryOptions({
@@ -33,6 +33,17 @@ export function useUpdateAccount() {
 
   return useMutation({
     mutationFn: updateAccount,
+    onSuccess: (updatedAccount) => {
+      queryClient.setQueryData(['account', updatedAccount.email], updatedAccount)
+    },
+  })
+}
+
+export function useUpdateLastActive() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ email, now }: { email: string; now: Date }) => updateLastActive(email, now),
     onSuccess: (updatedAccount) => {
       queryClient.setQueryData(['account', updatedAccount.email], updatedAccount)
     },

--- a/frontend/src/services/collection/collectionService.ts
+++ b/frontend/src/services/collection/collectionService.ts
@@ -1,7 +1,8 @@
 import { getCardById } from '@/lib/CardsDB'
 import { supabase } from '@/lib/supabase'
 import { chunk } from '@/lib/utils'
-import type { AccountRow, CardAmountsRowUpdate, CardAmountUpdate, Collection, CollectionRow } from '@/types'
+import type { CardAmountsRowUpdate, CardAmountUpdate, Collection, CollectionRow, UserAccountRow } from '@/types'
+import { updateCollectionTimestamp } from '../account/accountService'
 
 export interface CollectionRowUpdate {
   email: string
@@ -20,17 +21,9 @@ export const removeLocalCacheItems = (email: string) => {
   localStorage.removeItem(`${COLLECTION_TIMESTAMP_KEY}_${email}`)
 }
 
-export async function getCollection(email: string, collectionLastUpdatedRaw?: Date | string): Promise<Collection> {
+export async function getCollection(email: string, collectionLastUpdated?: Date): Promise<Collection> {
   if (!email) {
     throw new Error('Email is required to fetch collection')
-  }
-
-  // it seems sometimes the collectionLastUpdated is a string, then we need to parse it into a Date.
-  let collectionLastUpdated: Date | undefined
-  if (typeof collectionLastUpdatedRaw === 'string') {
-    collectionLastUpdated = new Date(collectionLastUpdatedRaw)
-  } else {
-    collectionLastUpdated = collectionLastUpdatedRaw
   }
 
   // Check if we should use cached data
@@ -68,19 +61,6 @@ export function getPublicCollection(friendId: string) {
   return fetchCollectionFromAPI('public_card_amounts_collection', 'friend_id', friendId)
 }
 
-export async function updateCollectionTimestamp(email: string, now: Date) {
-  const { error, data } = await supabase
-    .from('accounts')
-    .update({ collection_last_updated: now })
-    .eq('email', email)
-    .select('*, trade_rarity_settings:trade_rarity_settings!email(*)')
-    .single()
-  if (error) {
-    throw new Error(`Failed updating account: ${error.message}`)
-  }
-  return data as AccountRow
-}
-
 export const updateCards = async (email: string, rowsToUpdate: CardAmountUpdate[], collection: Collection) => {
   if (!email) {
     throw new Error('Email is required to update cards')
@@ -110,7 +90,7 @@ export const updateCards = async (email: string, rowsToUpdate: CardAmountUpdate[
     .filter((row, index, self) => index === self.findIndex((r) => r.internal_id === row.internal_id))
 
   // Execute all three database calls in parallel
-  let account: AccountRow
+  let account: UserAccountRow
   try {
     const [accountResult, cardAmountsResult] = await Promise.all([updateCollectionTimestamp(email, now), supabase.from('card_amounts').upsert(amountRows)])
 
@@ -160,7 +140,7 @@ export const updateCards = async (email: string, rowsToUpdate: CardAmountUpdate[
 
   return {
     cards: collection,
-    account: account as AccountRow,
+    account: account as UserAccountRow,
   }
 }
 
@@ -241,7 +221,7 @@ export const deleteCard = async (email: string, collection: Collection, cardIds:
 
   return {
     cards: collection,
-    account: updatedAccount as AccountRow,
+    account: updatedAccount as UserAccountRow,
   }
 }
 

--- a/frontend/src/services/collection/useCollection.ts
+++ b/frontend/src/services/collection/useCollection.ts
@@ -2,16 +2,10 @@ import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/r
 import { useContext } from 'react'
 import { DialogContext } from '@/context/DialogContext.ts'
 import { useToast } from '@/hooks/use-toast.ts'
+import { updateCollectionTimestamp } from '@/services/account/accountService'
 import { useAccount } from '@/services/account/useAccount.ts'
 import { userQuery } from '@/services/auth/useAuth.ts'
-import {
-  deleteCard,
-  getCollection,
-  getPublicCollection,
-  updateAmountWanted,
-  updateCards,
-  updateCollectionTimestamp,
-} from '@/services/collection/collectionService.ts'
+import { deleteCard, getCollection, getPublicCollection, updateAmountWanted, updateCards } from '@/services/collection/collectionService.ts'
 import type { CardAmountUpdate, CollectionRow } from '@/types'
 
 export function collectionQuery(email: string | undefined, collectionLastUpdated: Date | undefined) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,16 +47,18 @@ export interface RaritySettingsRow {
   to_keep: number
 }
 
-export interface AccountRow {
-  $id: string
-  email: string
+export interface PublicAccountRow {
   username: string | null
   friend_id: string
   language: GameLanguage | null
+  is_active_trading: boolean
+  trade_rarity_settings: RaritySettingsRow[]
+}
+
+export interface UserAccountRow extends PublicAccountRow {
+  email: string
   collection_last_updated: Date
   is_public: boolean
-  is_active_trading: boolean
-  trade_rarity_settings?: RaritySettingsRow[]
   completed_missions?: string[]
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -57,6 +57,7 @@ export interface PublicAccountRow {
 
 export interface UserAccountRow extends PublicAccountRow {
   email: string
+  last_active: Date
   collection_last_updated: Date
   is_public: boolean
   completed_missions?: string[]

--- a/scripts/sql/find-card.sql
+++ b/scripts/sql/find-card.sql
@@ -7,7 +7,6 @@ WITH recent_accounts AS (
     WHERE
         a.is_active_trading = TRUE
         AND a.is_public = TRUE
-        AND a.collection_last_updated IS NOT NULL
         AND EXISTS (
             SELECT internal_id
             FROM card_amounts ca
@@ -16,7 +15,7 @@ WITH recent_accounts AS (
                 AND ca.internal_id = 792963
                 AND ca.amount_owned > t.to_keep
         )
-    ORDER BY collection_last_updated DESC
+    ORDER BY last_active DESC
     LIMIT 50
 )
 SELECT

--- a/scripts/sql/schema.sql
+++ b/scripts/sql/schema.sql
@@ -48,6 +48,7 @@ CREATE TABLE public.accounts (
     collection_last_updated timestamp with time zone,
     completed_missions character varying[],
     language character(2),
+    last_active timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT username_min_length CHECK (((username IS NULL) OR (length((username)::text) >= 2)))
 );
 
@@ -312,8 +313,8 @@ CREATE TABLE public.trades (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     offering_friend_id character varying NOT NULL,
     receiving_friend_id character varying NOT NULL,
-    offer_card_id character varying NOT NULL,
-    receiver_card_id character varying NOT NULL,
+    offer_card_id character varying,
+    receiver_card_id character varying,
     status character varying NOT NULL,
     offerer_ended boolean DEFAULT false NOT NULL,
     receiver_ended boolean DEFAULT false NOT NULL
@@ -461,7 +462,7 @@ CREATE INDEX idx_accounts_collection_last_updated ON public.accounts USING btree
 -- Name: idx_accounts_recent; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_accounts_recent ON public.accounts USING btree (is_active_trading, is_public, collection_last_updated DESC) WHERE (collection_last_updated IS NOT NULL);
+CREATE INDEX idx_accounts_recent ON public.accounts USING btree (is_active_trading, is_public, last_active DESC);
 
 
 --

--- a/scripts/sql/trade-partners.sql
+++ b/scripts/sql/trade-partners.sql
@@ -7,12 +7,11 @@ WITH recent_accounts AS (
       AND is_active_trading = TRUE
       AND is_public = TRUE
       AND username IS NOT NULL
-      AND collection_last_updated IS NOT NULL
       AND ($2::text IS NULL OR language = $2::text)
-      AND collection_last_updated >= now() - interval '14 days'
+      AND last_active >= now() - interval '14 days'
       AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
       AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
-    ORDER BY collection_last_updated DESC
+    ORDER BY last_active DESC
     LIMIT 50
 )
 SELECT
@@ -89,7 +88,6 @@ WITH recent_accounts AS (
         AND a.is_active_trading = TRUE
         AND a.is_public = TRUE
         AND a.username IS NOT NULL
-        AND a.collection_last_updated IS NOT NULL
         AND EXISTS (
             SELECT internal_id
             FROM card_amounts ca
@@ -99,10 +97,10 @@ WITH recent_accounts AS (
                 AND ca.amount_owned > COALESCE(ca.amount_wanted, t.to_keep)
         )
         AND ($3::text IS NULL OR language = $3::text)
-        AND collection_last_updated >= now() - interval '14 days'
+        AND last_active >= now() - interval '14 days'
         AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
         AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
-    ORDER BY collection_last_updated DESC
+    ORDER BY last_active DESC
     LIMIT 50
 )
 SELECT

--- a/supabase/functions/get-trading-partners/index.ts
+++ b/supabase/functions/get-trading-partners/index.ts
@@ -20,12 +20,11 @@ WITH recent_accounts AS (
       AND is_active_trading = TRUE
       AND is_public = TRUE
       AND username IS NOT NULL
-      AND collection_last_updated IS NOT NULL
       AND ($2::text IS NULL OR language = $2::text)
-      AND collection_last_updated >= now() - interval '14 days'
+      AND last_active >= now() - interval '14 days'
       AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
       AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
-    ORDER BY collection_last_updated DESC
+    ORDER BY last_active DESC
     LIMIT 50
 )
 SELECT
@@ -103,7 +102,6 @@ WITH recent_accounts AS (
         AND a.is_active_trading = TRUE
         AND a.is_public = TRUE
         AND a.username IS NOT NULL
-        AND a.collection_last_updated IS NOT NULL
         AND EXISTS (
             SELECT internal_id
             FROM card_amounts ca
@@ -113,10 +111,10 @@ WITH recent_accounts AS (
                 AND ca.amount_owned > COALESCE(ca.amount_wanted, t.to_keep)
         )
         AND ($3::text IS NULL OR language = $3::text)
-        AND collection_last_updated >= now() - interval '14 days'
+        AND last_active >= now() - interval '14 days'
         AND (SELECT COUNT(*) FROM trades WHERE status = 'accepted' AND (offering_friend_id = friend_id OR receiving_friend_id = friend_id)) < 8
         AND (SELECT COUNT(*) FROM trades WHERE status = 'offered' AND receiving_friend_id = friend_id) < 3
-    ORDER BY collection_last_updated DESC
+    ORDER BY last_active DESC
     LIMIT 50
 )
 SELECT


### PR DESCRIPTION
Closes #966.

We used `collection_last_updated` for the potential trade partners ordering because it was available and it was a decent proxy of activity. However, some users are not satisfied with this, saying that they update their collection in bulk once every set, but they remain actively trading, especially being dissatisfied that they need to perform "shadow updates" (+1 then -1 on a card) to keep being shown to other users.

This PR adds a `last_active` column to track last user login time and uses it in trading.

Additionally:
- Splits the public and user account typescript types for nicer handling
- Fixes a bug where `EditProfile` would delete the trade settings on the client side
- Fixes a bug where `collection_last_updated` was not transformed into `Date` but kept as `string`

Please run:

```sql
ALTER TABLE public.accounts
ADD COLUMN last_active timestamp with time zone NOT NULL DEFAULT now();

UPDATE public.accounts
SET last_active = COALESCE(
    collection_last_updated,
    TIMESTAMP WITH TIME ZONE '2025-01-01 00:00:00+00'
);
```

And then update `scripts/sql/schema.sql`.