### PR TITLE
feat: B4a translations + es-ES backfill + B4-19 data fixes

### DIFF
--- a/frontend/assets/cards.json
+++ b/frontend/assets/cards.json
@@ -94448,7 +94448,7 @@
     "image": "/images/en-US/B4-19.webp",
     "hp": 90,
     "energy": "grass",
-    "name": "Teal MaskOgerpon",
+    "name": "Teal Mask Ogerpon",
     "card_type": "pokémon",
     "evolution_type": "basic",
     "attacks": [

--- a/frontend/assets/cards.json
+++ b/frontend/assets/cards.json
@@ -94454,8 +94454,8 @@
     "attacks": [
       {
         "cost": ["grass", "grass", "colorless"],
-        "name": "Ogre’s",
-        "damage": "Whip",
+        "name": "Ogre’s Whip",
+        "damage": "",
         "effect": "This attack does damage to your opponent's Active Pokémon equal to this Pokémon's remaining HP."
       }
     ],

--- a/frontend/assets/pokemon_translations.json
+++ b/frontend/assets/pokemon_translations.json
@@ -8265,7 +8265,7 @@
   },
   "paldean wooper": {
     "en-US": "Paldean Wooper",
-    "es-ES": null,
+    "es-ES": "Wooper de Paldea",
     "pt-BR": null,
     "fr-FR": "Axoloto de Paldea",
     "it-IT": null,
@@ -8273,7 +8273,7 @@
   },
   "paldean clodsire": {
     "en-US": "Paldean Clodsire",
-    "es-ES": null,
+    "es-ES": "Clodsire de Paldea",
     "pt-BR": null,
     "fr-FR": "Terraiste de Paldea",
     "it-IT": null,
@@ -8281,7 +8281,7 @@
   },
   "alolan exeggutor": {
     "en-US": "Alolan Exeggutor",
-    "es-ES": null,
+    "es-ES": "Exeggutor de Alola",
     "pt-BR": null,
     "fr-FR": "Noadkoko d'Alola",
     "it-IT": null,
@@ -8289,7 +8289,7 @@
   },
   "alolan marowak": {
     "en-US": "Alolan Marowak",
-    "es-ES": null,
+    "es-ES": "Marowak de Alola",
     "pt-BR": null,
     "fr-FR": "Ossatueur d'Alola",
     "it-IT": null,
@@ -8297,7 +8297,7 @@
   },
   "alolan sandshrew": {
     "en-US": "Alolan Sandshrew",
-    "es-ES": null,
+    "es-ES": "Sandshrew de Alola",
     "pt-BR": null,
     "fr-FR": "Sabelette d'Alola",
     "it-IT": null,
@@ -8305,7 +8305,7 @@
   },
   "alolan sandslash": {
     "en-US": "Alolan Sandslash",
-    "es-ES": null,
+    "es-ES": "Sandslash de Alola",
     "pt-BR": null,
     "fr-FR": "Sablaireau d'Alola",
     "it-IT": null,
@@ -8313,7 +8313,7 @@
   },
   "alolan vulpix": {
     "en-US": "Alolan Vulpix",
-    "es-ES": null,
+    "es-ES": "Vulpix de Alola",
     "pt-BR": null,
     "fr-FR": "Goupix d'Alola",
     "it-IT": null,
@@ -8321,7 +8321,7 @@
   },
   "alolan ninetales": {
     "en-US": "Alolan Ninetales",
-    "es-ES": null,
+    "es-ES": "Ninetales de Alola",
     "pt-BR": null,
     "fr-FR": "Feunard d'Alola",
     "it-IT": null,
@@ -8329,7 +8329,7 @@
   },
   "alolan raichu": {
     "en-US": "Alolan Raichu",
-    "es-ES": null,
+    "es-ES": "Raichu de Alola",
     "pt-BR": null,
     "fr-FR": "Raichu d'Alola",
     "it-IT": null,
@@ -8337,7 +8337,7 @@
   },
   "alolan geodude": {
     "en-US": "Alolan Geodude",
-    "es-ES": null,
+    "es-ES": "Geodude de Alola",
     "pt-BR": null,
     "fr-FR": "Racaillou d'Alola",
     "it-IT": null,
@@ -8345,7 +8345,7 @@
   },
   "alolan graveler": {
     "en-US": "Alolan Graveler",
-    "es-ES": null,
+    "es-ES": "Graveler de Alola",
     "pt-BR": null,
     "fr-FR": "Gravalanch d'Alola",
     "it-IT": null,
@@ -8353,7 +8353,7 @@
   },
   "alolan golem": {
     "en-US": "Alolan Golem",
-    "es-ES": null,
+    "es-ES": "Golem de Alola",
     "pt-BR": null,
     "fr-FR": "Grolem d'Alola",
     "it-IT": null,
@@ -8361,7 +8361,7 @@
   },
   "alolan rattata": {
     "en-US": "Alolan Rattata",
-    "es-ES": null,
+    "es-ES": "Rattata de Alola",
     "pt-BR": null,
     "fr-FR": "Rattata d'Alola",
     "it-IT": null,
@@ -8369,7 +8369,7 @@
   },
   "alolan raticate": {
     "en-US": "Alolan Raticate",
-    "es-ES": null,
+    "es-ES": "Raticate de Alola",
     "pt-BR": null,
     "fr-FR": "Rattatac d'Alola",
     "it-IT": null,
@@ -8377,7 +8377,7 @@
   },
   "alolan meowth": {
     "en-US": "Alolan Meowth",
-    "es-ES": null,
+    "es-ES": "Meowth de Alola",
     "pt-BR": null,
     "fr-FR": "Miaouss d'Alola",
     "it-IT": null,
@@ -8385,7 +8385,7 @@
   },
   "alolan persian": {
     "en-US": "Alolan Persian",
-    "es-ES": null,
+    "es-ES": "Persian de Alola",
     "pt-BR": null,
     "fr-FR": "Persian d'Alola",
     "it-IT": null,
@@ -8393,7 +8393,7 @@
   },
   "alolan grimer": {
     "en-US": "Alolan Grimer",
-    "es-ES": null,
+    "es-ES": "Grimer de Alola",
     "pt-BR": null,
     "fr-FR": "Tadmorv d'Alola",
     "it-IT": null,
@@ -8401,7 +8401,7 @@
   },
   "alolan muk": {
     "en-US": "Alolan Muk",
-    "es-ES": null,
+    "es-ES": "Muk de Alola",
     "pt-BR": null,
     "fr-FR": "Grotadmorv d'Alola",
     "it-IT": null,
@@ -8409,7 +8409,7 @@
   },
   "alolan diglett": {
     "en-US": "Alolan Diglett",
-    "es-ES": null,
+    "es-ES": "Diglett de Alola",
     "pt-BR": null,
     "fr-FR": "Taupiqueur d'Alola",
     "it-IT": null,
@@ -8417,7 +8417,7 @@
   },
   "alolan dugtrio": {
     "en-US": "Alolan Dugtrio",
-    "es-ES": null,
+    "es-ES": "Dugtrio de Alola",
     "pt-BR": null,
     "fr-FR": "Triopikeur d'Alola",
     "it-IT": null,
@@ -8449,7 +8449,7 @@
   },
   "galarian corsola": {
     "en-US": "Galarian Corsola",
-    "es-ES": null,
+    "es-ES": "Corsola de Galar",
     "pt-BR": null,
     "fr-FR": "Corayon de Galar",
     "it-IT": null,
@@ -8457,7 +8457,7 @@
   },
   "galarian cursola": {
     "en-US": "Galarian Cursola",
-    "es-ES": null,
+    "es-ES": "Cursola de Galar",
     "pt-BR": null,
     "fr-FR": "Corayôme de Galar",
     "it-IT": null,
@@ -8513,28 +8513,28 @@
   },
   "mega venusaur": {
     "en-US": "Mega Venusaur",
-    "es-ES": null,
+    "es-ES": "Mega-Venusaur",
     "pt-BR": null,
     "fr-FR": "Méga-Florizarre",
     "it-IT": null
   },
   "mega charizard y": {
     "en-US": "Mega Charizard Y",
-    "es-ES": null,
+    "es-ES": "Mega-Charizard Y",
     "pt-BR": null,
     "fr-FR": "Méga-Dracaufeu Y",
     "it-IT": null
   },
   "mega blastoise": {
     "en-US": "Mega Blastoise",
-    "es-ES": null,
+    "es-ES": "Mega-Blastoise",
     "pt-BR": null,
     "fr-FR": "Méga-Tortank",
     "it-IT": null
   },
   "mega lopunny": {
     "en-US": "Mega Lopunny",
-    "es-ES": null,
+    "es-ES": "Mega-Lopunny",
     "pt-BR": null,
     "fr-FR": "Méga-Lockpin",
     "it-IT": null
@@ -8556,175 +8556,175 @@
   },
   "hearthflame mask ogerpon": {
     "en-US": "Hearthflame Mask Ogerpon",
-    "es-ES": null,
+    "es-ES": "Ogerpon Máscara Horno",
     "pt-BR": null,
     "fr-FR": "Ogerpon Masque du Fourneau",
     "it-IT": null
   },
   "galarian mr. mime": {
     "en-US": "Galarian Mr. Mime",
-    "es-ES": null,
+    "es-ES": "Mr. Mime de Galar",
     "pt-BR": null,
     "fr-FR": "M. Mime de Galar",
     "it-IT": null
   },
   "galarian mr. rime": {
     "en-US": "Galarian Mr. Rime",
-    "es-ES": null,
+    "es-ES": "Mr. Rime de Galar",
     "pt-BR": null,
     "fr-FR": "M. Glaquette de Galar",
     "it-IT": null
   },
   "mega swampert": {
     "en-US": "Mega Swampert",
-    "es-ES": null,
+    "es-ES": "Mega-Swampert",
     "pt-BR": null,
     "fr-FR": "Méga-Laggron",
     "it-IT": null
   },
   "wellspring mask ogerpon": {
     "en-US": "Wellspring Mask Ogerpon",
-    "es-ES": null,
+    "es-ES": "Ogerpon Máscara Fuente",
     "pt-BR": null,
     "fr-FR": "Ogerpon Masque du Puits",
     "it-IT": null
   },
   "galarian ponyta": {
     "en-US": "Galarian Ponyta",
-    "es-ES": null,
+    "es-ES": "Ponyta de Galar",
     "pt-BR": null,
     "fr-FR": "Ponyta de Galar",
     "it-IT": null
   },
   "galarian rapidash": {
     "en-US": "Galarian Rapidash",
-    "es-ES": null,
+    "es-ES": "Rapidash de Galar",
     "pt-BR": null,
     "fr-FR": "Galopa de Galar",
     "it-IT": null
   },
   "mega gardevoir": {
     "en-US": "Mega Gardevoir",
-    "es-ES": null,
+    "es-ES": "Mega-Gardevoir",
     "pt-BR": null,
     "fr-FR": "Méga-Gardevoir",
     "it-IT": null
   },
   "cornerstone mask ogerpon": {
     "en-US": "Cornerstone Mask Ogerpon",
-    "es-ES": null,
+    "es-ES": "Ogerpon Máscara Cimiento",
     "pt-BR": null,
     "fr-FR": "Ogerpon Masque de la Pierre",
     "it-IT": null
   },
   "galarian zigzagoon": {
     "en-US": "Galarian Zigzagoon",
-    "es-ES": null,
+    "es-ES": "Zigzagoon de Galar",
     "pt-BR": null,
     "fr-FR": "Zigzaton de Galar",
     "it-IT": null
   },
   "galarian linoone": {
     "en-US": "Galarian Linoone",
-    "es-ES": null,
+    "es-ES": "Linoone de Galar",
     "pt-BR": null,
     "fr-FR": "Linéon de Galar",
     "it-IT": null
   },
   "galarian obstagoon": {
     "en-US": "Galarian Obstagoon",
-    "es-ES": null,
+    "es-ES": "Obstagoon de Galar",
     "pt-BR": null,
     "fr-FR": "Ixon de Galar",
     "it-IT": null
   },
   "galarian meowth": {
     "en-US": "Galarian Meowth",
-    "es-ES": null,
+    "es-ES": "Meowth de Galar",
     "pt-BR": null,
     "fr-FR": "Miaouss de Galar",
     "it-IT": null
   },
   "galarian perrserker": {
     "en-US": "Galarian Perrserker",
-    "es-ES": null,
+    "es-ES": "Perrserker de Galar",
     "pt-BR": null,
     "fr-FR": "Berserkatt de Galar",
     "it-IT": null
   },
   "mega mawile": {
     "en-US": "Mega Mawile",
-    "es-ES": null,
+    "es-ES": "Mega-Mawile",
     "pt-BR": null,
     "fr-FR": "Méga-Mysdibule",
     "it-IT": null
   },
   "galarian stunfisk": {
     "en-US": "Galarian Stunfisk",
-    "es-ES": null,
+    "es-ES": "Stunfisk de Galar",
     "pt-BR": null,
     "fr-FR": "Limonde de Galar",
     "it-IT": null
   },
   "mega kangaskhan": {
     "en-US": "Mega Kangaskhan",
-    "es-ES": null,
+    "es-ES": "Mega-Kangaskhan",
     "pt-BR": null,
     "fr-FR": "Méga-Kangourex",
     "it-IT": null
   },
   "mega charizard x": {
     "en-US": "Mega Charizard X",
-    "es-ES": null,
+    "es-ES": "Mega-Charizard X",
     "pt-BR": null,
     "fr-FR": "Méga-Dracaufeu X",
     "it-IT": null
   },
   "mega slowbro": {
     "en-US": "Mega Slowbro",
-    "es-ES": null,
+    "es-ES": "Mega-Slowbro",
     "pt-BR": null,
     "fr-FR": "Méga Flagadoss",
     "it-IT": null
   },
   "mega manectric": {
     "en-US": "Mega Manectric",
-    "es-ES": null,
+    "es-ES": "Mega-Manectric",
     "pt-BR": null,
     "fr-FR": "Méga-Élecsprint",
     "it-IT": null
   },
   "mega gengar": {
     "en-US": "Mega Gengar",
-    "es-ES": null,
+    "es-ES": "Mega-Gengar",
     "pt-BR": null,
     "fr-FR": "Méga-Ectoplasma",
     "it-IT": null
   },
   "mega scizor": {
     "en-US": "Mega Scizor",
-    "es-ES": null,
+    "es-ES": "Mega-Scizor",
     "pt-BR": null,
     "fr-FR": "Méga-Cizayox",
     "it-IT": null
   },
   "mega pidgeot": {
     "en-US": "Mega Pidgeot",
-    "es-ES": null,
+    "es-ES": "Mega-Pidgeot",
     "pt-BR": null,
     "fr-FR": "Méga-Roucarnage",
     "it-IT": null
   },
   "mega latios": {
     "en-US": "Mega Latios",
-    "es-ES": null,
+    "es-ES": "Mega-Latios",
     "pt-BR": null,
     "fr-FR": "Méga-Latios",
     "it-IT": null
   },
   "mega medicham": {
     "en-US": "Mega Medicham",
-    "es-ES": null,
+    "es-ES": "Mega-Medicham",
     "pt-BR": null,
     "fr-FR": "Méga-Charmina",
     "it-IT": null
@@ -8804,7 +8804,7 @@
   "mega heracross": {
     "en-US": "Mega Heracross",
     "fr-FR": null,
-    "es-ES": null,
+    "es-ES": "Mega-Heracross",
     "pt-BR": null,
     "it-IT": null,
     "de-DE": null
@@ -8896,5 +8896,269 @@
     "pt-BR": null,
     "it-IT": "Mega Sharpedo",
     "de-DE": "Mega-Tohaido"
+  },
+  "team rocket's magmar": {
+    "en-US": "Team Rocket's Magmar",
+    "fr-FR": "Magmar de la Team Rocket",
+    "es-ES": "Magmar del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Magmar del Team Rocket",
+    "de-DE": "Team Rockets Magmar"
+  },
+  "team rocket's moltres": {
+    "en-US": "Team Rocket's Moltres",
+    "fr-FR": "Sulfura de la Team Rocket",
+    "es-ES": "Moltres del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Moltres del Team Rocket",
+    "de-DE": "Team Rockets Lavados"
+  },
+  "team rocket's houndour": {
+    "en-US": "Team Rocket's Houndour",
+    "fr-FR": "Malosse de la Team Rocket",
+    "es-ES": "Houndour del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Houndour del Team Rocket",
+    "de-DE": "Team Rockets Hunduster"
+  },
+  "team rocket's houndoom": {
+    "en-US": "Team Rocket's Houndoom",
+    "fr-FR": "Démolosse de la Team Rocket",
+    "es-ES": "Houndoom del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Houndoom del Team Rocket",
+    "de-DE": "Team Rockets Hundemon"
+  },
+  "team rocket's lapras": {
+    "en-US": "Team Rocket's Lapras",
+    "fr-FR": "Lokhlass de la Team Rocket",
+    "es-ES": "Lapras del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Lapras del Team Rocket",
+    "de-DE": "Team Rockets Lapras"
+  },
+  "team rocket's articuno": {
+    "en-US": "Team Rocket's Articuno",
+    "fr-FR": "Artikodin de la Team Rocket",
+    "es-ES": "Articuno del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Articuno del Team Rocket",
+    "de-DE": "Team Rockets Arktos"
+  },
+  "team rocket's voltorb": {
+    "en-US": "Team Rocket's Voltorb",
+    "fr-FR": "Voltorbe de la Team Rocket",
+    "es-ES": "Voltorb del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Voltorb del Team Rocket",
+    "de-DE": "Team Rockets Voltobal"
+  },
+  "team rocket's electrode": {
+    "en-US": "Team Rocket's Electrode",
+    "fr-FR": "Électrode de la Team Rocket",
+    "es-ES": "Electrode del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Electrode del Team Rocket",
+    "de-DE": "Team Rockets Lektrobal"
+  },
+  "team rocket's zapdos": {
+    "en-US": "Team Rocket's Zapdos",
+    "fr-FR": "Électhor de la Team Rocket",
+    "es-ES": "Zapdos del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Zapdos del Team Rocket",
+    "de-DE": "Team Rockets Zapdos"
+  },
+  "team rocket's pincurchin": {
+    "en-US": "Team Rocket's Pincurchin",
+    "fr-FR": "Wattapik de la Team Rocket",
+    "es-ES": "Pincurchin del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Pincurchin del Team Rocket",
+    "de-DE": "Team Rockets Britzigel"
+  },
+  "team rocket's slowpoke": {
+    "en-US": "Team Rocket's Slowpoke",
+    "fr-FR": "Ramoloss de la Team Rocket",
+    "es-ES": "Slowpoke del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Slowpoke del Team Rocket",
+    "de-DE": "Team Rockets Flegmon"
+  },
+  "team rocket's slowking": {
+    "en-US": "Team Rocket's Slowking",
+    "fr-FR": "Roigada de la Team Rocket",
+    "es-ES": "Slowking del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Slowking del Team Rocket",
+    "de-DE": "Team Rockets Laschoking"
+  },
+  "team rocket's drowzee": {
+    "en-US": "Team Rocket's Drowzee",
+    "fr-FR": "Soporifik de la Team Rocket",
+    "es-ES": "Drowzee del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Drowzee del Team Rocket",
+    "de-DE": "Team Rockets Traumato"
+  },
+  "team rocket's hypno": {
+    "en-US": "Team Rocket's Hypno",
+    "fr-FR": "Hypnomade de la Team Rocket",
+    "es-ES": "Hypno del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Hypno del Team Rocket",
+    "de-DE": "Team Rockets Hypno"
+  },
+  "team rocket's mr. mime": {
+    "en-US": "Team Rocket's Mr. Mime",
+    "fr-FR": "M. Mime de la Team Rocket",
+    "es-ES": "Mr. Mime del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Mr. Mime del Team Rocket",
+    "de-DE": "Team Rockets Pantimos"
+  },
+  "team rocket's mewtwo": {
+    "en-US": "Team Rocket's Mewtwo",
+    "fr-FR": "Mewtwo de la Team Rocket",
+    "es-ES": "Mewtwo del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Mewtwo del Team Rocket",
+    "de-DE": "Team Rockets Mewtu"
+  },
+  "team rocket's ekans": {
+    "en-US": "Team Rocket's Ekans",
+    "fr-FR": "Abo de la Team Rocket",
+    "es-ES": "Ekans del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Ekans del Team Rocket",
+    "de-DE": "Team Rockets Rettan"
+  },
+  "team rocket's arbok": {
+    "en-US": "Team Rocket's Arbok",
+    "fr-FR": "Arbok de la Team Rocket",
+    "es-ES": "Arbok del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Arbok del Team Rocket",
+    "de-DE": "Team Rockets Arbok"
+  },
+  "team rocket's grimer": {
+    "en-US": "Team Rocket's Grimer",
+    "fr-FR": "Tadmorv de la Team Rocket",
+    "es-ES": "Grimer del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Grimer del Team Rocket",
+    "de-DE": "Team Rockets Sleima"
+  },
+  "team rocket's muk": {
+    "en-US": "Team Rocket's Muk",
+    "fr-FR": "Grotadmorv de la Team Rocket",
+    "es-ES": "Muk del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Muk del Team Rocket",
+    "de-DE": "Team Rockets Sleimok"
+  },
+  "team rocket's koffing": {
+    "en-US": "Team Rocket's Koffing",
+    "fr-FR": "Smogo de la Team Rocket",
+    "es-ES": "Koffing del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Koffing del Team Rocket",
+    "de-DE": "Team Rockets Smogon"
+  },
+  "team rocket's weezing": {
+    "en-US": "Team Rocket's Weezing",
+    "fr-FR": "Smogogo de la Team Rocket",
+    "es-ES": "Weezing del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Weezing del Team Rocket",
+    "de-DE": "Team Rockets Smogmog"
+  },
+  "team rocket's sneasel": {
+    "en-US": "Team Rocket's Sneasel",
+    "fr-FR": "Farfuret de la Team Rocket",
+    "es-ES": "Sneasel del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Sneasel del Team Rocket",
+    "de-DE": "Team Rockets Sniebel"
+  },
+  "team rocket's tinkatink": {
+    "en-US": "Team Rocket's Tinkatink",
+    "fr-FR": "Forgerette de la Team Rocket",
+    "es-ES": "Tinkatink del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Tinkatink del Team Rocket",
+    "de-DE": "Team Rockets Forgita"
+  },
+  "team rocket's tinkatuff": {
+    "en-US": "Team Rocket's Tinkatuff",
+    "fr-FR": "Forgella de la Team Rocket",
+    "es-ES": "Tinkatuff del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Tinkatuff del Team Rocket",
+    "de-DE": "Team Rockets Tafforgita"
+  },
+  "team rocket's tinkaton": {
+    "en-US": "Team Rocket's Tinkaton",
+    "fr-FR": "Forgelina de la Team Rocket",
+    "es-ES": "Tinkaton del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Tinkaton del Team Rocket",
+    "de-DE": "Team Rockets Granforgita"
+  },
+  "team rocket's rattata": {
+    "en-US": "Team Rocket's Rattata",
+    "fr-FR": "Rattata de la Team Rocket",
+    "es-ES": "Rattata del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Rattata del Team Rocket",
+    "de-DE": "Team Rockets Rattfratz"
+  },
+  "team rocket's raticate": {
+    "en-US": "Team Rocket's Raticate",
+    "fr-FR": "Rattatac de la Team Rocket",
+    "es-ES": "Raticate del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Raticate del Team Rocket",
+    "de-DE": "Team Rockets Rattikarl"
+  },
+  "team rocket's meowth": {
+    "en-US": "Team Rocket's Meowth",
+    "fr-FR": "Miaouss de la Team Rocket",
+    "es-ES": "Meowth del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Meowth del Team Rocket",
+    "de-DE": "Team Rockets Mauzi"
+  },
+  "team rocket's persian": {
+    "en-US": "Team Rocket's Persian",
+    "fr-FR": "Persian de la Team Rocket",
+    "es-ES": "Persian del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Persian del Team Rocket",
+    "de-DE": "Team Rockets Snobilikat"
+  },
+  "team rocket's kecleon": {
+    "en-US": "Team Rocket's Kecleon",
+    "fr-FR": "Kecleon de la Team Rocket",
+    "es-ES": "Kecleon del Team Rocket",
+    "pt-BR": null,
+    "it-IT": "Kecleon del Team Rocket",
+    "de-DE": "Team Rockets Kecleon"
+  },
+  "hisuian basculin": {
+    "en-US": "Hisuian Basculin",
+    "fr-FR": "Bargantua de Hisui",
+    "es-ES": "Basculin de Hisui",
+    "pt-BR": null,
+    "it-IT": "Basculin di Hisui",
+    "de-DE": "Hisui-Barschuft"
+  },
+  "hisuian basculegion": {
+    "en-US": "Hisuian Basculegion",
+    "fr-FR": "Paragruel de Hisui",
+    "es-ES": "Basculegion de Hisui",
+    "pt-BR": null,
+    "it-IT": "Basculegion di Hisui",
+    "de-DE": "Hisui-Salmagnis"
   }
 }

--- a/frontend/assets/pokemon_translations.json
+++ b/frontend/assets/pokemon_translations.json
@@ -8201,7 +8201,7 @@
   },
   "mow rotom": {
     "en-US": "Mow Rotom",
-    "es-ES": null,
+    "es-ES": "Rotom Corte",
     "pt-BR": null,
     "fr-FR": "Motisma Tonte",
     "it-IT": null,
@@ -8209,7 +8209,7 @@
   },
   "heat rotom": {
     "en-US": "Heat Rotom",
-    "es-ES": null,
+    "es-ES": "Rotom Calor",
     "pt-BR": null,
     "fr-FR": "Motisma Chaleur",
     "it-IT": null,
@@ -8217,7 +8217,7 @@
   },
   "wash rotom": {
     "en-US": "Wash Rotom",
-    "es-ES": null,
+    "es-ES": "Rotom Lavado",
     "pt-BR": null,
     "fr-FR": "Motisma Lavage",
     "it-IT": null,
@@ -8225,7 +8225,7 @@
   },
   "frost rotom": {
     "en-US": "Frost Rotom",
-    "es-ES": null,
+    "es-ES": "Rotom Frío",
     "pt-BR": null,
     "fr-FR": "Motisma Froid",
     "it-IT": null,
@@ -8233,7 +8233,7 @@
   },
   "fan rotom": {
     "en-US": "Fan Rotom",
-    "es-ES": null,
+    "es-ES": "Rotom Ventilador",
     "pt-BR": null,
     "fr-FR": "Motisma Hélice",
     "it-IT": null,
@@ -8241,7 +8241,7 @@
   },
   "origin forme palkia": {
     "en-US": "Origin Forme Palkia",
-    "es-ES": null,
+    "es-ES": "Palkia Forma Origen",
     "pt-BR": null,
     "fr-FR": "Palkia Forme Originelle",
     "it-IT": null,
@@ -8249,7 +8249,7 @@
   },
   "origin forme dialga": {
     "en-US": "Origin Forme Dialga",
-    "es-ES": null,
+    "es-ES": "Dialga Forma Origen",
     "pt-BR": null,
     "fr-FR": "Dialga Forme Originelle",
     "it-IT": null,
@@ -8425,7 +8425,7 @@
   },
   "dawn wings necrozma": {
     "en-US": "Dawn Wings Necrozma",
-    "es-ES": null,
+    "es-ES": "Necrozma Alas del Alba",
     "pt-BR": null,
     "fr-FR": "Necrozma Ailes de l'Aurore",
     "it-IT": null,
@@ -8433,7 +8433,7 @@
   },
   "dusk mane necrozma": {
     "en-US": "Dusk Mane Necrozma",
-    "es-ES": null,
+    "es-ES": "Necrozma Melena Crepuscular",
     "pt-BR": null,
     "fr-FR": "Necrozma Crinière du Couchant",
     "it-IT": null,
@@ -8441,7 +8441,7 @@
   },
   "ultra necrozma": {
     "en-US": "Ultra Necrozma",
-    "es-ES": null,
+    "es-ES": "Ultra-Necrozma",
     "pt-BR": null,
     "fr-FR": "Ultra-Necrozma",
     "it-IT": null,

--- a/frontend/assets/tools_translations.json
+++ b/frontend/assets/tools_translations.json
@@ -622,5 +622,29 @@
     "pt-BR": "Litoral Calmante",
     "it-IT": "Litorale Confortante",
     "de-DE": "Heilende Küste"
+  },
+  "team rocket's thieving machine": {
+    "en-US": "Team Rocket's Thieving Machine",
+    "fr-FR": "Robot Rafleur de la Team Rocket",
+    "es-ES": "Robomatón del Team Rocket",
+    "pt-BR": "Máquina de Roubo da Equipe Rocket",
+    "it-IT": "Ladrobot del Team Rocket",
+    "de-DE": "Team Rockets Raubmaschine"
+  },
+  "team rocket's goo-zooka": {
+    "en-US": "Team Rocket's Goo-zooka",
+    "fr-FR": "Bazooka Dégueu de la Team Rocket",
+    "es-ES": "Babazuca del Team Rocket",
+    "pt-BR": "Bazuca de Gosma da Equipe Rocket",
+    "it-IT": "Sparacolla del Team Rocket",
+    "de-DE": "Team Rockets Schleim-Bazooka"
+  },
+  "arcade": {
+    "en-US": "Arcade",
+    "fr-FR": "Salle d'Arcade",
+    "es-ES": "Salón Recreativo",
+    "pt-BR": "Arcade",
+    "it-IT": "Centro Giochi",
+    "de-DE": "Gamer-Paradies"
   }
 }

--- a/frontend/assets/trainers_translations.json
+++ b/frontend/assets/trainers_translations.json
@@ -630,5 +630,29 @@
     "pt-BR": "Fã de Filhotes",
     "it-IT": "Amante dei Cuccioli",
     "de-DE": "Welpenliebhaberin"
+  },
+  "team rocket's boss": {
+    "en-US": "Team Rocket's Boss",
+    "fr-FR": "Boss de la Team Rocket",
+    "es-ES": "Jefe del Team Rocket",
+    "pt-BR": "Chefe da Equipe Rocket",
+    "it-IT": "Capo Team Rocket",
+    "de-DE": "Boss von Team Rocket"
+  },
+  "team rocket's master plan": {
+    "en-US": "Team Rocket's Master Plan",
+    "fr-FR": "Plan Machiavélique de la Team Rocket",
+    "es-ES": "Plan Maestro del Team Rocket",
+    "pt-BR": "Plano Mestre da Equipe Rocket",
+    "it-IT": "Grande Piano del Team Rocket",
+    "de-DE": "Team Rockets Großer Plan"
+  },
+  "team rocket's researcher": {
+    "en-US": "Team Rocket's Researcher",
+    "fr-FR": "Chercheuse de la Team Rocket",
+    "es-ES": "Investigación del Team Rocket",
+    "pt-BR": "Pesquisador da Equipe Rocket",
+    "it-IT": "Ricercatrice del Team Rocket",
+    "de-DE": "Forscherin von Team Rocket"
   }
 }


### PR DESCRIPTION
## Summary

Three related things bundled because they share the `cards.json` / translation-files scope:

### 1. B4a translations (39 new entries)

- **33 Pokémon**: 31 Team Rocket's variants built from base name + per-language template, verified from Bulbapedia's *In other languages* on the trainer pages (`es "{X} del Team Rocket"`, `fr "{X} de la Team Rocket"`, `de "Team Rockets {X}"`, `it "{X} del Team Rocket"`). Plus Hisuian Basculin/Basculegion following the existing hisuian template.
- **3 Supporters**: Team Rocket's Boss / Master Plan / Researcher.
- **3 Tools/Stadium**: Team Rocket's Thieving Machine / Goo-zooka + Arcade.

All non-Pokémon values sourced verbatim from Bulbapedia. `pt-BR` is left `null` for Team Rocket's Pokémon to match the existing project convention (base Pokémon entries have `pt-BR: null` throughout).

### 2. es-ES backfill for prior sets (62 entries)

Filled Spanish nulls for regional and Mega forms:

- Alolan (18): `{X} de Alola`
- Galarian (12): `{X} de Galar`
- Paldean Wooper/Clodsire (2): `{X} de Paldea`
- Mega (17): `Mega-{X}`
- Wellspring/Hearthflame/Cornerstone Mask Ogerpon (3)
- Necrozma Dawn Wings / Dusk Mane / Ultra (3)
- Origin Forme Dialga/Palkia (2)
- Rotom Heat/Wash/Frost/Fan/Mow (5)

Templates verified from existing filled entries (`Hisuian Zorua`, `Mega-Rayquaza`, `Tauros de Paldea`, `Ogerpon Máscara Turquesa`, `Castform Forma Sol`). Necrozma/Origin/Rotom names sourced from wikidex.net.

### 3. Two B4-19 data bugs

- **Name**: `"Teal MaskOgerpon"` → `"Teal Mask Ogerpon"`. Missing space broke the translation lookup — every other Ogerpon uses the correctly spaced key.
- **Attack**: `name="Ogre's"` + `damage="Whip"` → `name="Ogre's Whip"`, `damage=""`. The two words were split across the wrong fields; attack has variable damage (no fixed number).

## Test plan

- [x] Sample lookups render translated names in the UI
- [x] `pnpm run hashes --verify` passes
- [x] `pnpm build` passes

## Known gaps out of scope

- pt-BR is null for ~890 base Pokémon across the whole project — separate concern, needs its own source.
- it-IT / de-DE also have ~73 / ~31 prior-set gaps of the same kind. Same templates apply; deferred to keep this PR focused on es-ES which was directly reported.
- ~247 other attacks across older sets have the same "attack name split into name+damage" bug as B4-19 — systemic scraper bug worth a separate PR.