### PR TITLE
fix(scripts): align generate-cards-table import with tradable rename

### DIFF
--- a/scripts/sql/generate-cards-table.ts
+++ b/scripts/sql/generate-cards-table.ts
@@ -9,7 +9,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { allCards as cardsToInsert, tradeableExpansions } from '../../frontend/src/lib/CardsDB'
+import { allCards as cardsToInsert, tradableExpansions } from '../../frontend/src/lib/CardsDB'
 import { type Card, type Rarity, tradableRarities } from '../../frontend/src/types'
 
 // Get the directory name using ESM compatible approach
@@ -43,7 +43,7 @@ INSERT INTO cards_list (internal_id, card_id, rarity, tradable) VALUES
   const values = dedupedCards
     .map((card) => {
       const rarity = card.rarity
-      const tradable = (tradableRarities as readonly Rarity[]).includes(card.rarity) && tradeableExpansions.includes(card.expansion)
+      const tradable = (tradableRarities as readonly Rarity[]).includes(card.rarity) && tradableExpansions.includes(card.expansion)
 
       return `(${card.internal_id}, '${card.card_id}', '${rarity}', ${tradable})`
     })


### PR DESCRIPTION
## Summary

Small follow-up to #1015. That PR renamed the CardsDB export from `tradeableExpansions` to `tradableExpansions`, but `scripts/sql/generate-cards-table.ts` still imports the old name — so `pnpm scraper` fails at the `generate-cards-table` step with:

```
SyntaxError: The requested module '../../frontend/src/lib/CardsDB' does not provide an export named 'tradeableExpansions'
```

## Changes

Two-line rename in `scripts/sql/generate-cards-table.ts`: the import and the one call site. No behaviour change.

## Test plan

- [ ] `pnpm scraper` reaches the end (previously died before `pnpm lint:fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVJ3kwCb1biPXcTAMnGwBU
