### PR TITLE
fix(sw): stale-while-revalidate + version bump so image updates propagate

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,24 +1,49 @@
-const CACHE_NAME = 'tcg-pocket-cache-v1'
-const IMAGE_CACHE = 'images/'
+// Bump this whenever the caching strategy changes, or to force every user
+// to drop stale entries from a previous version. The activate handler
+// deletes any cache whose name doesn't match.
+const CACHE_NAME = 'tcg-pocket-cache-v2'
+const IMAGE_PATH_MARKER = '/images/'
 
-self.addEventListener('activate', (_event) => {
-  console.log('Service Worker activated.')
+self.addEventListener('install', (event) => {
+  // Take over immediately so returning users get the new strategy on the
+  // next fetch instead of the tab-close-and-reopen dance.
+  event.waitUntil(self.skipWaiting())
 })
 
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const names = await caches.keys()
+      await Promise.all(names.filter((n) => n !== CACHE_NAME).map((n) => caches.delete(n)))
+      await self.clients.claim()
+    })(),
+  )
+})
+
+// Stale-while-revalidate: serve the cached copy immediately (fast, offline
+// friendly) and refresh the cache in the background so the next request
+// gets the newer bytes. Previous versions used cache-first with no refresh,
+// which pinned outdated image binaries in every returning user's browser
+// even after we shipped replacements.
 self.addEventListener('fetch', (event) => {
-  if (event.request.url.includes(IMAGE_CACHE)) {
-    event.respondWith(
-      caches.match(event.request).then((cachedResponse) => {
-        return (
-          cachedResponse ||
-          fetch(event.request).then((response) => {
-            return caches.open(CACHE_NAME).then((cache) => {
-              cache.put(event.request, response.clone())
-              return response
-            })
-          })
-        )
-      }),
-    )
+  const { request } = event
+  if (request.method !== 'GET' || !request.url.includes(IMAGE_PATH_MARKER)) {
+    return
   }
+
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME)
+      const cached = await cache.match(request)
+      const network = fetch(request)
+        .then((response) => {
+          if (response?.ok) {
+            cache.put(request, response.clone()).catch(() => {})
+          }
+          return response
+        })
+        .catch(() => undefined)
+      return cached || (await network) || Response.error()
+    })(),
+  )
 })


### PR DESCRIPTION
## Summary

`frontend/public/service-worker.js` was cache-first over `/images/` with no revalidation, so once a browser cached an image it kept serving that copy forever — even after we shipped a replacement. The only way a returning user could see the new bytes was Ctrl+Shift+R (which bypasses the SW) or manually unregistering the worker.

## The bug in the wild

- #1013 replaced `P-B-79..86` with fixed WebP binaries.
- Users who had visited before #1013 still saw the broken versions — their SW kept serving the pre-#1013 cache.
- Same story for the 16 stale set logos refreshed in #1017 (B4a's placeholder, all the A-series updates, etc.).
- Clearing the site's Cache Storage (or unregistering the SW) made the new images appear instantly — confirming the SW was the culprit and the server had the right bytes all along.

## Changes

- **Strategy → stale-while-revalidate.** Cache is served if present, but a background fetch always updates it for the next request. Users still get fast loads and offline resilience, but they pick up new bytes within one visit of us shipping a replacement.
- **`CACHE_NAME` bumped `v1` → `v2`** with a new `activate` handler that deletes any cache whose name doesn't match. Every returning user's old `tcg-pocket-cache-v1` is dropped on the next SW activation — a one-time invalidation that immediately unpins the stale P-B-79..86 and stale-logo bytes people are currently seeing.
- **`skipWaiting()` + `clients.claim()`** so the new worker takes over on the next fetch instead of waiting for every tab to close.
- **Skip non-GET requests** to avoid caching POSTs.
- Cache miss that also fails the network now returns `Response.error()` instead of an implicit `undefined`.

## Depends on / relates to

- Complements #1017: that PR fixes the server-side staleness (updated set logos), this one fixes the client-side staleness that would otherwise keep users from seeing them.

## Test plan

- [ ] Deploy → open the site in a browser that had the old SW registered → without any manual cache clearing, the refreshed logos and P-B images appear within one page load.
- [ ] DevTools → Application → Cache Storage → confirm `tcg-pocket-cache-v1` is deleted and `tcg-pocket-cache-v2` is populated on next visit.
- [ ] Offline test: after a first online visit, going offline still serves cached images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVJ3kwCb1biPXcTAMnGwBU