### PR TITLE
Fix TradeWith spinner

### DIFF
--- a/frontend/src/pages/trade/TradeWith.tsx
+++ b/frontend/src/pages/trade/TradeWith.tsx
@@ -131,7 +131,7 @@ function TradeWith() {
           </div>
           <hr className="border-neutral-700 my-2" />
           {allTrades.isLoading ? (
-            <Spinner size="md" />
+            <Spinner size="md" className="mx-auto" />
           ) : (
             allTrades.data && (
               <>

--- a/frontend/src/pages/trade/components/TradeWithTable.tsx
+++ b/frontend/src/pages/trade/components/TradeWithTable.tsx
@@ -44,7 +44,7 @@ export default function TradeWithTable({ ownAccount, friendAccount }: Props) {
   }, [location, friendCards, ownedCards?.size]) // Uses size because ReactQuery returns a different object every 10 seconds
 
   if (isLoadingOwnCards || isLoadingFriendCards) {
-    return <Spinner size="lg" overlay />
+    return <Spinner size="lg" className="mx-auto mt-8" />
   }
 
   if (ownedCards === undefined || friendCards === undefined) {


### PR DESCRIPTION
Fixes a bug where the trades table loading spinner was `overlay`, covering the main component and preventing the user from interacting with the active trades.