### PR TITLE
Fix virtualized height in collection page

### DIFF
--- a/frontend/src/components/CardsTable.tsx
+++ b/frontend/src/components/CardsTable.tsx
@@ -1,7 +1,8 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
 import i18n from 'i18next'
-import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useRemainingViewportHeight } from '@/hooks/useRemainingViewportHeight'
 import { getExpansionById } from '@/lib/CardsDB.ts'
 import { chunk, cn } from '@/lib/utils.ts'
 import { type Card as CardType, type Expansion, type ExpansionId, expansionIds } from '@/types'
@@ -18,11 +19,8 @@ interface Props {
 export function CardsTable({ className, children, cards, groupExpansions, render }: Props) {
   const { t } = useTranslation(['common/sets', 'pages/collection'])
 
-  const scrollRef = useRef<HTMLDivElement>(null)
+  const { ref: scrollRef, height: scrollContainerHeight } = useRemainingViewportHeight()
   const [width, setWidth] = useState(900)
-  // this has to be a small number because it is what initially is rendered before we calculated the actual max height. When setting it to 'auto' it will render the entire collection on first render.
-  const [scrollContainerHeight, setScrollContainerHeight] = useState('100px')
-
   useEffect(() => {
     const el = scrollRef.current
     if (!el) {
@@ -30,9 +28,6 @@ export function CardsTable({ className, children, cards, groupExpansions, render
     }
     const observer = new ResizeObserver((entries) => {
       setWidth(entries[0].contentRect.width)
-      const headerHeight = (document.querySelector('#header') as HTMLElement | null)?.offsetHeight || 0
-      const maxHeight = window.innerHeight - headerHeight
-      setScrollContainerHeight(`${maxHeight}px`)
     })
     observer.observe(el)
     return () => observer.disconnect()
@@ -78,48 +73,46 @@ export function CardsTable({ className, children, cards, groupExpansions, render
   })
 
   return (
-    <div ref={scrollRef} className={cn('overflow-y-auto', className)} style={{ scrollbarWidth: 'thin' }}>
+    <div ref={scrollRef} className={cn('overflow-y-auto', className)} style={{ scrollbarWidth: 'thin', height: scrollContainerHeight }}>
       {children}
       {cards.length === 0 && <p className="text-xl text-center py-8">No cards to show</p>}
-      <div style={{ height: scrollContainerHeight }}>
-        <div style={{ height: `${rowVirtualizer.getTotalSize()}px` }} className="relative w-full">
-          {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-            const row = rows[virtualRow.index]
-            return (
-              <div
-                key={virtualRow.key}
-                style={{ height: `${virtualRow.size}px`, transform: `translateY(${virtualRow.start}px)` }}
-                className="absolute top-0 left-0 w-full"
-              >
-                {row.type === 'header' ? (
-                  <div className="flex items-center gap-2 scroll-m-20 border-b-2 border-slate-600 pb-2 tracking-tight transition-colors">
-                    <img
-                      src={`/images/sets/${i18n.language}/${row.expansion.id}.webp`}
-                      alt={row.expansion.name}
-                      className="max-w-[60px]"
-                      onError={(e) => {
-                        const img = e.currentTarget
-                        const fallback = `/images/sets/en-US/${row.expansion.id}.webp`
-                        if (!img.src.endsWith(fallback)) {
-                          img.src = fallback
-                        }
-                      }}
-                    />
-                    <h2 className="text-center font-semibold sm:text-lg md:text-2xl">{t(row.expansion.name)}</h2>
-                  </div>
-                ) : (
-                  <div className="w-full flex justify-start">
-                    {row.cards.map((c) => (
-                      <div key={`${c.expansion}-${c.internal_id}`} className={`${basis} min-w-0 px-2`}>
-                        {render(c)}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )
-          })}
-        </div>
+      <div style={{ height: `${rowVirtualizer.getTotalSize()}px` }} className="relative w-full">
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+          const row = rows[virtualRow.index]
+          return (
+            <div
+              key={virtualRow.key}
+              style={{ height: `${virtualRow.size}px`, transform: `translateY(${virtualRow.start}px)` }}
+              className="absolute top-0 left-0 w-full"
+            >
+              {row.type === 'header' ? (
+                <div className="flex items-center gap-2 scroll-m-20 border-b-2 border-slate-600 pb-2 tracking-tight transition-colors">
+                  <img
+                    src={`/images/sets/${i18n.language}/${row.expansion.id}.webp`}
+                    alt={row.expansion.name}
+                    className="max-w-[60px]"
+                    onError={(e) => {
+                      const img = e.currentTarget
+                      const fallback = `/images/sets/en-US/${row.expansion.id}.webp`
+                      if (!img.src.endsWith(fallback)) {
+                        img.src = fallback
+                      }
+                    }}
+                  />
+                  <h2 className="text-center font-semibold sm:text-lg md:text-2xl">{t(row.expansion.name)}</h2>
+                </div>
+              ) : (
+                <div className="w-full flex justify-start">
+                  {row.cards.map((c) => (
+                    <div key={`${c.expansion}-${c.internal_id}`} className={`${basis} min-w-0 px-2`}>
+                      {render(c)}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/frontend/src/hooks/useRemainingViewportHeight.ts
+++ b/frontend/src/hooks/useRemainingViewportHeight.ts
@@ -1,0 +1,37 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
+/** Fill the viewport below an element's document position, including preceding controls and gaps. */
+export function useRemainingViewportHeight() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [height, setHeight] = useState(0)
+
+  useLayoutEffect(() => {
+    const element = ref.current
+    if (!element) {
+      return
+    }
+
+    const measure = () => {
+      const top = element.getBoundingClientRect().top + window.scrollY
+      setHeight(Math.max(0, window.innerHeight - top))
+    }
+
+    // A preceding sibling (such as a wrapping navbar) can move the element
+    // without changing the element's own size.
+    const observer = new ResizeObserver(measure)
+    for (let ancestor: Element | null = element; ancestor; ancestor = ancestor.parentElement) {
+      observer.observe(ancestor)
+      for (let sibling = ancestor.previousElementSibling; sibling; sibling = sibling.previousElementSibling) {
+        observer.observe(sibling)
+      }
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [])
+
+  return { ref, height }
+}

--- a/frontend/src/pages/collection/CollectionCards.tsx
+++ b/frontend/src/pages/collection/CollectionCards.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import useSearchState from '@/hooks/use-search-state'
 import { toast } from '@/hooks/use-toast'
+import { useRemainingViewportHeight } from '@/hooks/useRemainingViewportHeight'
 import {
   abilityOptions,
   cardTypeOptions,
@@ -58,6 +59,7 @@ interface Props {
 }
 
 export default function CollectionCards({ children, cards, account }: Props) {
+  const { ref: pageRef, height: pageHeight } = useRemainingViewportHeight()
   const { t } = useTranslation('pages/collection')
   const isMobile = useMediaQuery({ query: '(max-width: 767px)' }) // tailwind "md"
 
@@ -182,7 +184,7 @@ export default function CollectionCards({ children, cards, account }: Props) {
   )
 
   return (
-    <div className="flex justify-center gap-2 xl:gap-8 px-1">
+    <div ref={pageRef} style={{ height: pageHeight }} className="flex min-h-0 justify-center gap-2 xl:gap-8 px-1">
       {isMobile ? (
         <Sheet open={isFiltersSheetOpen} onOpenChange={setIsFiltersSheetOpen}>
           <SheetContent side="left" className="w-full">
@@ -193,11 +195,11 @@ export default function CollectionCards({ children, cards, account }: Props) {
           </SheetContent>
         </Sheet>
       ) : (
-        <div className="w-80">{filtersPanel}</div>
+        <div className="w-80 min-h-0 overflow-y-auto">{filtersPanel}</div>
       )}
-      <div className="w-full max-w-[900px]">
+      <div className="flex min-h-0 min-w-0 w-full max-w-[900px] flex-col">
         {isMobile && (
-          <div className="h-9 flex overflow-hidden text-center rounded-md text-sm font-medium border shadow-sm border-neutral-700 divide-x divide-neutral-700 [&>*]:cursor-pointer [&>*]:hover:bg-neutral-600 [&>*]:hover:text-neutral-50">
+          <div className="h-9 shrink-0 flex overflow-hidden text-center rounded-md text-sm font-medium border shadow-sm border-neutral-700 divide-x divide-neutral-700 [&>*]:cursor-pointer [&>*]:hover:bg-neutral-600 [&>*]:hover:text-neutral-50">
             <button type="button" className="flex-1" onClick={() => setIsFiltersSheetOpen(true)}>
               Filters
               {activeFilters > 0 && ` (${activeFilters})`}
@@ -209,7 +211,7 @@ export default function CollectionCards({ children, cards, account }: Props) {
             )}
           </div>
         )}
-        {children}
+        {children && <div className="shrink-0">{children}</div>}
         <CardsTable
           cards={filteredCards}
           groupExpansions={filters.sortBy === 'expansion-newest'}


### PR DESCRIPTION
Fixes issues with calculating the height of the virtualized cards tables.

#### First issue

Before when the page got long and became scrollable, the height was still the same, resulting in a cropped table when you scroll the main page.

<img width="1387" height="1080" alt="image" src="https://github.com/user-attachments/assets/a091dd1c-e13d-4daa-a67e-8e3da531215b" />

Filters panel now has it's individual scroll:

<img width="1347" height="1073" alt="image" src="https://github.com/user-attachments/assets/630b69d1-3d4f-4bd1-a844-e7ab53dc39ad" />

#### Second issue

The height did not account for the "filters" button on mobile devices, resulting in two scrollbars:

<img width="464" height="937" alt="image" src="https://github.com/user-attachments/assets/d61efaa4-6632-46c5-9f69-6c50f106caec" />

Now it's fixed, the main page does not scroll, only the virtualized table.