### PR TITLE
Fix verify scraper workflow

### DIFF
--- a/.github/workflows/verify-scraper.yml
+++ b/.github/workflows/verify-scraper.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run scraper
-        run: pnpm run scraper
+        run: pnpm run scraper-cards
 
       - name: Verify scraper output is committed
         run: |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "pnpm --filter frontend run dev",
     "build": "pnpm --filter frontend run build",
     "scraper": "tsx scripts/scraper.js && node scripts/download-packs.js && tsx scripts/generate-scan-hashes.ts && tsx scripts/sql/generate-cards-table.ts && node scripts/scrape-missions.js && pnpm lint:fix",
+    "scraper-cards": "tsx scripts/scraper.js && node scripts/download-packs.js && tsx scripts/generate-scan-hashes.ts && tsx scripts/sql/generate-cards-table.ts && pnpm lint:fix",
     "hashes": "tsx scripts/generate-scan-hashes.ts",
     "sync-locales": "node scripts/sync-locales.js"
   },


### PR DESCRIPTION
The workflow at #1009 fails because of the scrape missions script. It targets pokemon-zone, which is behind cloudflare (see the discussion at #751) which apparently blocks GitHub actions runners.

This PR adds a second command that skips scraping missions, to be used in the runner. The main `scraper` command is kept as is for convenience.