### PR TITLE
fix(ui): truncate long card names on desktop with tooltip

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -64,8 +64,8 @@ export function Card({ card, onImageClick, className, editable = true }: CardPro
         {isPending && <Spinner size="md" overlay />}
       </button>
       <p
-        className="w-full min-w-0 text-[12px] pt-2 text-center font-semibold leading-tight"
-        title={card.updated_at ? `Last update ${card.updated_at.toLocaleString()}` : undefined}
+        className="w-full min-w-0 text-[12px] pt-2 text-center font-semibold leading-tight md:truncate"
+        title={`${getCardNameByLang(card, i18n.language)}${card.updated_at ? ` — Last update ${card.updated_at.toLocaleString()}` : ''}`}
       >
         <span className="block md:inline">{card.card_id}</span>
         <span className="hidden md:inline"> – </span>


### PR DESCRIPTION
Card names longer than the grid tile width (e.g. "Necrozma Melena Crepuscular ex", "Team Rockets Zapdos-ex") pushed the layout around on desktop because .truncate only applied inside a block child, and on desktop the name span was inline. Applied md:truncate on the whole line so the id + name pair truncates together on desktop, and set the tile tooltip to always include the localized name (previously it only appeared when card.updated_at was set).