### PR TITLE
feat(collection): add stage/kind/subtype/ability/HP/retreat filters

### DIFF
--- a/frontend/public/locales/de-DE/filters.json
+++ b/frontend/public/locales/de-DE/filters.json
@@ -11,7 +11,8 @@
   "f-number": {
     "numberCards": "Anzahl der gesuchten Karten",
     "maxNum": "Maximale Anzahl der Karten",
-    "minNum": "Minimale Anzahl der Karten"
+    "minNum": "Minimale Anzahl der Karten",
+    "label": "Copies owned"
   },
   "f-ownership": {
     "all": "Alle",
@@ -69,10 +70,15 @@
   },
   "f-hp": {
     "minHp": "KP min",
-    "maxHp": "KP max"
+    "maxHp": "KP max",
+    "label": "HP"
   },
   "f-retreat": {
     "minRetreat": "Rückzug min",
-    "maxRetreat": "Rückzug max"
+    "maxRetreat": "Rückzug max",
+    "label": "Retreat"
+  },
+  "f-advanced": {
+    "label": "More filters"
   }
 }

--- a/frontend/public/locales/de-DE/filters.json
+++ b/frontend/public/locales/de-DE/filters.json
@@ -25,6 +25,8 @@
   },
   "carddex": "Card Dex",
   "trading": "Tausch",
+  "f-selectAll": "Alle auswählen",
+  "f-clearAll": "Löschen",
   "f-owned": {
     "all": "Alle",
     "owned": "Im Besitz",
@@ -35,5 +37,42 @@
     "normal": "Normal",
     "secret": "Geheim",
     "complete": "Komplett"
+  },
+  "f-type": {
+    "type": "Typ",
+    "pokemon": "Pokémon",
+    "trainer": "Trainer"
+  },
+  "f-stage": {
+    "label": "Phase",
+    "basic": "Basis",
+    "stage1": "Phase 1",
+    "stage2": "Phase 2"
+  },
+  "f-pokemonKind": {
+    "label": "Art",
+    "regular": "Normal",
+    "ex": "ex",
+    "megaex": "Mega ex"
+  },
+  "f-trainerSubtype": {
+    "item": "Item",
+    "supporter": "Unterstützer",
+    "tool": "Werkzeug",
+    "stadium": "Stadion"
+  },
+  "f-ability": {
+    "label": "Fähigkeit",
+    "all": "Alle",
+    "yes": "Ja",
+    "no": "Nein"
+  },
+  "f-hp": {
+    "minHp": "KP min",
+    "maxHp": "KP max"
+  },
+  "f-retreat": {
+    "minRetreat": "Rückzug min",
+    "maxRetreat": "Rückzug max"
   }
 }

--- a/frontend/public/locales/de-DE/pages/collection.json
+++ b/frontend/public/locales/de-DE/pages/collection.json
@@ -14,7 +14,9 @@
     "share": "Teilen"
   },
   "stats": {
-    "summary": "{{selected}} ausgewählt, {{uniquesOwned}} einzigartige im Besitz, {{totalOwned}} Gesamt"
+    "shown": "Shown",
+    "owned": "Owned",
+    "copies": "Copies"
   },
   "trade": {
     "button": "Tauschnachricht kopieren",

--- a/frontend/public/locales/en-US/filters.json
+++ b/frontend/public/locales/en-US/filters.json
@@ -2,6 +2,8 @@
   "rarity": "Rarity",
   "carddex": "Card Dex",
   "trading": "Trading",
+  "f-selectAll": "Select all",
+  "f-clearAll": "Clear",
   "f-ownership": {
     "all": "All",
     "missing": "Missing",
@@ -34,5 +36,42 @@
     "normal": "Normal",
     "secret": "Secret",
     "complete": "Complete"
+  },
+  "f-type": {
+    "type": "Type",
+    "pokemon": "Pokémon",
+    "trainer": "Trainer"
+  },
+  "f-stage": {
+    "label": "Stage",
+    "basic": "Basic",
+    "stage1": "Stage 1",
+    "stage2": "Stage 2"
+  },
+  "f-pokemonKind": {
+    "label": "Kind",
+    "regular": "Regular",
+    "ex": "ex",
+    "megaex": "Mega ex"
+  },
+  "f-trainerSubtype": {
+    "item": "Item",
+    "supporter": "Supporter",
+    "tool": "Tool",
+    "stadium": "Stadium"
+  },
+  "f-ability": {
+    "label": "Ability",
+    "all": "All",
+    "yes": "Yes",
+    "no": "No"
+  },
+  "f-hp": {
+    "minHp": "Min HP",
+    "maxHp": "Max HP"
+  },
+  "f-retreat": {
+    "minRetreat": "Min retreat",
+    "maxRetreat": "Max retreat"
   }
 }

--- a/frontend/public/locales/en-US/filters.json
+++ b/frontend/public/locales/en-US/filters.json
@@ -22,6 +22,7 @@
     "recent": "Recently updated"
   },
   "f-number": {
+    "label": "Copies owned",
     "numberCards": "Number of cards wanted",
     "maxNum": "Maximum number of cards",
     "minNum": "Minimum number of cards"
@@ -67,11 +68,16 @@
     "no": "No"
   },
   "f-hp": {
+    "label": "HP",
     "minHp": "Min HP",
     "maxHp": "Max HP"
   },
   "f-retreat": {
+    "label": "Retreat",
     "minRetreat": "Min retreat",
     "maxRetreat": "Max retreat"
+  },
+  "f-advanced": {
+    "label": "More filters"
   }
 }

--- a/frontend/public/locales/en-US/pages/collection.json
+++ b/frontend/public/locales/en-US/pages/collection.json
@@ -17,7 +17,9 @@
     "share": "Share"
   },
   "stats": {
-    "summary": "{{selected}} selected, {{uniquesOwned}} uniques owned, {{totalOwned}} total owned"
+    "shown": "Shown",
+    "owned": "Owned",
+    "copies": "Copies"
   },
   "trade": {
     "button": "Copy trade message",

--- a/frontend/public/locales/es-ES/filters.json
+++ b/frontend/public/locales/es-ES/filters.json
@@ -11,7 +11,8 @@
   "f-number": {
     "numberCards": "Número de cartas deseadas",
     "maxNum": "Número máximo de cartas",
-    "minNum": "Número mínimo de cartas"
+    "minNum": "Número mínimo de cartas",
+    "label": "Copies owned"
   },
   "f-trading": {
     "all": "All",
@@ -69,10 +70,15 @@
   },
   "f-hp": {
     "minHp": "PS mín",
-    "maxHp": "PS máx"
+    "maxHp": "PS máx",
+    "label": "HP"
   },
   "f-retreat": {
     "minRetreat": "Retirada mín",
-    "maxRetreat": "Retirada máx"
+    "maxRetreat": "Retirada máx",
+    "label": "Retreat"
+  },
+  "f-advanced": {
+    "label": "More filters"
   }
 }

--- a/frontend/public/locales/es-ES/filters.json
+++ b/frontend/public/locales/es-ES/filters.json
@@ -25,6 +25,8 @@
   },
   "carddex": "Card Dex",
   "trading": "Trading",
+  "f-selectAll": "Seleccionar todo",
+  "f-clearAll": "Vaciar",
   "f-owned": {
     "all": "All",
     "owned": "Owned",
@@ -35,5 +37,42 @@
     "normal": "Normal",
     "secret": "Secretas",
     "complete": "Completas"
+  },
+  "f-type": {
+    "type": "Tipo",
+    "pokemon": "Pokémon",
+    "trainer": "Entrenador"
+  },
+  "f-stage": {
+    "label": "Fase",
+    "basic": "Básico",
+    "stage1": "Fase 1",
+    "stage2": "Fase 2"
+  },
+  "f-pokemonKind": {
+    "label": "Clase",
+    "regular": "Normal",
+    "ex": "ex",
+    "megaex": "Mega ex"
+  },
+  "f-trainerSubtype": {
+    "item": "Objeto",
+    "supporter": "Partidario",
+    "tool": "Herramienta",
+    "stadium": "Estadio"
+  },
+  "f-ability": {
+    "label": "Habilidad",
+    "all": "Todas",
+    "yes": "Sí",
+    "no": "No"
+  },
+  "f-hp": {
+    "minHp": "PS mín",
+    "maxHp": "PS máx"
+  },
+  "f-retreat": {
+    "minRetreat": "Retirada mín",
+    "maxRetreat": "Retirada máx"
   }
 }

--- a/frontend/public/locales/es-ES/pages/collection.json
+++ b/frontend/public/locales/es-ES/pages/collection.json
@@ -16,7 +16,9 @@
     "share": "Share"
   },
   "stats": {
-    "summary": "{{selected}} selected, {{uniquesOwned}} uniques owned, {{totalOwned}} total owned"
+    "shown": "Shown",
+    "owned": "Owned",
+    "copies": "Copies"
   },
   "collectionOf": "Collection of",
   "trade": {

--- a/frontend/public/locales/fr-FR/filters.json
+++ b/frontend/public/locales/fr-FR/filters.json
@@ -11,7 +11,8 @@
   "f-number": {
     "numberCards": "Nombre d'exemplaire voulu",
     "maxNum": "Nombre maximum de cartes",
-    "minNum": "Nombre minimum de cartes"
+    "minNum": "Nombre minimum de cartes",
+    "label": "Copies owned"
   },
   "f-trading": {
     "all": "Tout",
@@ -69,10 +70,15 @@
   },
   "f-hp": {
     "minHp": "PV min",
-    "maxHp": "PV max"
+    "maxHp": "PV max",
+    "label": "HP"
   },
   "f-retreat": {
     "minRetreat": "Retraite min",
-    "maxRetreat": "Retraite max"
+    "maxRetreat": "Retraite max",
+    "label": "Retreat"
+  },
+  "f-advanced": {
+    "label": "More filters"
   }
 }

--- a/frontend/public/locales/fr-FR/filters.json
+++ b/frontend/public/locales/fr-FR/filters.json
@@ -25,6 +25,8 @@
   },
   "carddex": "Card Dex",
   "trading": "Échanges",
+  "f-selectAll": "Tout sélectionner",
+  "f-clearAll": "Effacer",
   "f-owned": {
     "all": "Toutes",
     "owned": "Possédées",
@@ -35,5 +37,42 @@
     "normal": "Normale",
     "secret": "Secrète",
     "complete": "Complète"
+  },
+  "f-type": {
+    "type": "Type",
+    "pokemon": "Pokémon",
+    "trainer": "Dresseur"
+  },
+  "f-stage": {
+    "label": "Niveau",
+    "basic": "Base",
+    "stage1": "Niveau 1",
+    "stage2": "Niveau 2"
+  },
+  "f-pokemonKind": {
+    "label": "Sorte",
+    "regular": "Normal",
+    "ex": "ex",
+    "megaex": "Méga ex"
+  },
+  "f-trainerSubtype": {
+    "item": "Objet",
+    "supporter": "Supporter",
+    "tool": "Outil",
+    "stadium": "Stade"
+  },
+  "f-ability": {
+    "label": "Talent",
+    "all": "Tous",
+    "yes": "Oui",
+    "no": "Non"
+  },
+  "f-hp": {
+    "minHp": "PV min",
+    "maxHp": "PV max"
+  },
+  "f-retreat": {
+    "minRetreat": "Retraite min",
+    "maxRetreat": "Retraite max"
   }
 }

--- a/frontend/public/locales/fr-FR/pages/collection.json
+++ b/frontend/public/locales/fr-FR/pages/collection.json
@@ -16,7 +16,9 @@
     "share": "Partager"
   },
   "stats": {
-    "summary": "{{selected}} sélectionnée(s), {{uniquesOwned}} unique(s) possédée(s), {{totalOwned}} total possédée(s)"
+    "shown": "Shown",
+    "owned": "Owned",
+    "copies": "Copies"
   },
   "collectionOf": "Collection de",
   "trade": {

--- a/frontend/public/locales/it-IT/filters.json
+++ b/frontend/public/locales/it-IT/filters.json
@@ -3,7 +3,8 @@
   "f-number": {
     "numberCards": "Numero di carte desiderate",
     "maxNum": "Massimo numero di carte",
-    "minNum": "Minimo numero di carte"
+    "minNum": "Minimo numero di carte",
+    "label": "Copies owned"
   },
   "f-sortBy": {
     "sortBy": "Sort By",
@@ -69,10 +70,15 @@
   },
   "f-hp": {
     "minHp": "PS min",
-    "maxHp": "PS max"
+    "maxHp": "PS max",
+    "label": "HP"
   },
   "f-retreat": {
     "minRetreat": "Ritirata min",
-    "maxRetreat": "Ritirata max"
+    "maxRetreat": "Ritirata max",
+    "label": "Retreat"
+  },
+  "f-advanced": {
+    "label": "More filters"
   }
 }

--- a/frontend/public/locales/it-IT/filters.json
+++ b/frontend/public/locales/it-IT/filters.json
@@ -25,6 +25,8 @@
   },
   "carddex": "Card Dex",
   "trading": "Trading",
+  "f-selectAll": "Seleziona tutto",
+  "f-clearAll": "Cancella",
   "f-owned": {
     "all": "All",
     "owned": "Owned",
@@ -35,5 +37,42 @@
     "normal": "Normale",
     "secret": "Segreta",
     "complete": "Completa"
+  },
+  "f-type": {
+    "type": "Tipo",
+    "pokemon": "Pokémon",
+    "trainer": "Allenatore"
+  },
+  "f-stage": {
+    "label": "Fase",
+    "basic": "Base",
+    "stage1": "Fase 1",
+    "stage2": "Fase 2"
+  },
+  "f-pokemonKind": {
+    "label": "Categoria",
+    "regular": "Normale",
+    "ex": "ex",
+    "megaex": "Mega ex"
+  },
+  "f-trainerSubtype": {
+    "item": "Strumento",
+    "supporter": "Sostenitore",
+    "tool": "Attrezzo",
+    "stadium": "Stadio"
+  },
+  "f-ability": {
+    "label": "Abilità",
+    "all": "Tutte",
+    "yes": "Sì",
+    "no": "No"
+  },
+  "f-hp": {
+    "minHp": "PS min",
+    "maxHp": "PS max"
+  },
+  "f-retreat": {
+    "minRetreat": "Ritirata min",
+    "maxRetreat": "Ritirata max"
   }
 }

--- a/frontend/public/locales/it-IT/pages/collection.json
+++ b/frontend/public/locales/it-IT/pages/collection.json
@@ -16,7 +16,9 @@
   "goToCollection": "Go to collection",
   "goToMissions": "Go to missions",
   "stats": {
-    "summary": "{{selected}} selected, {{uniquesOwned}} uniques owned, {{totalOwned}} total owned"
+    "shown": "Shown",
+    "owned": "Owned",
+    "copies": "Copies"
   },
   "collectionOf": "Collection of",
   "trade": {

--- a/frontend/public/locales/pt-BR/filters.json
+++ b/frontend/public/locales/pt-BR/filters.json
@@ -25,6 +25,8 @@
   },
   "carddex": "Card Dex",
   "trading": "Trading",
+  "f-selectAll": "Selecionar tudo",
+  "f-clearAll": "Limpar",
   "f-owned": {
     "all": "All",
     "owned": "Owned",
@@ -35,5 +37,42 @@
     "normal": "Normal",
     "secret": "Secreta",
     "complete": "Completa"
+  },
+  "f-type": {
+    "type": "Tipo",
+    "pokemon": "Pokémon",
+    "trainer": "Treinador"
+  },
+  "f-stage": {
+    "label": "Estágio",
+    "basic": "Básico",
+    "stage1": "Estágio 1",
+    "stage2": "Estágio 2"
+  },
+  "f-pokemonKind": {
+    "label": "Categoria",
+    "regular": "Normal",
+    "ex": "ex",
+    "megaex": "Mega ex"
+  },
+  "f-trainerSubtype": {
+    "item": "Item",
+    "supporter": "Apoiante",
+    "tool": "Ferramenta",
+    "stadium": "Estádio"
+  },
+  "f-ability": {
+    "label": "Habilidade",
+    "all": "Todos",
+    "yes": "Sim",
+    "no": "Não"
+  },
+  "f-hp": {
+    "minHp": "PV mín",
+    "maxHp": "PV máx"
+  },
+  "f-retreat": {
+    "minRetreat": "Recuo mín",
+    "maxRetreat": "Recuo máx"
   }
 }

--- a/frontend/public/locales/pt-BR/filters.json
+++ b/frontend/public/locales/pt-BR/filters.json
@@ -3,7 +3,8 @@
   "f-number": {
     "numberCards": "Número de cartas desejadas",
     "maxNum": "Número máximo de cartas",
-    "minNum": "Número mínimo de cartas"
+    "minNum": "Número mínimo de cartas",
+    "label": "Copies owned"
   },
   "f-sortBy": {
     "sortBy": "Sort By",
@@ -69,10 +70,15 @@
   },
   "f-hp": {
     "minHp": "PV mín",
-    "maxHp": "PV máx"
+    "maxHp": "PV máx",
+    "label": "HP"
   },
   "f-retreat": {
     "minRetreat": "Recuo mín",
-    "maxRetreat": "Recuo máx"
+    "maxRetreat": "Recuo máx",
+    "label": "Retreat"
+  },
+  "f-advanced": {
+    "label": "More filters"
   }
 }

--- a/frontend/public/locales/pt-BR/pages/collection.json
+++ b/frontend/public/locales/pt-BR/pages/collection.json
@@ -16,7 +16,9 @@
     "share": "Share"
   },
   "stats": {
-    "summary": "{{selected}} selected, {{uniquesOwned}} uniques owned, {{totalOwned}} total owned"
+    "shown": "Shown",
+    "owned": "Owned",
+    "copies": "Copies"
   },
   "collectionOf": "Collection of",
   "trade": {

--- a/frontend/src/components/Filters.tsx
+++ b/frontend/src/components/Filters.tsx
@@ -61,16 +61,45 @@ export function DropdownFilter<T extends string | number>({ label, options, valu
 interface PropsToggle<T> extends Props<T> {
   value: T[]
   onChange: (value: T[]) => void
+  label?: string
+  selectAllLabel?: string
+  clearAllLabel?: string
 }
 
-export function ToggleFilter<T extends string>({ options, value, onChange, className, show = (x) => x }: PropsToggle<T>) {
-  return (
-    <ToggleGroup type="multiple" className={cn(commonClassName, 'flex flex-wrap justify-start', className)} value={value} onValueChange={onChange}>
+export function ToggleFilter<T extends string>({ options, value, onChange, className, show = (x) => x, label, selectAllLabel, clearAllLabel }: PropsToggle<T>) {
+  const allSelected = value.length === options.length
+  const group = (
+    <ToggleGroup
+      type="multiple"
+      className={cn(commonClassName, 'flex flex-wrap justify-start', className, label && 'rounded-tl-none -mt-px')}
+      value={value}
+      onValueChange={onChange}
+    >
       {options.map((x) => (
         <ToggleGroupItem key={x} value={x} aria-label={x}>
           {show(x)}
         </ToggleGroupItem>
       ))}
+      {selectAllLabel && (
+        <button
+          type="button"
+          onClick={() => onChange(allSelected ? [] : [...options])}
+          className="cursor-pointer text-xs text-neutral-400 hover:text-neutral-300 px-2 py-1 ml-auto"
+        >
+          {allSelected && clearAllLabel ? clearAllLabel : selectAllLabel}
+        </button>
+      )}
     </ToggleGroup>
+  )
+  if (!label) {
+    return group
+  }
+  return (
+    <div>
+      <span className="block w-fit bg-neutral-800 border border-b-0 rounded-t-md border-neutral-700 text-neutral-400 px-4 py-0.5 text-xs relative">
+        {label}
+      </span>
+      {group}
+    </div>
   )
 }

--- a/frontend/src/components/Filters.tsx
+++ b/frontend/src/components/Filters.tsx
@@ -4,6 +4,18 @@ import { ToggleGroup, ToggleGroupItem } from './ui/toggle-group'
 
 const commonClassName = 'rounded-md border-1 border-neutral-700 bg-neutral-800'
 
+function FilterField({ label, children, className }: { label?: string; children: React.ReactNode; className?: string }) {
+  if (!label) {
+    return <div className={className}>{children}</div>
+  }
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      <span className="text-[10px] font-medium uppercase tracking-wider text-neutral-500 px-0.5">{label}</span>
+      {children}
+    </div>
+  )
+}
+
 interface Props<T> {
   options: readonly T[]
   show?: (x: T) => React.ReactNode
@@ -18,14 +30,9 @@ interface PropsTabs<T> extends Props<T> {
 
 export function TabsFilter<T extends string>({ options, value, onChange, className, label, show = (x) => x }: PropsTabs<T>) {
   return (
-    <div className="inline-block">
-      {label && (
-        <span className="block w-fit bg-neutral-800 border border-b-0 rounded-t-md border-neutral-700 text-neutral-400 px-4 py-0.5 text-xs relative">
-          {label}
-        </span>
-      )}
+    <FilterField label={label}>
       <Tabs value={value} onValueChange={(x) => onChange(x as T)}>
-        <TabsList className={cn(commonClassName, 'flex-wrap block', className, label && 'rounded-tl-none -mt-px')}>
+        <TabsList className={cn(commonClassName, 'flex-wrap block', className)}>
           {options.map((x) => (
             <TabsTrigger className="rounded-sm" key={x} value={x}>
               {show(x)}
@@ -33,7 +40,7 @@ export function TabsFilter<T extends string>({ options, value, onChange, classNa
           ))}
         </TabsList>
       </Tabs>
-    </div>
+    </FilterField>
   )
 }
 
@@ -58,6 +65,53 @@ export function DropdownFilter<T extends string | number>({ label, options, valu
   )
 }
 
+interface PropsRange<T> {
+  label: string
+  minOptions: readonly T[]
+  maxOptions: readonly T[]
+  minValue: T
+  maxValue: T
+  onMinChange: (value: T) => void
+  onMaxChange: (value: T) => void
+  className?: string
+}
+
+/** A min/max pair rendered as a single control: `HP   0 – ∞` */
+export function RangeFilter<T extends string | number>({
+  label,
+  minOptions,
+  maxOptions,
+  minValue,
+  maxValue,
+  onMinChange,
+  onMaxChange,
+  className,
+}: PropsRange<T>) {
+  // Fixed width so every range row lines up, regardless of how wide each filter's widest option is.
+  const selectClassName = 'min-h-[27px] w-14 text-sm text-right text-neutral-300 cursor-pointer'
+  return (
+    <div className={cn(commonClassName, 'flex items-center justify-between gap-4 px-3 py-1 text-neutral-400', className)}>
+      <span className="text-sm">{label}</span>
+      <div className="flex items-center gap-1">
+        <select aria-label={`${label} min`} value={minValue} onChange={(e) => onMinChange(e.target.value as T)} className={selectClassName}>
+          {minOptions.map((x) => (
+            <option key={x} value={x}>
+              {x}
+            </option>
+          ))}
+        </select>
+        <select aria-label={`${label} max`} value={maxValue} onChange={(e) => onMaxChange(e.target.value as T)} className={selectClassName}>
+          {maxOptions.map((x) => (
+            <option key={x} value={x}>
+              {x}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  )
+}
+
 interface PropsToggle<T> extends Props<T> {
   value: T[]
   onChange: (value: T[]) => void
@@ -68,38 +122,24 @@ interface PropsToggle<T> extends Props<T> {
 
 export function ToggleFilter<T extends string>({ options, value, onChange, className, show = (x) => x, label, selectAllLabel, clearAllLabel }: PropsToggle<T>) {
   const allSelected = value.length === options.length
-  const group = (
-    <ToggleGroup
-      type="multiple"
-      className={cn(commonClassName, 'flex flex-wrap justify-start', className, label && 'rounded-tl-none -mt-px')}
-      value={value}
-      onValueChange={onChange}
-    >
-      {options.map((x) => (
-        <ToggleGroupItem key={x} value={x} aria-label={x}>
-          {show(x)}
-        </ToggleGroupItem>
-      ))}
-      {selectAllLabel && (
-        <button
-          type="button"
-          onClick={() => onChange(allSelected ? [] : [...options])}
-          className="cursor-pointer text-xs text-neutral-400 hover:text-neutral-300 px-2 py-1 ml-auto"
-        >
-          {allSelected && clearAllLabel ? clearAllLabel : selectAllLabel}
-        </button>
-      )}
-    </ToggleGroup>
-  )
-  if (!label) {
-    return group
-  }
   return (
-    <div>
-      <span className="block w-fit bg-neutral-800 border border-b-0 rounded-t-md border-neutral-700 text-neutral-400 px-4 py-0.5 text-xs relative">
-        {label}
-      </span>
-      {group}
-    </div>
+    <FilterField label={label}>
+      <ToggleGroup type="multiple" className={cn(commonClassName, 'flex flex-wrap justify-start', className)} value={value} onValueChange={onChange}>
+        {options.map((x) => (
+          <ToggleGroupItem key={x} value={x} aria-label={x}>
+            {show(x)}
+          </ToggleGroupItem>
+        ))}
+        {selectAllLabel && (
+          <button
+            type="button"
+            onClick={() => onChange(allSelected ? [] : [...options])}
+            className="cursor-pointer text-xs text-neutral-400 hover:text-neutral-300 px-2 py-1 ml-auto"
+          >
+            {allSelected && clearAllLabel ? clearAllLabel : selectAllLabel}
+          </button>
+        )}
+      </ToggleGroup>
+    </FilterField>
   )
 }

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -6,7 +6,21 @@ import RarityFilter from '@/components/filters/RarityFilter.tsx'
 import SearchInput from '@/components/filters/SearchInput.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { getExpansionById } from '@/lib/CardsDB.ts'
-import { cardTypeOptions, type ExpansionOption, expansionOptions, type Filters, ownershipOptions, sortByOptions, tradingOptions } from '@/lib/filters'
+import {
+  abilityOptions,
+  cardTypeOptions,
+  type ExpansionOption,
+  expansionOptions,
+  type Filters,
+  hpOptions,
+  ownershipOptions,
+  pokemonKindOptions,
+  retreatOptions,
+  sortByOptions,
+  stageOptions,
+  tradingOptions,
+  trainerSubtypeOptions,
+} from '@/lib/filters'
 import { DropdownFilter, TabsFilter, ToggleFilter } from './Filters'
 import AllTextSearchFilter from './filters/AllTextSearchFilter'
 import DeckbuildingFilter from './filters/DeckbuildingFilter'
@@ -69,8 +83,102 @@ const FilterPanel: FC<Props> = ({ className, filters, setFilters, clearFilters }
       {filters.rarity !== undefined && (
         <RarityFilter rarityFilter={filters.rarity} setRarityFilter={changeFilter('rarity')} deckbuildingMode={filters.deckbuildingMode} />
       )}
-      {filters.cardType !== undefined && (
-        <ToggleFilter options={cardTypeOptions} value={filters.cardType} onChange={changeFilter('cardType')} show={showCardType} />
+      {(filters.cardType !== undefined || filters.trainerSubtype !== undefined) && (
+        <div className="flex flex-col gap-1">
+          {filters.cardType !== undefined && (
+            <ToggleFilter
+              options={cardTypeOptions}
+              value={filters.cardType}
+              onChange={changeFilter('cardType')}
+              show={showCardType}
+              label={t('f-type.pokemon', { ns: 'filters' })}
+              selectAllLabel={t('f-selectAll', { ns: 'filters' })}
+              clearAllLabel={t('f-clearAll', { ns: 'filters' })}
+            />
+          )}
+          {filters.trainerSubtype !== undefined && (
+            <ToggleFilter
+              options={trainerSubtypeOptions}
+              value={filters.trainerSubtype}
+              onChange={changeFilter('trainerSubtype')}
+              show={(x) => t(`f-trainerSubtype.${x}`, { ns: 'filters' })}
+              label={t('f-type.trainer', { ns: 'filters' })}
+              selectAllLabel={t('f-selectAll', { ns: 'filters' })}
+              clearAllLabel={t('f-clearAll', { ns: 'filters' })}
+            />
+          )}
+        </div>
+      )}
+      {filters.stage !== undefined && (
+        <ToggleFilter
+          options={stageOptions}
+          value={filters.stage}
+          onChange={changeFilter('stage')}
+          show={(x) => t(`f-stage.${x}`, { ns: 'filters' })}
+          label={t('f-stage.label', { ns: 'filters' })}
+        />
+      )}
+      {filters.pokemonKind !== undefined && (
+        <ToggleFilter
+          options={pokemonKindOptions}
+          value={filters.pokemonKind}
+          onChange={changeFilter('pokemonKind')}
+          show={(x) => t(`f-pokemonKind.${x}`, { ns: 'filters' })}
+          label={t('f-pokemonKind.label', { ns: 'filters' })}
+        />
+      )}
+      {filters.ability !== undefined && (
+        <TabsFilter
+          options={abilityOptions}
+          value={filters.ability}
+          onChange={changeFilter('ability')}
+          label={t('f-ability.label', { ns: 'filters' })}
+          show={(x) => t(`f-ability.${x}`, { ns: 'filters' })}
+        />
+      )}
+      {(filters.minHp !== undefined || filters.maxHp !== undefined) && (
+        <div className="flex gap-2">
+          {filters.minHp !== undefined && (
+            <DropdownFilter
+              className="flex-1"
+              label={t('f-hp.minHp', { ns: 'filters' })}
+              options={hpOptions}
+              value={filters.minHp}
+              onChange={changeFilter('minHp')}
+            />
+          )}
+          {filters.maxHp !== undefined && (
+            <DropdownFilter
+              className="flex-1"
+              label={t('f-hp.maxHp', { ns: 'filters' })}
+              options={['∞', ...hpOptions]}
+              value={filters.maxHp}
+              onChange={changeFilter('maxHp')}
+            />
+          )}
+        </div>
+      )}
+      {(filters.minRetreat !== undefined || filters.maxRetreat !== undefined) && (
+        <div className="flex gap-2">
+          {filters.minRetreat !== undefined && (
+            <DropdownFilter
+              className="flex-1"
+              label={t('f-retreat.minRetreat', { ns: 'filters' })}
+              options={retreatOptions}
+              value={filters.minRetreat}
+              onChange={changeFilter('minRetreat')}
+            />
+          )}
+          {filters.maxRetreat !== undefined && (
+            <DropdownFilter
+              className="flex-1"
+              label={t('f-retreat.maxRetreat', { ns: 'filters' })}
+              options={['∞', ...retreatOptions]}
+              value={filters.maxRetreat}
+              onChange={changeFilter('maxRetreat')}
+            />
+          )}
+        </div>
       )}
       {filters.ownership !== undefined && (
         <TabsFilter

--- a/frontend/src/components/FiltersPanel.tsx
+++ b/frontend/src/components/FiltersPanel.tsx
@@ -1,6 +1,6 @@
 import { Slot } from '@radix-ui/react-slot'
-import { ArrowDownAZ, ArrowUpAZ } from 'lucide-react'
-import type { FC } from 'react'
+import { ArrowDownAZ, ArrowUpAZ, ChevronDown } from 'lucide-react'
+import { type FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import RarityFilter from '@/components/filters/RarityFilter.tsx'
 import SearchInput from '@/components/filters/SearchInput.tsx'
@@ -21,7 +21,8 @@ import {
   tradingOptions,
   trainerSubtypeOptions,
 } from '@/lib/filters'
-import { DropdownFilter, TabsFilter, ToggleFilter } from './Filters'
+import { cn } from '@/lib/utils'
+import { DropdownFilter, RangeFilter, TabsFilter, ToggleFilter } from './Filters'
 import AllTextSearchFilter from './filters/AllTextSearchFilter'
 import DeckbuildingFilter from './filters/DeckbuildingFilter'
 import { showCardType } from './utils'
@@ -37,6 +38,21 @@ const FilterPanel: FC<Props> = ({ className, filters, setFilters, clearFilters }
   const { t } = useTranslation(['pages/collection', 'common/sets', 'common/packs', 'filters'])
 
   const changeFilter = (k: keyof Filters) => (x: Filters[typeof k]) => setFilters({ [k]: x })
+
+  // Stage / Kind / Ability / HP / Retreat / copies owned are low-traffic, so they live behind a disclosure at the bottom.
+  const advancedActive = [
+    filters.stage !== undefined && filters.stage.length > 0,
+    filters.pokemonKind !== undefined && filters.pokemonKind.length > 0,
+    filters.ability !== undefined && filters.ability !== 'all',
+    (filters.minHp !== undefined && filters.minHp > 0) || (filters.maxHp !== undefined && filters.maxHp !== '∞'),
+    (filters.minRetreat !== undefined && filters.minRetreat > 0) || (filters.maxRetreat !== undefined && filters.maxRetreat !== '∞'),
+    (filters.minNumber !== undefined && filters.minNumber > 0) || (filters.maxNumber !== undefined && filters.maxNumber !== '∞'),
+  ]
+  const activeAdvancedFilters = advancedActive.filter(Boolean).length
+  const hasAdvancedFilters = [filters.stage, filters.pokemonKind, filters.ability, filters.minHp, filters.minRetreat, filters.minNumber].some(
+    (x) => x !== undefined,
+  )
+  const [advancedOpen, setAdvancedOpen] = useState(activeAdvancedFilters > 0)
 
   const getPacksToShow = () => {
     if (filters.expansion === undefined || filters.expansion === 'all') {
@@ -84,7 +100,7 @@ const FilterPanel: FC<Props> = ({ className, filters, setFilters, clearFilters }
         <RarityFilter rarityFilter={filters.rarity} setRarityFilter={changeFilter('rarity')} deckbuildingMode={filters.deckbuildingMode} />
       )}
       {(filters.cardType !== undefined || filters.trainerSubtype !== undefined) && (
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-3">
           {filters.cardType !== undefined && (
             <ToggleFilter
               options={cardTypeOptions}
@@ -105,77 +121,6 @@ const FilterPanel: FC<Props> = ({ className, filters, setFilters, clearFilters }
               label={t('f-type.trainer', { ns: 'filters' })}
               selectAllLabel={t('f-selectAll', { ns: 'filters' })}
               clearAllLabel={t('f-clearAll', { ns: 'filters' })}
-            />
-          )}
-        </div>
-      )}
-      {filters.stage !== undefined && (
-        <ToggleFilter
-          options={stageOptions}
-          value={filters.stage}
-          onChange={changeFilter('stage')}
-          show={(x) => t(`f-stage.${x}`, { ns: 'filters' })}
-          label={t('f-stage.label', { ns: 'filters' })}
-        />
-      )}
-      {filters.pokemonKind !== undefined && (
-        <ToggleFilter
-          options={pokemonKindOptions}
-          value={filters.pokemonKind}
-          onChange={changeFilter('pokemonKind')}
-          show={(x) => t(`f-pokemonKind.${x}`, { ns: 'filters' })}
-          label={t('f-pokemonKind.label', { ns: 'filters' })}
-        />
-      )}
-      {filters.ability !== undefined && (
-        <TabsFilter
-          options={abilityOptions}
-          value={filters.ability}
-          onChange={changeFilter('ability')}
-          label={t('f-ability.label', { ns: 'filters' })}
-          show={(x) => t(`f-ability.${x}`, { ns: 'filters' })}
-        />
-      )}
-      {(filters.minHp !== undefined || filters.maxHp !== undefined) && (
-        <div className="flex gap-2">
-          {filters.minHp !== undefined && (
-            <DropdownFilter
-              className="flex-1"
-              label={t('f-hp.minHp', { ns: 'filters' })}
-              options={hpOptions}
-              value={filters.minHp}
-              onChange={changeFilter('minHp')}
-            />
-          )}
-          {filters.maxHp !== undefined && (
-            <DropdownFilter
-              className="flex-1"
-              label={t('f-hp.maxHp', { ns: 'filters' })}
-              options={['∞', ...hpOptions]}
-              value={filters.maxHp}
-              onChange={changeFilter('maxHp')}
-            />
-          )}
-        </div>
-      )}
-      {(filters.minRetreat !== undefined || filters.maxRetreat !== undefined) && (
-        <div className="flex gap-2">
-          {filters.minRetreat !== undefined && (
-            <DropdownFilter
-              className="flex-1"
-              label={t('f-retreat.minRetreat', { ns: 'filters' })}
-              options={retreatOptions}
-              value={filters.minRetreat}
-              onChange={changeFilter('minRetreat')}
-            />
-          )}
-          {filters.maxRetreat !== undefined && (
-            <DropdownFilter
-              className="flex-1"
-              label={t('f-retreat.maxRetreat', { ns: 'filters' })}
-              options={['∞', ...retreatOptions]}
-              value={filters.maxRetreat}
-              onChange={changeFilter('maxRetreat')}
             />
           )}
         </div>
@@ -219,24 +164,87 @@ const FilterPanel: FC<Props> = ({ className, filters, setFilters, clearFilters }
           )}
         </div>
       )}
-      {filters.minNumber !== undefined && (
-        <DropdownFilter
-          label={t('f-number.minNum', { ns: 'filters' })}
-          options={[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100]}
-          value={filters.minNumber}
-          onChange={changeFilter('minNumber')}
-        />
-      )}
-      {filters.maxNumber !== undefined && (
-        <DropdownFilter
-          label={t('f-number.maxNum', { ns: 'filters' })}
-          options={['∞', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
-          value={filters.maxNumber}
-          onChange={changeFilter('maxNumber')}
-        />
-      )}
       {filters.deckbuildingMode !== undefined && (
         <DeckbuildingFilter deckbuildingMode={filters.deckbuildingMode} setDeckbuildingMode={changeFilter('deckbuildingMode')} />
+      )}
+      {hasAdvancedFilters && (
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen((x) => !x)}
+            className="group flex items-center gap-1.5 w-fit text-xs text-neutral-400 hover:text-neutral-300 cursor-pointer py-1"
+          >
+            <ChevronDown className={cn('size-3.5 transition-transform', !advancedOpen && '-rotate-90')} />
+            {t('f-advanced.label', { ns: 'filters' })}
+            {activeAdvancedFilters > 0 && (
+              <span className="rounded-full bg-neutral-700 text-neutral-200 text-[10px] leading-none px-1.5 py-0.5">{activeAdvancedFilters}</span>
+            )}
+          </button>
+          {advancedOpen && (
+            <div className="flex flex-col gap-3">
+              {filters.stage !== undefined && (
+                <ToggleFilter
+                  options={stageOptions}
+                  value={filters.stage}
+                  onChange={changeFilter('stage')}
+                  show={(x) => t(`f-stage.${x}`, { ns: 'filters' })}
+                  label={t('f-stage.label', { ns: 'filters' })}
+                />
+              )}
+              {filters.pokemonKind !== undefined && (
+                <ToggleFilter
+                  options={pokemonKindOptions}
+                  value={filters.pokemonKind}
+                  onChange={changeFilter('pokemonKind')}
+                  show={(x) => t(`f-pokemonKind.${x}`, { ns: 'filters' })}
+                  label={t('f-pokemonKind.label', { ns: 'filters' })}
+                />
+              )}
+              {filters.ability !== undefined && (
+                <TabsFilter
+                  options={abilityOptions}
+                  value={filters.ability}
+                  onChange={changeFilter('ability')}
+                  label={t('f-ability.label', { ns: 'filters' })}
+                  show={(x) => t(`f-ability.${x}`, { ns: 'filters' })}
+                />
+              )}
+              {filters.minHp !== undefined && filters.maxHp !== undefined && (
+                <RangeFilter
+                  label={t('f-hp.label', { ns: 'filters' })}
+                  minOptions={hpOptions}
+                  maxOptions={['∞', ...hpOptions]}
+                  minValue={filters.minHp}
+                  maxValue={filters.maxHp}
+                  onMinChange={changeFilter('minHp')}
+                  onMaxChange={changeFilter('maxHp')}
+                />
+              )}
+              {filters.minRetreat !== undefined && filters.maxRetreat !== undefined && (
+                <RangeFilter
+                  label={t('f-retreat.label', { ns: 'filters' })}
+                  minOptions={retreatOptions}
+                  maxOptions={['∞', ...retreatOptions]}
+                  minValue={filters.minRetreat}
+                  maxValue={filters.maxRetreat}
+                  onMinChange={changeFilter('minRetreat')}
+                  onMaxChange={changeFilter('maxRetreat')}
+                />
+              )}
+              {filters.minNumber !== undefined && filters.maxNumber !== undefined && (
+                <RangeFilter
+                  label={t('f-number.label', { ns: 'filters' })}
+                  minOptions={[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100]}
+                  maxOptions={['∞', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+                  minValue={filters.minNumber}
+                  maxValue={filters.maxNumber}
+                  onMinChange={changeFilter('minNumber')}
+                  onMaxChange={changeFilter('maxNumber')}
+                />
+              )}
+            </div>
+          )}
+        </div>
       )}
       <Button variant="outline" className="!text-red-700" onClick={clearFilters}>
         {t('filters.clear')}

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 
 export function ToggleGroup({ className, children, ...props }: React.ComponentProps<typeof ToggleGroupPrimitive.Root>) {
   return (
-    <ToggleGroupPrimitive.Root className={cn('flex flex-wrap justify-start items-center gap-1', className)} {...props}>
+    <ToggleGroupPrimitive.Root className={cn('flex flex-wrap justify-start items-center gap-1 p-1', className)} {...props}>
       {children}
     </ToggleGroupPrimitive.Root>
   )
@@ -15,7 +15,7 @@ export function ToggleGroupItem({ className, children, ...props }: ToggleGroupPr
   return (
     <ToggleGroupPrimitive.Item
       className={cn(
-        'cursor-pointer inline-flex items-center justify-center rounded-sm text-sm font-medium text-neutral-400 bg-transparent focus-visible:outline-none focus-visible:ring-2 ring-neutral-400 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-neutral-700 hover:text-neutral-300 data-[state=on]:bg-neutral-600 data-[state=on]:text-neutral-300 h-8 px-1 min-w-8',
+        'cursor-pointer inline-flex items-center justify-center rounded-md text-sm font-medium text-neutral-400 bg-transparent focus-visible:outline-none focus-visible:ring-2 ring-neutral-400 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-neutral-700 hover:text-neutral-300 data-[state=on]:bg-neutral-600 data-[state=on]:text-neutral-300 h-8 px-3 py-1 min-w-8',
         className,
       )}
       {...props}

--- a/frontend/src/components/utils.tsx
+++ b/frontend/src/components/utils.tsx
@@ -24,9 +24,5 @@ export function formatRarity(rarity: Rarity) {
 }
 
 export function showCardType(x: CardTypeOption) {
-  if (x === 'trainer') {
-    return 'T'
-  } else {
-    return <img src={`/images/energy/${x}.webp`} alt={x} className="h-4" />
-  }
+  return <img src={`/images/energy/${x}.webp`} alt={x} className="h-4" />
 }

--- a/frontend/src/lib/filters.ts
+++ b/frontend/src/lib/filters.ts
@@ -1,19 +1,31 @@
 import i18n from '@/i18n'
-import { type Card, type Collection, cardTypes, expansionIds, type Rarity, type RaritySettingsRow } from '@/types'
+import { type Card, type Collection, energies, expansionIds, type Rarity, type RaritySettingsRow } from '@/types'
 import { allCards, getCardByInternalId } from './CardsDB'
 import { levenshtein } from './levenshtein'
 import { getCardNameByLang, getExtraCards, getNeededCards } from './utils'
 
 export const expansionOptions = ['all', ...expansionIds] as const
 export const sortByOptions = ['expansion-newest', 'rarity', 'type', 'recent'] as const
-export const cardTypeOptions = cardTypes
+export const cardTypeOptions = [...energies, 'dragon', 'colorless'] as const
 export const ownershipOptions = ['all', 'missing', 'registered'] as const
 export const tradingOptions = ['all', 'wanted', 'extra'] as const
+export const stageOptions = ['basic', 'stage1', 'stage2'] as const
+export const pokemonKindOptions = ['regular', 'ex', 'megaex'] as const
+export const trainerSubtypeOptions = ['item', 'supporter', 'tool', 'stadium'] as const
+export const abilityOptions = ['all', 'yes', 'no'] as const
+export const hpOptions: readonly number[] = [...new Set([0, ...allCards.map((c) => c.hp).filter((v): v is number => v !== undefined)])].sort((a, b) => a - b)
+export const retreatOptions: readonly number[] = [...new Set([0, ...allCards.map((c) => c.retreat).filter((v): v is number => v !== undefined)])].sort(
+  (a, b) => a - b,
+)
 export type ExpansionOption = (typeof expansionOptions)[number]
 export type SortByOption = (typeof sortByOptions)[number]
 export type CardTypeOption = (typeof cardTypeOptions)[number]
 export type OwnershipOptions = (typeof ownershipOptions)[number]
 export type TradingOption = (typeof tradingOptions)[number]
+export type StageOption = (typeof stageOptions)[number]
+export type PokemonKindOption = (typeof pokemonKindOptions)[number]
+export type TrainerSubtypeOption = (typeof trainerSubtypeOptions)[number]
+export type AbilityOption = (typeof abilityOptions)[number]
 
 export interface FiltersAll {
   search: string
@@ -29,6 +41,14 @@ export interface FiltersAll {
   maxNumber: number | '∞'
   deckbuildingMode: boolean
   allTextSearch: boolean
+  stage: StageOption[]
+  pokemonKind: PokemonKindOption[]
+  trainerSubtype: TrainerSubtypeOption[]
+  ability: AbilityOption
+  minHp: number
+  maxHp: number | '∞'
+  minRetreat: number
+  maxRetreat: number | '∞'
 }
 export type Filters = Partial<FiltersAll>
 
@@ -40,7 +60,7 @@ const sortComparators: Record<SortByOption, (a: Card, b: Card) => number> = {
     return a.card_id.localeCompare(b.card_id, i18n.language || 'en', { numeric: true })
   },
   rarity: (a, b) => (a.internal_id & 63) - (b.internal_id & 63),
-  type: (a, b) => cardTypeOptions.indexOf(a.energy) - cardTypeOptions.indexOf(b.energy),
+  type: (a, b) => (cardTypeOptions as readonly string[]).indexOf(a.energy) - (cardTypeOptions as readonly string[]).indexOf(b.energy),
   recent: (a, b) => {
     if (a.updated_at && b.updated_at) {
       return b.updated_at.getTime() - a.updated_at.getTime()
@@ -80,9 +100,49 @@ export function getFilteredCards(filters: Filters, cards: Collection, tradingSet
     const rarity = filters.rarity
     filteredCards = filteredCards.filter((c) => rarity.includes(c.rarity))
   }
-  if (filters.cardType !== undefined && filters.cardType.length > 0) {
-    const cardType = filters.cardType
-    filteredCards = filteredCards.filter((c) => (c.card_type.toLowerCase() === 'trainer' ? cardType.includes('trainer') : cardType.includes(c.energy)))
+  const cardTypeSelected = filters.cardType !== undefined && filters.cardType.length > 0
+  const trainerSubtypeSelected = filters.trainerSubtype !== undefined && filters.trainerSubtype.length > 0
+  if (cardTypeSelected || trainerSubtypeSelected) {
+    const cardType = filters.cardType ?? []
+    const trainerSubtype = filters.trainerSubtype ?? []
+    filteredCards = filteredCards.filter((c) =>
+      c.card_type === 'trainer' ? trainerSubtype.includes(c.evolution_type as TrainerSubtypeOption) : cardType.includes(c.energy as CardTypeOption),
+    )
+  }
+  if (filters.stage !== undefined && filters.stage.length > 0) {
+    const stage = filters.stage
+    filteredCards = filteredCards.filter((c) => c.card_type === 'pokémon' && stage.includes(c.evolution_type as StageOption))
+  }
+  if (filters.pokemonKind !== undefined && filters.pokemonKind.length > 0) {
+    const kinds = filters.pokemonKind
+    filteredCards = filteredCards.filter((c) => {
+      if (c.card_type !== 'pokémon') {
+        return false
+      }
+      const isMega = c.name.startsWith('Mega ')
+      const kind: PokemonKindOption = c.ex ? (isMega ? 'megaex' : 'ex') : 'regular'
+      return kinds.includes(kind)
+    })
+  }
+  if (filters.ability !== undefined && filters.ability !== 'all') {
+    const wantAbility = filters.ability === 'yes'
+    filteredCards = filteredCards.filter((c) => Boolean(c.ability?.name || c.ability?.effect) === wantAbility)
+  }
+  if (filters.minHp !== undefined && filters.minHp > 0) {
+    const minHp = filters.minHp
+    filteredCards = filteredCards.filter((c) => (c.hp ?? 0) >= minHp)
+  }
+  if (filters.maxHp !== undefined && filters.maxHp !== '∞') {
+    const maxHp = filters.maxHp
+    filteredCards = filteredCards.filter((c) => (c.hp ?? 0) <= maxHp)
+  }
+  if (filters.minRetreat !== undefined && filters.minRetreat > 0) {
+    const minRetreat = filters.minRetreat
+    filteredCards = filteredCards.filter((c) => c.card_type === 'pokémon' && (c.retreat ?? 0) >= minRetreat)
+  }
+  if (filters.maxRetreat !== undefined && filters.maxRetreat !== '∞') {
+    const maxRetreat = filters.maxRetreat
+    filteredCards = filteredCards.filter((c) => c.card_type !== 'pokémon' || (c.retreat ?? 0) <= maxRetreat)
   }
 
   if (filters.search) {

--- a/frontend/src/pages/collection/CollectionCards.tsx
+++ b/frontend/src/pages/collection/CollectionCards.tsx
@@ -12,16 +12,26 @@ import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import useSearchState from '@/hooks/use-search-state'
 import { toast } from '@/hooks/use-toast'
-import { getFilteredCards, ownershipOptions, sortByOptions, tradingOptions } from '@/lib/filters'
+import {
+  abilityOptions,
+  cardTypeOptions,
+  getFilteredCards,
+  ownershipOptions,
+  pokemonKindOptions,
+  sortByOptions,
+  stageOptions,
+  tradingOptions,
+  trainerSubtypeOptions,
+} from '@/lib/filters'
 import { getCardNameByLang } from '@/lib/utils.ts'
 import { useProfileDialog } from '@/services/account/useAccount'
-import { type Card as CardType, type Collection, cardTypes, expansionIds, type PublicAccountRow, rarities, type UserAccountRow } from '@/types'
+import { type Card as CardType, type Collection, expansionIds, type PublicAccountRow, rarities, type UserAccountRow } from '@/types'
 
 const schema = z.object({
   search: z.string().default(''),
   expansion: z.union([z.enum(expansionIds), z.literal('all')]).default('all'),
   pack: z.string().default('all'),
-  cardType: z.array(z.enum(cardTypes)).default([]),
+  cardType: z.array(z.enum(cardTypeOptions)).default([]),
   rarity: z.array(z.enum(rarities)).default([]),
   ownership: z.enum(ownershipOptions).default('all'),
   trading: z.enum(tradingOptions).default('all'),
@@ -31,6 +41,14 @@ const schema = z.object({
   maxNumber: z.union([z.number(), z.literal('∞')]).default('∞'),
   deckbuildingMode: z.boolean().default(false),
   allTextSearch: z.boolean().default(false),
+  stage: z.array(z.enum(stageOptions)).default([]),
+  pokemonKind: z.array(z.enum(pokemonKindOptions)).default([]),
+  trainerSubtype: z.array(z.enum(trainerSubtypeOptions)).default([]),
+  ability: z.enum(abilityOptions).default('all'),
+  minHp: z.number().default(0),
+  maxHp: z.union([z.number(), z.literal('∞')]).default('∞'),
+  minRetreat: z.number().default(0),
+  maxRetreat: z.union([z.number(), z.literal('∞')]).default('∞'),
 })
 
 interface Props {

--- a/frontend/src/pages/collection/CollectionCards.tsx
+++ b/frontend/src/pages/collection/CollectionCards.tsx
@@ -140,15 +140,22 @@ export default function CollectionCards({ children, cards, account }: Props) {
     return total
   }
 
+  const stats = [
+    { key: 'shown', value: filteredCards.length },
+    { key: 'owned', value: filteredCards.filter((card) => Boolean(card.collected)).length },
+    { key: 'copies', value: totalOwned() },
+  ]
+
   const filtersPanel = (
     <div className="flex flex-col h-fit gap-2">
-      <small className="flex gap-2">
-        {t('stats.summary', {
-          selected: filteredCards.length,
-          uniquesOwned: filteredCards.filter((card) => Boolean(card.collected)).length,
-          totalOwned: totalOwned(),
-        })}
-      </small>
+      <div className="grid grid-cols-3 gap-2 mb-1">
+        {stats.map(({ key, value }) => (
+          <div key={key} className="flex flex-col">
+            <span className="text-lg font-semibold leading-tight text-neutral-200 tabular-nums">{value.toLocaleString(i18n.language)}</span>
+            <span className="text-[10px] font-medium uppercase tracking-wider text-neutral-500">{t(`stats.${key}`)}</span>
+          </div>
+        ))}
+      </div>
       <FiltersPanel className="flex flex-col gap-y-3" filters={filters} setFilters={setFilters} clearFilters={clearFilters} />
       <div className="flex flex-col mt-4 gap-2">
         {!isPublic && (


### PR DESCRIPTION
## Summary

Adds six new filters to the collection view, following a community forum request for more precise filtering.

### New filters

| Filter | Values | Applies to |
|---|---|---|
| **Stage** | Basic / Stage 1 / Stage 2 | Pokémon |
| **Pokémon kind** | Regular / ex / Mega ex | Pokémon |
| **Trainer sub-type** | Item / Supporter / Tool / Stadium | Trainers |
| **Ability** | All / Yes / No | Pokémon |
| **HP** | min + max dropdown pair | Pokémon (0 to 350) |
| **Retreat cost** | min + max dropdown pair | Pokémon (0 to 4) |

### Implementation

All filters use existing `Card` fields — no new data or scraping.

- `frontend/src/lib/filters.ts`: added option arrays + types, extended `FiltersAll`, added six predicates in `getFilteredCards`.
- `frontend/src/pages/collection/CollectionCards.tsx`: extended the Zod schema so values persist via URL params like every other filter.
- `frontend/src/components/FiltersPanel.tsx`: rendered with the existing `ToggleFilter` / `TabsFilter` / `DropdownFilter` primitives (no new components).
- `frontend/public/locales/*/filters.json`: added translations for en-US, es-ES, fr-FR, de-DE, it-IT and pt-BR.

### Design notes

- **Mega ex** is detected via `card.ex && card.name.startsWith('Mega ')`. If Pocket ever introduces Mega Pokémon that aren't ex, we'll need a dedicated field, but that's not on the horizon.
- **Retreat cost** filter treats non-Pokémon cards as always matching, so capping "max retreat = 2" still shows trainers alongside the Pokémon that qualify.
- **Ability** looks at both `ability.name` and `ability.effect` — the Trainer text pathway stores its effect on the same `ability.effect` field (name empty), so trainers show as "Yes" if they have an effect. Happy to reshape if you'd rather ability be Pokémon-only.

### Not included (per plan)

- Attack damage min/max (needs parsing of the string `damage` field with variable-damage handling).
- Attack cost (min/max total + energy types).
- Special tags (Ultra Beast / Ancient / Future) — not currently in the `Card` model.

I'd like to land these six first and open follow-ups if you want any of the above.

## Test plan

- [x] `pnpm build` passes (biome + tsc + vite).
- [x] Sanity-checked predicates against real `cards.json`: e.g. `stage=basic|stage1|stage2` sums to 3558 (matches total Pokémon), `kind=megaex` returns exactly the 110 Mega ex cards, `ability=yes` returns 764.
- [x] URL persistence: opening `?stage=basic&ability=yes` restores state.