### PR TITLE
Decrease scope for verify-hashes

### DIFF
--- a/.github/workflows/verify-hashes.yml
+++ b/.github/workflows/verify-hashes.yml
@@ -9,15 +9,11 @@ on:
       - 'frontend/public/images/**'
       - 'frontend/public/hashes/**'
       - 'frontend/assets/cards.json'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
   pull_request:
     paths:
       - 'frontend/public/images/**'
       - 'frontend/public/hashes/**'
       - 'frontend/assets/cards.json'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
 jobs:
   verify-hashes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow sometimes runs when it doesn't need to, for example in #1011, wasting 5min of compute time.