### PR TITLE
Prevent offering impossible trades

### DIFF
--- a/frontend/src/pages/trade/components/TradeOffer.tsx
+++ b/frontend/src/pages/trade/components/TradeOffer.tsx
@@ -23,18 +23,17 @@ interface Props {
   friendCard: Card | null
   setYourCard: (card: Card | null) => void
   setFriendCard: (card: Card | null) => void
+  disabled: boolean
 }
 
-export const TradeOffer: FC<Props> = ({ yourId, friendId, yourCard, friendCard, setYourCard, setFriendCard }) => {
+export const TradeOffer: FC<Props> = ({ yourId, friendId, yourCard, friendCard, setYourCard, setFriendCard, disabled }) => {
   const { t } = useTranslation('trade-matches')
   const { toast } = useToast()
 
   const insertTradeMutation = useInsertTrade()
 
-  const enabled = (!yourCard && friendCard) || (yourCard && friendCard && yourCard.rarity === friendCard.rarity)
-
   async function submit() {
-    if (!enabled) {
+    if (disabled) {
       return
     }
     if (!yourId?.match(/^\d{16}$/)) {
@@ -45,7 +44,7 @@ export const TradeOffer: FC<Props> = ({ yourId, friendId, yourCard, friendCard, 
       offering_friend_id: yourId,
       receiving_friend_id: friendId,
       offer_card_id: yourCard?.card_id,
-      receiver_card_id: friendCard.card_id,
+      receiver_card_id: friendCard?.card_id,
       status: 'offered',
     } as TradeRow
     try {
@@ -80,7 +79,7 @@ export const TradeOffer: FC<Props> = ({ yourId, friendId, yourCard, friendCard, 
           <OfferCard card={friendCard} />
         </div>
       </div>
-      <Button className="block w-full sm:w-96 mx-auto mt-1 text-center" variant="default" onClick={submit} disabled={!enabled}>
+      <Button className="block w-full sm:w-96 mx-auto mt-1 text-center" variant="default" onClick={submit} disabled={disabled}>
         {t('offerTrades')}
       </Button>
     </div>

--- a/frontend/src/pages/trade/components/TradeWithTable.tsx
+++ b/frontend/src/pages/trade/components/TradeWithTable.tsx
@@ -7,7 +7,7 @@ import { Spinner } from '@/components/Spinner'
 import { getCardByInternalId } from '@/lib/CardsDB'
 import { getExtraCards, getNeededCards, getTradeCards } from '@/lib/utils'
 import { publicCollectionQuery, useCollection } from '@/services/collection/useCollection'
-import { type Card, type PublicAccountRow, tradableRarities } from '@/types'
+import { type Card, type PublicAccountRow, type TradableRarity, tradableRarities } from '@/types'
 import { CardList } from './CardList'
 import { TradeOffer } from './TradeOffer'
 
@@ -62,6 +62,9 @@ export default function TradeWithTable({ ownAccount, friendAccount }: Props) {
 
   const hasPossibleTrades = tradableRarities.some((r) => (cardsToGive[r] ?? []).length > 0 && (cardsToReceive[r] ?? []).length > 0)
 
+  const canSendOffer =
+    (!yourCard && friendCard && !!cardsToGive[friendCard.rarity as TradableRarity]) || (yourCard && friendCard && yourCard.rarity === friendCard.rarity)
+
   return (
     <>
       <TradeOffer
@@ -71,6 +74,7 @@ export default function TradeWithTable({ ownAccount, friendAccount }: Props) {
         friendCard={friendCard}
         setYourCard={setYourCard}
         setFriendCard={setFriendCard}
+        disabled={!canSendOffer}
       />
 
       {!hasPossibleTrades && (


### PR DESCRIPTION
Prevents the user from offering a trade with an empty card when they do not have any extra card with this rarity.