### PR TITLE
fix(B4): correct trainer name translations for Drayden, Skyla, Wally,…

### DIFF
--- a/frontend/assets/trainers_translations.json
+++ b/frontend/assets/trainers_translations.json
@@ -594,34 +594,34 @@
   "drayden": {
     "en-US": "Drayden",
     "fr-FR": "Watson",
-    "es-ES": "Draco",
+    "es-ES": "Lirio",
     "pt-BR": "Drayden",
-    "it-IT": "Drayden",
-    "de-DE": "Drayden"
+    "it-IT": "Aristide",
+    "de-DE": "Lysander"
   },
   "skyla": {
     "en-US": "Skyla",
-    "fr-FR": "Cameron",
-    "es-ES": "Miho",
+    "fr-FR": "Carolina",
+    "es-ES": "Gerania",
     "pt-BR": "Skyla",
-    "it-IT": "Skyla",
-    "de-DE": "Skyla"
+    "it-IT": "Anemone",
+    "de-DE": "Géraldine"
   },
   "wally": {
     "en-US": "Wally",
     "fr-FR": "Timmy",
-    "es-ES": "Berto",
+    "es-ES": "Blasco",
     "pt-BR": "Wally",
-    "it-IT": "Wally",
-    "de-DE": "Kalle"
+    "it-IT": "Lino",
+    "de-DE": "Heiko"
   },
   "psychic": {
     "en-US": "Psychic",
     "fr-FR": "Kinésiste",
-    "es-ES": "Psíquico",
+    "es-ES": "Médium",
     "pt-BR": "Psíquico",
-    "it-IT": "Psichico",
-    "de-DE": "Psi-Trainer"
+    "it-IT": "Sensitivo",
+    "de-DE": "Seher"
   },
   "puppy-loving girl": {
     "en-US": "Puppy-Loving Girl",


### PR DESCRIPTION
… Psychic

Verified against Bulbapedia's Ruler of the Skies (B4) card entries:
- Drayden es-ES Draco→Lirio, it-IT/de-DE placeholder→Aristide/Lysander
- Skyla es-ES Miho→Gerania, fr-FR Cameron→Carolina, it-IT/de-DE placeholder→Anemone/Géraldine
- Wally es-ES Berto→Blasco, it-IT/de-DE placeholder→Lino/Heiko
- Psychic es-ES Psíquico→Médium, it-IT Psichico→Sensitivo, de-DE Psi-Trainer→Seher

Affects cards B4-150/151/152/153 and their star variants B4-190/191/192/193.